### PR TITLE
fix: resolve demo mode issues across frontend

### DIFF
--- a/frontend/app/dashboard/blueprints/page.tsx
+++ b/frontend/app/dashboard/blueprints/page.tsx
@@ -65,7 +65,6 @@ export default function BlueprintsPage() {
 
   useEffect(() => {
     if (isDemoMode()) {
-      api.blueprints.templates().then(setTemplates).catch(() => {});
       setLoading(false);
       return;
     }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-
-const isDemo = process.env.NEXT_PUBLIC_FORCE_DEMO === "true";
+import { LandingHeader } from "@/components/LandingHeader";
 
 const features = [
   {
@@ -52,24 +51,7 @@ const templates = [
 export default function Home() {
   return (
     <div className="flex min-h-screen flex-col">
-      <header className="border-b border-border">
-        <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6">
-          <div className="flex items-center gap-2">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground font-bold text-sm">
-              AF
-            </div>
-            <span className="text-xl font-bold">Forge</span>
-          </div>
-          <div className="flex items-center gap-4">
-            <Link href={isDemo ? "/dashboard" : "/login"}>
-              <Button variant="ghost">{isDemo ? "Dashboard" : "Log in"}</Button>
-            </Link>
-            <Link href={isDemo ? "/dashboard" : "/signup"}>
-              <Button>{isDemo ? "Try Demo" : "Get Started"}</Button>
-            </Link>
-          </div>
-        </div>
-      </header>
+      <LandingHeader />
 
       <main className="flex flex-1 flex-col items-center px-6">
         {/* Hero */}
@@ -84,9 +66,9 @@ export default function Home() {
             all through a clean web interface, CLI, or API.
           </p>
           <div className="mt-10 flex items-center justify-center gap-4">
-            <Link href={isDemo ? "/dashboard" : "/signup"}>
+            <Link href="/dashboard">
               <Button size="lg" className="text-base px-8">
-                {isDemo ? "Explore Demo" : "Start Building"}
+                Start Building
               </Button>
             </Link>
             <Link href="/dashboard">
@@ -142,7 +124,7 @@ export default function Home() {
               "FastAPI",
               "LangChain",
               "OpenAI",
-              "Supabase",
+              "SQLite / Supabase",
               "TypeScript",
               "Python 3.12",
               "Tailwind CSS",

--- a/frontend/components/LandingHeader.tsx
+++ b/frontend/components/LandingHeader.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export function LandingHeader() {
+  // Default to demo-style links (all point to /dashboard) to avoid hydration mismatch.
+  // On mount, check if we're actually in non-demo mode and swap to login/signup links.
+  const [isDemo, setIsDemo] = useState(true);
+
+  useEffect(() => {
+    const onVercel = window.location.hostname.includes("vercel.app");
+    const forceDemo = process.env.NEXT_PUBLIC_FORCE_DEMO === "true";
+    const cookieDemo = document.cookie.includes("forge_demo=1");
+    if (!onVercel && !forceDemo && !cookieDemo) {
+      setIsDemo(false);
+    }
+  }, []);
+
+  return (
+    <header className="border-b border-border">
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6">
+        <div className="flex items-center gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground font-bold text-sm">
+            F
+          </div>
+          <span className="text-xl font-bold">Forge</span>
+        </div>
+        <div className="flex items-center gap-4">
+          <Link href={isDemo ? "/dashboard" : "/login"}>
+            <Button variant="ghost">{isDemo ? "Dashboard" : "Log in"}</Button>
+          </Link>
+          <Link href={isDemo ? "/dashboard" : "/signup"}>
+            <Button>{isDemo ? "Try Demo" : "Get Started"}</Button>
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/components/dashboard/RunHistory.tsx
+++ b/frontend/components/dashboard/RunHistory.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { api, Run } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
-import { isDemoMode } from "@/lib/demo-data";
+import { isDemoMode, DEMO_RUNS } from "@/lib/demo-data";
 
 export function RunHistory() {
   const [runs, setRuns] = useState<Run[]>([]);
@@ -12,6 +12,7 @@ export function RunHistory() {
 
   useEffect(() => {
     if (isDemoMode()) {
+      setRuns(DEMO_RUNS);
       setLoading(false);
       return;
     }

--- a/frontend/lib/backend-context.tsx
+++ b/frontend/lib/backend-context.tsx
@@ -23,8 +23,11 @@ export function BackendProvider({ children }: { children: ReactNode }) {
   const [mode, setMode] = useState<AppMode>("loading");
 
   useEffect(() => {
-    // If NEXT_PUBLIC_FORCE_DEMO is set (Vercel deployment), skip detection
-    if (process.env.NEXT_PUBLIC_FORCE_DEMO === "true") {
+    // If NEXT_PUBLIC_FORCE_DEMO is set or we're on vercel.app, skip health check entirely
+    if (
+      process.env.NEXT_PUBLIC_FORCE_DEMO === "true" ||
+      window.location.hostname.includes("vercel.app")
+    ) {
       setMode("demo");
       return;
     }

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -1,5 +1,5 @@
 export const API_URL = process.env.NEXT_PUBLIC_API_URL || (() => {
-  if (typeof window !== "undefined") {
+  if (typeof window !== "undefined" && !window.location.hostname.includes("vercel.app")) {
     console.warn("NEXT_PUBLIC_API_URL is not set — falling back to http://localhost:8000. Set this variable for production deployments.");
   }
   return "http://localhost:8000";

--- a/frontend/lib/demo-data.ts
+++ b/frontend/lib/demo-data.ts
@@ -132,6 +132,92 @@ export const DEMO_TIMELINE = [
   },
 ];
 
+export const DEMO_RUNS = [
+  {
+    id: "run-demo-1",
+    agent_id: "demo-1",
+    user_id: "demo",
+    input_text: "Research the latest developments in AI agent architectures and multi-agent coordination patterns",
+    input_file_url: null,
+    status: "completed" as const,
+    output: "Found 12 relevant sources on AI agent architectures...",
+    step_logs: [
+      { step: 1, result: "Searched for AI agent architectures", duration_ms: 3200 },
+      { step: 2, result: "Synthesized findings from 12 sources", duration_ms: 5100 },
+      { step: 3, result: "Generated final report", duration_ms: 4100 },
+    ],
+    tokens_used: 3420,
+    duration_ms: 12400,
+    created_at: "2026-03-12T12:30:00Z",
+  },
+  {
+    id: "run-demo-2",
+    agent_id: "demo-2",
+    user_id: "demo",
+    input_text: "Extract all company names and revenue figures from the Q4 earnings report",
+    input_file_url: null,
+    status: "completed" as const,
+    output: "Extracted 24 entities from input document.",
+    step_logs: [
+      { step: 1, result: "Parsed input document", duration_ms: 1200 },
+      { step: 2, result: "Extracted 24 entities", duration_ms: 1800 },
+      { step: 3, result: "Formatted output as JSON", duration_ms: 1200 },
+    ],
+    tokens_used: 890,
+    duration_ms: 4200,
+    created_at: "2026-03-12T12:25:00Z",
+  },
+  {
+    id: "run-demo-3",
+    agent_id: "demo-3",
+    user_id: "demo",
+    input_text: "Review the authentication module for security vulnerabilities and suggest improvements",
+    input_file_url: null,
+    status: "running" as const,
+    output: null,
+    step_logs: [
+      { step: 1, result: "Analyzing code structure", duration_ms: 2100 },
+    ],
+    tokens_used: 450,
+    duration_ms: null,
+    created_at: "2026-03-12T12:31:00Z",
+  },
+  {
+    id: "run-demo-4",
+    agent_id: "demo-1",
+    user_id: "demo",
+    input_text: "Summarize the top 5 trending topics in machine learning this week",
+    input_file_url: null,
+    status: "completed" as const,
+    output: "Top 5 ML trends: 1) Multi-modal agents...",
+    step_logs: [
+      { step: 1, result: "Searched ML news sources", duration_ms: 2800 },
+      { step: 2, result: "Ranked trending topics", duration_ms: 3200 },
+      { step: 3, result: "Generated summary", duration_ms: 2700 },
+    ],
+    tokens_used: 2100,
+    duration_ms: 8700,
+    created_at: "2026-03-12T11:00:00Z",
+  },
+  {
+    id: "run-demo-5",
+    agent_id: "demo-2",
+    user_id: "demo",
+    input_text: "Parse the CSV upload and extract structured JSON records for each customer entry",
+    input_file_url: null,
+    status: "completed" as const,
+    output: "Extracted 156 customer records.",
+    step_logs: [
+      { step: 1, result: "Parsed CSV headers", duration_ms: 800 },
+      { step: 2, result: "Extracted 156 records", duration_ms: 3200 },
+      { step: 3, result: "Validated and formatted JSON", duration_ms: 1300 },
+    ],
+    tokens_used: 1560,
+    duration_ms: 5300,
+    created_at: "2026-03-12T10:15:00Z",
+  },
+];
+
 export const DEMO_COST_SUMMARY = {
   period: "today",
   total_input_tokens: 18_200,
@@ -369,5 +455,6 @@ export const DEMO_WORKSPACES = [
 export function isDemoMode(): boolean {
   if (typeof window === "undefined") return false;
   if (process.env.NEXT_PUBLIC_FORCE_DEMO === "true") return true;
+  if (window.location.hostname.includes("vercel.app")) return true;
   return document.cookie.includes("forge_demo=1");
 }


### PR DESCRIPTION
## Summary
- Convert landing header to client component with hostname-based demo detection (fixes hydration mismatch)
- Update logo "AF" → "F", tech stack "Supabase" → "SQLite / Supabase"
- Skip backend health check and suppress API_URL warning on vercel.app (eliminates console `ERR_CONNECTION_REFUSED` flood)
- Add `DEMO_RUNS` data so "Recent Runs" shows sample data in demo mode
- Guard blueprints template fetch to prevent unguarded `localhost:8000` API call in demo mode
- Add `vercel.app` hostname check to `isDemoMode()` for consistent detection across all components

## Test plan
- [ ] Verify `bun run build` passes (confirmed locally)
- [ ] Landing page on Vercel: logo shows "F", buttons say "Dashboard"/"Try Demo", tech stack shows "SQLite / Supabase"
- [ ] Dashboard: "Recent Runs" shows 5 sample runs in demo mode
- [ ] Console: zero `ERR_CONNECTION_REFUSED` errors on vercel.app
- [ ] Blueprints page: no `localhost:8000/api/blueprints/templates` fetch in demo mode
- [ ] All 18 nav pages load without JS errors
- [ ] Sign out → lands on `/` (no redirect loop)