### PR TITLE
fix: resolve React hydration errors (#418) on blueprints page

### DIFF
--- a/frontend/app/dashboard/agents/[id]/page.tsx
+++ b/frontend/app/dashboard/agents/[id]/page.tsx
@@ -18,12 +18,14 @@ export default function AgentDetailPage() {
   const [agent, setAgent] = useState<Agent | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [demo, setDemo] = useState(false);
 
   useEffect(() => {
     if (isDemoMode()) {
-      const demo = DEMO_AGENTS.find((a) => a.id === params.id) as Agent | undefined;
-      setAgent(demo || null);
-      if (!demo) setError("Agent not found");
+      setDemo(true);
+      const found = DEMO_AGENTS.find((a) => a.id === params.id) as Agent | undefined;
+      setAgent(found || null);
+      if (!found) setError("Agent not found");
       setLoading(false);
       return;
     }
@@ -43,8 +45,6 @@ export default function AgentDetailPage() {
     }
     load();
   }, [params.id]);
-
-  const demo = isDemoMode();
 
   async function handleDelete() {
     if (!agent || demo) return;

--- a/frontend/app/dashboard/blueprints/page.tsx
+++ b/frontend/app/dashboard/blueprints/page.tsx
@@ -61,10 +61,12 @@ export default function BlueprintsPage() {
   const [templates, setTemplates] = useState<Blueprint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [demo, setDemo] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
     if (isDemoMode()) {
+      setDemo(true);
       setLoading(false);
       return;
     }
@@ -125,7 +127,7 @@ export default function BlueprintsPage() {
             Visual DAG workflows with deterministic and AI-powered nodes
           </p>
         </div>
-        {!isDemoMode() && (
+        {!demo && (
           <Link href="/dashboard/blueprints/new">
             <Button>New Blueprint</Button>
           </Link>
@@ -177,7 +179,7 @@ export default function BlueprintsPage() {
                           </span>
                         ))}
                       </div>
-                      {!isDemoMode() && (
+                      {!demo && (
                         <Button
                           size="sm"
                           variant="outline"
@@ -200,7 +202,7 @@ export default function BlueprintsPage() {
               <p className="mt-2 text-sm text-muted-foreground">
                 Create your first blueprint to build visual workflows.
               </p>
-              {!isDemoMode() && (
+              {!demo && (
                 <Link href="/dashboard/blueprints/new">
                   <Button className="mt-4">New Blueprint</Button>
                 </Link>


### PR DESCRIPTION
## Summary
- Move `isDemoMode()` calls from render body to `useEffect`-driven state in blueprints and agent detail pages
- Prevents SSR/client mismatch: SSR renders with `isDemoMode()=false` (no window), client renders with `true` (vercel.app detected)
- Eliminates all React error #418 hydration warnings on the Vercel demo

## Test plan
- [ ] Navigate to `/dashboard/blueprints` on Vercel — zero console errors
- [ ] Navigate to `/dashboard/agents/demo-1` on Vercel — zero console errors
- [ ] All other 16 dashboard pages remain error-free