### PR TITLE
chore(ci): fix Vercel deploy with pull/build/prebuilt pattern

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
-      - name: Deploy to Vercel
-        run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Pull Vercel project settings
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: frontend
+      - name: Build with Vercel
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: frontend
+      - name: Deploy prebuilt artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: frontend
 
   deploy-backend:


### PR DESCRIPTION
## Summary

The single-step `vercel deploy --prod` flow in `Deploy.yml` stopped working after a Vercel CLI update — the run for #42 failed with `Could not retrieve Project Settings. To link your Project, remove the .vercel directory and deploy again.`

Switching to the documented `vercel pull → vercel build → vercel deploy --prebuilt` pattern restores the deploy step. I verified the flow locally — it produced production deploy `https://forge-nz03edh2g-aaroncxs-projects.vercel.app` aliased to `https://forge-theta-teal.vercel.app`.

## Test plan

- [ ] CI green on this PR
- [ ] On merge, the Deploy workflow succeeds and the live site reflects #42's nav refactor