### PR TITLE
fix: sign out redirects to landing page, not login loop

### DIFF
--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -128,8 +128,9 @@ export default function DashboardLayout({
   }, [pathname]);
 
   async function handleLogout() {
+    document.cookie = "forge_demo=; max-age=0; path=/";
     await authLogout();
-    window.location.href = "/login";
+    window.location.href = "/";
   }
 
   const logo = (


### PR DESCRIPTION
## Summary
- Clear `forge_demo` cookie on sign out
- Redirect to `/` instead of `/login` to avoid middleware bounce-back on Vercel demo

## Test plan
- [ ] Click Sign Out on Vercel demo → lands on `/` (landing page)
- [ ] No redirect loop