### PR TITLE
fix(blueprints): demo seeds, always-visible create, and live CRUD verification

### DIFF
--- a/frontend/app/dashboard/blueprints/[id]/edit/page.tsx
+++ b/frontend/app/dashboard/blueprints/[id]/edit/page.tsx
@@ -20,9 +20,11 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
+import { toast } from "sonner";
+
 import { supabase } from "@/lib/supabase";
 import { api, Blueprint, BlueprintNode as ApiBlueprintNode, NodeTypeInfo } from "@/lib/api";
-import { isDemoMode } from "@/lib/demo-data";
+import { isDemoMode, DEMO_NODE_TYPES, findDemoBlueprint } from "@/lib/demo-data";
 import { Button } from "@/components/ui/button";
 import { NodePalette } from "@/components/blueprints/NodePalette";
 import { BlueprintNodeComponent_Memo } from "@/components/blueprints/BlueprintNode";
@@ -96,7 +98,18 @@ export default function BlueprintEditorPage() {
     }
 
     async function load() {
-      if (isDemoMode()) return;
+      if (isDemoMode()) {
+        const bp = findDemoBlueprint(blueprintId);
+        if (!bp) {
+          router.push("/dashboard/blueprints");
+          return;
+        }
+        setNodeTypeList(DEMO_NODE_TYPES);
+        setBlueprintName(bp.name);
+        setBlueprintDescription(bp.description);
+        hydrate(bp, DEMO_NODE_TYPES);
+        return;
+      }
       const { data } = await supabase.auth.getSession();
       if (!data.session) {
         router.push("/login");
@@ -222,6 +235,12 @@ export default function BlueprintEditorPage() {
 
   // Save
   async function handleSave() {
+    if (isDemoMode()) {
+      toast("Demo mode — sign in to persist your work", {
+        description: "Edits stay on this device until you connect a Forge runtime.",
+      });
+      return;
+    }
     setSaving(true);
     try {
       await api.blueprints.update(
@@ -233,8 +252,9 @@ export default function BlueprintEditorPage() {
         },
         tokenRef.current,
       );
+      toast.success("Blueprint saved");
     } catch {
-      // Could add toast here
+      toast.error("Failed to save blueprint");
     } finally {
       setSaving(false);
     }
@@ -242,6 +262,12 @@ export default function BlueprintEditorPage() {
 
   // Run blueprint
   async function handleRun() {
+    if (isDemoMode()) {
+      toast("Demo mode — sign in to run blueprints", {
+        description: "Connect a Forge runtime to execute this DAG.",
+      });
+      return;
+    }
     setRunning(true);
     setShowTrace(true);
     setExecutionLog([]);
@@ -374,8 +400,17 @@ export default function BlueprintEditorPage() {
       }
     : null;
 
+  const demo = isDemoMode();
+
   return (
     <div className="fixed inset-0 flex flex-col bg-background">
+      {demo && (
+        <div className="flex items-center justify-between gap-2 border-b border-yellow-700 bg-yellow-900/40 px-4 py-1.5 text-xs text-yellow-200">
+          <span>
+            Demo mode — fork to edit. Save and Run are disabled until you connect a Forge runtime.
+          </span>
+        </div>
+      )}
       {/* Top bar */}
       <div className="flex h-12 items-center justify-between border-b border-border bg-card px-4">
         <div className="flex items-center gap-3">

--- a/frontend/app/dashboard/blueprints/page.tsx
+++ b/frontend/app/dashboard/blueprints/page.tsx
@@ -5,19 +5,16 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { api, Blueprint } from "@/lib/api";
-import { isDemoMode } from "@/lib/demo-data";
+import { isDemoMode, DEMO_BLUEPRINTS, DEMO_STARTER_BLUEPRINT } from "@/lib/demo-data";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
 function BlueprintCard({ blueprint }: { blueprint: Blueprint }) {
-  const demo = isDemoMode();
-  const href = demo
-    ? `/dashboard/blueprints/${blueprint.id}`
-    : `/dashboard/blueprints/${blueprint.id}/edit`;
+  const href = `/dashboard/blueprints/${blueprint.id}/edit`;
 
   return (
-    <Link href={href}>
+    <Link href={href} data-seeded="true">
       <Card className="h-full transition-colors hover:border-primary/50">
         <CardHeader className="pb-2">
           <div className="flex items-start justify-between">
@@ -67,6 +64,7 @@ export default function BlueprintsPage() {
   useEffect(() => {
     if (isDemoMode()) {
       setDemo(true);
+      setBlueprints(DEMO_BLUEPRINTS);
       setLoading(false);
       return;
     }
@@ -127,11 +125,15 @@ export default function BlueprintsPage() {
             Visual DAG workflows with deterministic and AI-powered nodes
           </p>
         </div>
-        {!demo && (
-          <Link href="/dashboard/blueprints/new">
-            <Button>New Blueprint</Button>
-          </Link>
-        )}
+        <Link
+          href={
+            demo
+              ? `/dashboard/blueprints/${DEMO_STARTER_BLUEPRINT.id}/edit`
+              : "/dashboard/blueprints/new"
+          }
+        >
+          <Button>+ New Blueprint</Button>
+        </Link>
       </div>
 
       {loading ? (
@@ -202,11 +204,15 @@ export default function BlueprintsPage() {
               <p className="mt-2 text-sm text-muted-foreground">
                 Create your first blueprint to build visual workflows.
               </p>
-              {!demo && (
-                <Link href="/dashboard/blueprints/new">
-                  <Button className="mt-4">New Blueprint</Button>
-                </Link>
-              )}
+              <Link
+                href={
+                  demo
+                    ? `/dashboard/blueprints/${DEMO_STARTER_BLUEPRINT.id}/edit`
+                    : "/dashboard/blueprints/new"
+                }
+              >
+                <Button className="mt-4">+ New Blueprint</Button>
+              </Link>
             </div>
           )}
         </>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { cn } from "@/lib/utils";
 import { AuthSync } from "@/components/AuthSync";
 import { BackendProvider } from "@/lib/backend-context";
+import { Toaster } from "sonner";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -24,6 +25,7 @@ export default function RootLayout({
         <BackendProvider>
           <AuthSync />
           {children}
+          <Toaster theme="dark" position="bottom-right" />
         </BackendProvider>
       </body>
     </html>

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -40,6 +40,7 @@
         "react": "^18",
         "react-dom": "^18",
         "shadcn": "^4.0.2",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
         "tw-animate-css": "^1.4.0",
@@ -1556,6 +1557,8 @@
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/frontend/lib/demo-data.ts
+++ b/frontend/lib/demo-data.ts
@@ -3,6 +3,13 @@
  * Demo mode activates automatically when the backend is unreachable.
  */
 
+export {
+  DEMO_BLUEPRINTS,
+  DEMO_NODE_TYPES,
+  DEMO_STARTER_BLUEPRINT,
+  findDemoBlueprint,
+} from "@/lib/demo/blueprints";
+
 export const DEMO_STATS = {
   total_agents: 8,
   total_runs: 147,

--- a/frontend/lib/demo/blueprints.ts
+++ b/frontend/lib/demo/blueprints.ts
@@ -1,0 +1,163 @@
+import type { Blueprint, BlueprintNode, NodeTypeInfo } from "@/lib/api";
+
+const NOW = "2026-04-20T10:00:00Z";
+
+function nodeTypeInfo(
+  key: string,
+  display_name: string,
+  category: string,
+  node_class: "deterministic" | "agent",
+  description = ""
+): NodeTypeInfo {
+  return {
+    key,
+    display_name,
+    category,
+    node_class,
+    description,
+    input_schema: {},
+    output_schema: {},
+  };
+}
+
+export const DEMO_NODE_TYPES: NodeTypeInfo[] = [
+  nodeTypeInfo("fetch_url", "Fetch URL", "context", "deterministic"),
+  nodeTypeInfo("knowledge_retrieval", "Knowledge Retrieval", "context", "deterministic"),
+  nodeTypeInfo("template_renderer", "Template Renderer", "transform", "deterministic"),
+  nodeTypeInfo("output_formatter", "Output Formatter", "output", "deterministic"),
+  nodeTypeInfo("json_validator", "JSON Validator", "validate", "deterministic"),
+  nodeTypeInfo("approval_gate", "Approval Gate", "validate", "deterministic"),
+  nodeTypeInfo("llm_summarize", "Summarize", "agent", "agent"),
+  nodeTypeInfo("llm_extract", "Extract", "agent", "agent"),
+  nodeTypeInfo("llm_generate", "Generate", "agent", "agent"),
+  nodeTypeInfo("llm_review", "Review", "agent", "agent"),
+  nodeTypeInfo("agent_spawn", "Spawn Agent", "agent", "agent"),
+  nodeTypeInfo("agent_prompt", "Prompt Agent", "agent", "agent"),
+  nodeTypeInfo("agent_wait", "Wait for Agent", "agent", "agent"),
+  nodeTypeInfo("agent_result", "Read Agent Result", "agent", "agent"),
+  nodeTypeInfo("steer_see", "Steer: See", "agent", "agent"),
+  nodeTypeInfo("steer_click", "Steer: Click", "agent", "agent"),
+  nodeTypeInfo("steer_type", "Steer: Type", "agent", "agent"),
+  nodeTypeInfo("cu_planner", "CU Planner", "agent", "agent"),
+  nodeTypeInfo("cu_verifier", "CU Verifier", "agent", "agent"),
+];
+
+function n(
+  id: string,
+  type: string,
+  label: string,
+  x: number,
+  y: number,
+  dependencies: string[] = [],
+  config: Record<string, unknown> = {}
+): BlueprintNode {
+  return { id, type, label, config, dependencies, position: { x, y } };
+}
+
+const blueprint = (
+  id: string,
+  name: string,
+  description: string,
+  nodes: BlueprintNode[]
+): Blueprint => ({
+  id,
+  user_id: "demo",
+  name,
+  description,
+  version: 1,
+  is_template: false,
+  nodes,
+  context_config: {},
+  tool_scope: [],
+  retry_policy: { max_retries: 1 },
+  output_schema: null,
+  created_at: NOW,
+  updated_at: NOW,
+});
+
+const research_summarize_output = blueprint(
+  "demo-bp-research-summarize",
+  "Research → Summarize → Output",
+  "Single-agent linear DAG: pulls a URL, summarizes it, and formats the result.",
+  [
+    n("ctx", "fetch_url", "Fetch Source", 60, 160, [], { url: "https://example.com/article" }),
+    n("sum", "llm_summarize", "Summarize", 360, 160, ["ctx"], { model: "gpt-4o-mini" }),
+    n("out", "output_formatter", "Output", 660, 160, ["sum"], { format: "markdown" }),
+  ]
+);
+
+const multi_agent_pipeline = blueprint(
+  "demo-bp-multi-agent",
+  "Multi-agent research pipeline",
+  "Research Agent → Data Extractor → Code Reviewer with a conditional approval branch.",
+  [
+    n("research", "llm_generate", "Research Agent", 60, 100, [], { model: "gpt-4o-mini" }),
+    n("extract", "llm_extract", "Data Extractor", 360, 100, ["research"], { model: "gpt-4o-mini" }),
+    n("review", "llm_review", "Code Reviewer", 660, 100, ["extract"], { model: "gpt-4o-mini" }),
+    n("gate", "approval_gate", "Reviewer Approval", 660, 280, ["review"], { mode: "manual" }),
+    n("out", "output_formatter", "Output", 960, 190, ["gate"], { format: "json" }),
+  ]
+);
+
+const rag_qa = blueprint(
+  "demo-bp-rag-qa",
+  "RAG-backed Q&A",
+  "Retrieve from a knowledge base, render a prompt template, generate, and format.",
+  [
+    n("kb", "knowledge_retrieval", "KB Retrieval", 60, 160, [], { collection: "docs", k: 4 }),
+    n("tpl", "template_renderer", "Render Prompt", 360, 160, ["kb"], { template: "qa.md" }),
+    n("gen", "llm_generate", "Generate Answer", 660, 160, ["tpl"], { model: "gpt-4o-mini" }),
+    n("out", "output_formatter", "Output", 960, 160, ["gen"], { format: "markdown" }),
+  ]
+);
+
+const agent_on_agent = blueprint(
+  "demo-bp-agent-on-agent",
+  "Agent-on-agent: Claude Code worker",
+  "Spawn a Claude Code subagent, prompt it, wait for completion, and read the result.",
+  [
+    n("spawn", "agent_spawn", "Spawn Claude Code", 60, 160, [], { worker: "claude-code" }),
+    n("prompt", "agent_prompt", "Prompt Agent", 360, 160, ["spawn"], {
+      prompt: "Refactor scraper.py for clarity",
+    }),
+    n("wait", "agent_wait", "Wait", 660, 160, ["prompt"], { timeout_s: 120 }),
+    n("result", "agent_result", "Read Result", 960, 160, ["wait"]),
+  ]
+);
+
+const computer_use = blueprint(
+  "demo-bp-computer-use",
+  "Computer Use demo",
+  "GUI automation pipeline that sees the screen, plans, clicks, types, and verifies.",
+  [
+    n("see", "steer_see", "Capture Screen", 60, 160, [], { target: "screen" }),
+    n("plan", "cu_planner", "Plan Next Step", 360, 160, ["see"], { model: "gpt-4o-mini" }),
+    n("click", "steer_click", "Click Target", 660, 80, ["plan"], { selector: "button.primary" }),
+    n("type", "steer_type", "Type Input", 660, 240, ["plan"], { text: "hello forge" }),
+    n("verify", "cu_verifier", "Verify Outcome", 960, 160, ["click", "type"]),
+  ]
+);
+
+export const DEMO_BLUEPRINTS: Blueprint[] = [
+  research_summarize_output,
+  multi_agent_pipeline,
+  rag_qa,
+  agent_on_agent,
+  computer_use,
+];
+
+export const DEMO_STARTER_BLUEPRINT: Blueprint = blueprint(
+  "demo-bp-starter",
+  "Untitled blueprint",
+  "Drag nodes from the palette and connect them to build your workflow.",
+  [
+    n("input", "fetch_url", "Input", 100, 200, [], { url: "" }),
+    n("agent", "llm_generate", "Agent", 380, 200, ["input"], { model: "gpt-4o-mini" }),
+    n("output", "output_formatter", "Output", 660, 200, ["agent"], { format: "markdown" }),
+  ]
+);
+
+export function findDemoBlueprint(id: string): Blueprint | undefined {
+  if (id === DEMO_STARTER_BLUEPRINT.id) return DEMO_STARTER_BLUEPRINT;
+  return DEMO_BLUEPRINTS.find((bp) => bp.id === id);
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "react": "^18",
     "react-dom": "^18",
     "shadcn": "^4.0.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.4.0"


### PR DESCRIPTION
## Summary

PR 3 of 7 from the Forge cleanup spec. Fixes the broken demo blueprints experience and locks in live CRUD.

- **Five seeded blueprints** populate `/dashboard/blueprints` in demo mode (single-agent DAG · multi-agent pipeline · RAG-backed Q&A · agent-on-agent · Computer Use). Each ships with nodes, edges, and saved canvas positions so the editor opens populated.
- **`+ New Blueprint` always visible** top-right and inside the empty state. In demo mode the button skips `/new` and opens the starter template directly in the editor.
- **Cards are now clickable** in both modes — they open the visual DAG editor at `/dashboard/blueprints/[id]/edit`.
- **Demo-mode editor**: banner across the top reads "Demo mode — fork to edit. Save and Run are disabled until you connect a Forge runtime." Save and Run now surface toasts instead of silently no-oping. Hydrate path uses a static `DEMO_NODE_TYPES` fixture so node colors and config panel work without the API.
- **Toast plumbing**: adds `sonner` and mounts a dark Toaster in the root layout (also used by PR 4 for the workspace).
- **Live CRUD verification**: a manual checklist is in this PR description (see Test plan). Live save now also raises a success toast on completion and an error toast on failure.

## Acceptance criteria (from spec, Problem 3)

- [x] Demo `/dashboard/blueprints` shows ≥5 seeded blueprints
- [x] Each opens in the visual editor (read-only banner in demo)
- [x] `+ New Blueprint` always visible
- [ ] Live CRUD verified end-to-end — see manual test plan below
- [ ] `forge blueprints export` / `import` roundtrip works on the seeded set (CLI manual test)

## Test plan

### Automated
- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 21 tests pass
- [ ] CI green on GitHub Actions
- [ ] LastGate green

### Live CRUD (manual, on deployed Vercel)
- [ ] Sign in with a real account at `/dashboard/blueprints` and confirm the list renders user blueprints (not seeds)
- [ ] Create from scratch via `+ New Blueprint` → save → reload → state persists
- [ ] Create from template → edit → save → run → SSE stream completes
- [ ] `forge blueprints export <id>` then `forge blueprints import` → roundtrip preserves nodes/edges
- [ ] If any step fails in live, fix `backend/app/routers/blueprints.py` before merging

### Demo (deployed Vercel)
- [ ] `/dashboard/blueprints` shows the 5 seeded blueprints
- [ ] Clicking a card opens the editor populated; banner reads "Demo mode — fork to edit"
- [ ] Save and Run buttons raise toasts; nothing is sent to the backend