### PR TITLE
feat(nav): grouped sidebar IA with workspace as top-level

### DIFF
--- a/frontend/app/dashboard/computer-use/page.tsx
+++ b/frontend/app/dashboard/computer-use/page.tsx
@@ -1,0 +1,13 @@
+import { Monitor } from "lucide-react";
+import { RouteStub } from "@/components/dashboard/RouteStub";
+
+export default function ComputerUsePage() {
+  return (
+    <RouteStub
+      title="Computer Use"
+      description="Status and audit of the Steer (GUI) and Drive (Terminal) capability layer."
+      icon={Monitor}
+      cliCommand="forge cu status"
+    />
+  );
+}

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getUser, logout as authLogout } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,28 +13,115 @@ import {
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { useBackendMode } from "@/lib/backend-context";
-import { Menu } from "lucide-react";
+import {
+  Activity,
+  BookOpen,
+  Bot,
+  CheckCircle,
+  Code2,
+  Cpu,
+  GitBranch,
+  GitCompare,
+  Key,
+  LayoutDashboard,
+  ListChecks,
+  Menu,
+  MessageSquare,
+  Monitor,
+  Network,
+  Play,
+  Plug,
+  Settings as SettingsIcon,
+  Store,
+  Target,
+  Users,
+  Video,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
 
-const navItems = [
-  { href: "/dashboard", label: "Dashboard" },
-  { href: "/dashboard/monitor", label: "Monitor" },
-  { href: "/dashboard/analytics", label: "Analytics" },
-  { href: "/dashboard/orchestrate", label: "Orchestrate" },
-  { href: "/dashboard/agents", label: "Agents" },
-  { href: "/dashboard/blueprints", label: "Blueprints" },
-  { href: "/dashboard/compare", label: "Compare" },
-  { href: "/dashboard/runs", label: "Runs" },
-  { href: "/dashboard/evals", label: "Evals" },
-  { href: "/dashboard/approvals", label: "Approvals" },
-  { href: "/dashboard/triggers", label: "Triggers" },
-  { href: "/dashboard/traces", label: "Traces" },
-  { href: "/dashboard/prompts", label: "Prompts" },
-  { href: "/dashboard/knowledge", label: "Knowledge" },
-  { href: "/dashboard/marketplace", label: "Marketplace" },
-  { href: "/dashboard/team", label: "Team" },
-  { href: "/dashboard/workspace", label: "Workspace" },
-  { href: "/dashboard/settings", label: "Settings" },
+type NavItem = {
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  badge?: string;
+};
+
+type NavGroup = {
+  label: string | null;
+  items: NavItem[];
+};
+
+const NAV_GROUPS: NavGroup[] = [
+  {
+    label: "Overview",
+    items: [{ label: "Dashboard", href: "/dashboard", icon: LayoutDashboard }],
+  },
+  {
+    label: "Build",
+    items: [
+      { label: "Agents", href: "/dashboard/agents", icon: Bot },
+      { label: "Blueprints", href: "/dashboard/blueprints", icon: GitBranch },
+      { label: "Prompts", href: "/dashboard/prompts", icon: MessageSquare },
+      { label: "Knowledge", href: "/dashboard/knowledge", icon: BookOpen },
+    ],
+  },
+  {
+    label: null,
+    items: [{ label: "Workspace", href: "/dashboard/workspace", icon: Code2 }],
+  },
+  {
+    label: "Run",
+    items: [
+      { label: "Orchestrate", href: "/dashboard/orchestrate", icon: Network },
+      { label: "Approvals", href: "/dashboard/approvals", icon: CheckCircle },
+      { label: "Triggers", href: "/dashboard/triggers", icon: Zap },
+      { label: "Targets", href: "/dashboard/targets", icon: Target },
+    ],
+  },
+  {
+    label: "Observe",
+    items: [
+      { label: "Runs", href: "/dashboard/runs", icon: Play },
+      { label: "Traces", href: "/dashboard/traces", icon: Activity },
+      { label: "Recordings", href: "/dashboard/recordings", icon: Video },
+      { label: "Evals", href: "/dashboard/evals", icon: ListChecks },
+      { label: "Compare", href: "/dashboard/compare", icon: GitCompare },
+    ],
+  },
+  {
+    label: "Compute",
+    items: [
+      { label: "Computer Use", href: "/dashboard/computer-use", icon: Monitor },
+      { label: "Providers", href: "/dashboard/providers", icon: Cpu },
+      { label: "MCP", href: "/dashboard/mcp", icon: Plug },
+    ],
+  },
+  {
+    label: null,
+    items: [{ label: "Marketplace", href: "/dashboard/marketplace", icon: Store }],
+  },
+  {
+    label: "Settings",
+    items: [
+      { label: "Team", href: "/dashboard/team", icon: Users },
+      { label: "API Keys", href: "/dashboard/settings/api-keys", icon: Key },
+      { label: "Preferences", href: "/dashboard/settings", icon: SettingsIcon },
+    ],
+  },
 ];
+
+const ALL_HREFS = NAV_GROUPS.flatMap((g) => g.items.map((i) => i.href));
+
+function isActive(itemHref: string, pathname: string): boolean {
+  if (itemHref === "/dashboard") return pathname === "/dashboard";
+  // If a longer registered href matches the pathname, defer to that one.
+  const longer = ALL_HREFS.find(
+    (h) => h !== itemHref && h.startsWith(itemHref + "/") && (pathname === h || pathname.startsWith(h + "/"))
+  );
+  if (longer) return false;
+  return pathname === itemHref || pathname.startsWith(itemHref + "/");
+}
 
 function SidebarContent({
   pathname,
@@ -47,29 +134,44 @@ function SidebarContent({
   onLogout: () => void;
   onNavigate?: () => void;
 }) {
+  const groups = useMemo(() => NAV_GROUPS, []);
   return (
     <>
-      <nav className="flex flex-col gap-1 p-4">
-        {navItems.map((item) => {
-          const href = item.href;
-          return (
-            <Link
-              key={item.href}
-              href={href}
-              onClick={onNavigate}
-              className={cn(
-                "rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                (item.href === "/dashboard"
-                  ? pathname === "/dashboard"
-                  : pathname.startsWith(item.href))
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-              )}
-            >
-              {item.label}
-            </Link>
-          );
-        })}
+      <nav className="flex flex-col gap-4 p-4">
+        {groups.map((group, gi) => (
+          <div key={`group-${gi}`} className="flex flex-col gap-1">
+            {group.label && (
+              <div className="px-3 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                {group.label}
+              </div>
+            )}
+            {group.items.map((item) => {
+              const Icon = item.icon;
+              const active = isActive(item.href, pathname);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={onNavigate}
+                  className={cn(
+                    "flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                    active
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                  )}
+                >
+                  <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  <span className="truncate">{item.label}</span>
+                  {item.badge && (
+                    <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
+                      {item.badge}
+                    </span>
+                  )}
+                </Link>
+              );
+            })}
+          </div>
+        ))}
       </nav>
       <div className="mt-auto border-t border-border p-4">
         <p className="truncate text-xs text-muted-foreground" title={userEmail}>
@@ -105,11 +207,9 @@ export default function DashboardLayout({
     if (mode === "loading") return;
     if (demo) {
       setUserEmail("demo@forge.dev");
-      // Set cookie so middleware allows access without auth
       document.cookie = "forge_demo=1; path=/";
       return;
     }
-    // Live mode — require real auth
     getUser()
       .then((user) => {
         if (!user) {

--- a/frontend/app/dashboard/mcp/page.tsx
+++ b/frontend/app/dashboard/mcp/page.tsx
@@ -1,0 +1,13 @@
+import { Plug } from "lucide-react";
+import { RouteStub } from "@/components/dashboard/RouteStub";
+
+export default function McpPage() {
+  return (
+    <RouteStub
+      title="MCP"
+      description="Model Context Protocol connection management — connected servers, tool inventory, and add-connection flow."
+      icon={Plug}
+      cliCommand="forge mcp list"
+    />
+  );
+}

--- a/frontend/app/dashboard/providers/page.tsx
+++ b/frontend/app/dashboard/providers/page.tsx
@@ -1,0 +1,13 @@
+import { Cpu } from "lucide-react";
+import { RouteStub } from "@/components/dashboard/RouteStub";
+
+export default function ProvidersPage() {
+  return (
+    <RouteStub
+      title="Providers"
+      description="Multi-model provider registry, health checks, and side-by-side comparison."
+      icon={Cpu}
+      cliCommand="forge models list"
+    />
+  );
+}

--- a/frontend/app/dashboard/recordings/page.tsx
+++ b/frontend/app/dashboard/recordings/page.tsx
@@ -1,0 +1,13 @@
+import { Video } from "lucide-react";
+import { RouteStub } from "@/components/dashboard/RouteStub";
+
+export default function RecordingsPage() {
+  return (
+    <RouteStub
+      title="Recordings"
+      description="Screen recordings from Computer Use sessions — gallery, scrubbing player, trace links."
+      icon={Video}
+      cliCommand="forge recordings list"
+    />
+  );
+}

--- a/frontend/app/dashboard/settings/api-keys/page.tsx
+++ b/frontend/app/dashboard/settings/api-keys/page.tsx
@@ -1,0 +1,13 @@
+import { Key } from "lucide-react";
+import { RouteStub } from "@/components/dashboard/RouteStub";
+
+export default function ApiKeysPage() {
+  return (
+    <RouteStub
+      title="API Keys"
+      description="Manage API keys for accessing Forge from external systems."
+      icon={Key}
+      cliCommand="forge keys list"
+    />
+  );
+}

--- a/frontend/app/dashboard/targets/page.tsx
+++ b/frontend/app/dashboard/targets/page.tsx
@@ -1,0 +1,13 @@
+import { Target } from "lucide-react";
+import { RouteStub } from "@/components/dashboard/RouteStub";
+
+export default function TargetsPage() {
+  return (
+    <RouteStub
+      title="Targets"
+      description="Multi-machine dispatch — execution targets that blueprint nodes can route to."
+      icon={Target}
+      cliCommand="forge targets list"
+    />
+  );
+}

--- a/frontend/components/dashboard/RouteStub.tsx
+++ b/frontend/components/dashboard/RouteStub.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent } from "@/components/ui/card";
+import type { LucideIcon } from "lucide-react";
+
+interface RouteStubProps {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  cliCommand?: string;
+}
+
+export function RouteStub({ title, description, icon: Icon, cliCommand }: RouteStubProps) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
+        <p className="mt-2 text-muted-foreground">{description}</p>
+      </div>
+
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
+          <Icon className="h-10 w-10 text-muted-foreground" aria-hidden="true" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium">Building this surface</p>
+            <p className="max-w-md text-sm text-muted-foreground">
+              The web UI for this feature is on the roadmap. The CLI already has full coverage
+              {cliCommand ? (
+                <>
+                  {" "}via{" "}
+                  <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">{cliCommand}</code>
+                </>
+              ) : null}
+              .
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,6 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  async redirects() {
+    return [
+      {
+        source: "/dashboard/monitor",
+        destination: "/dashboard#live",
+        permanent: true,
+      },
+      {
+        source: "/dashboard/analytics",
+        destination: "/dashboard#usage",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

PR 1 of 7 from the Forge cleanup spec. Reorganizes the dashboard sidebar from a flat 18-item list into a grouped IA so the platform's structure is visible.

- Sidebar refactored into `NAV_GROUPS` config (Overview · Build · Run · Observe · Compute · Settings) with Workspace and Marketplace deliberately top-level.
- Stubs added for 6 new routes so the new nav has zero 404s: `/dashboard/computer-use`, `/dashboard/providers`, `/dashboard/mcp`, `/dashboard/targets`, `/dashboard/recordings`, `/dashboard/settings/api-keys`. Each stub points at its matching CLI command via a shared `RouteStub` component.
- Permanent (308) redirects from `/dashboard/monitor` → `/dashboard#live` and `/dashboard/analytics` → `/dashboard#usage`. The anchors land in PR 2 when the three pages merge; the redirect already preserves deep links.
- Lucide icons per item and tightened active-state matching so `/dashboard/settings/api-keys` highlights API Keys rather than Preferences.

## Acceptance criteria (from spec, Problem 1)

- [x] Sidebar renders the grouped IA with section labels
- [x] Workspace is its own top-level section (not under Settings)
- [x] Mobile collapses groups under a hamburger but preserves the grouping headers
- [x] No 404s — every nav item points to a real route (stubs cover the 6 new routes)

## Test plan

- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 21 tests pass
- [ ] CI green on GitHub Actions
- [ ] LastGate green
- [ ] Walk every nav item on the deployed Vercel preview — no 404s

## Out of scope (for later PRs)

- The unified `/dashboard` page that renders sections at `#live` / `#usage` / `#recent` (PR 2)
- Real content for the 6 stub routes (PR 5)