### PR TITLE
fix(blueprints): editor hydration mismatch from isDemoMode()

### DIFF
--- a/frontend/app/dashboard/blueprints/[id]/edit/page.tsx
+++ b/frontend/app/dashboard/blueprints/[id]/edit/page.tsx
@@ -59,8 +59,13 @@ export default function BlueprintEditorPage() {
 
   const [executionLog, setExecutionLog] = useState<string[]>([]);
   const [showTrace, setShowTrace] = useState(false);
+  const [mounted, setMounted] = useState(false);
 
   const tokenRef = useRef<string>("");
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   // Load blueprint and node types
   useEffect(() => {
@@ -400,7 +405,7 @@ export default function BlueprintEditorPage() {
       }
     : null;
 
-  const demo = isDemoMode();
+  const demo = mounted && isDemoMode();
 
   return (
     <div className="fixed inset-0 flex flex-col bg-background">


### PR DESCRIPTION
## Summary

Follow-up to #45. The blueprint editor at `/dashboard/blueprints/[id]/edit` was throwing 12 React hydration errors on Vercel because `const demo = isDemoMode()` resolves differently on server (no `window` → false) and client (vercel.app hostname → true), so the demo banner was diverging between SSR and hydration.

Adds a `mounted` state that flips after the first effect, and gates the demo banner on it. First paint now matches SSR; the banner appears once hydration completes.

## Test plan

- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 21 pass
- [ ] CI green
- [ ] LastGate green
- [ ] After merge, navigate to `/dashboard/blueprints/demo-bp-research-summarize/edit` on Vercel and confirm console is clean