### PR TITLE
feat(workspace): demo sandbox with scraper-agent and run-demo-agent

### DIFF
--- a/frontend/app/dashboard/workspace/[id]/page.tsx
+++ b/frontend/app/dashboard/workspace/[id]/page.tsx
@@ -3,15 +3,22 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
+import { toast } from "sonner";
 import { getToken } from "@/lib/auth-client";
 import { api, type Workspace } from "@/lib/api";
-import { isDemoMode } from "@/lib/demo-data";
+import {
+  isDemoMode,
+  DEMO_WORKSPACE,
+  DEMO_WORKSPACE_TREE,
+  DEMO_AGENT_RUN_COMMENT,
+  findDemoFile,
+} from "@/lib/demo-data";
 import { FileTree } from "@/components/workspace/FileTree";
 import { EditorTabs } from "@/components/workspace/EditorTabs";
 import { WorkspaceSocket, type FileChangeEvent } from "@/lib/workspace-ws";
 import { AgentPanel } from "@/components/workspace/AgentPanel";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, RefreshCw, TerminalSquare, PanelRightClose, PanelRightOpen } from "lucide-react";
+import { ArrowLeft, Play, RefreshCw, TerminalSquare, PanelRightClose, PanelRightOpen } from "lucide-react";
 import "@xterm/xterm/css/xterm.css";
 
 // Dynamic imports for browser-only components
@@ -21,6 +28,10 @@ const CodeEditor = dynamic(
 );
 const TerminalPanel = dynamic(
   () => import("@/components/workspace/Terminal").then((m) => m.TerminalPanel),
+  { ssr: false, loading: () => <div className="flex h-full items-center justify-center text-muted-foreground">Loading terminal...</div> }
+);
+const DemoTerminal = dynamic(
+  () => import("@/components/workspace/DemoTerminal").then((m) => m.DemoTerminal),
   { ssr: false, loading: () => <div className="flex h-full items-center justify-center text-muted-foreground">Loading terminal...</div> }
 );
 
@@ -38,6 +49,16 @@ interface OpenFile {
   originalContent: string;
 }
 
+function stripContent(entry: { name: string; path: string; type: "file" | "directory"; size: number | null; children: typeof entry[] | null }): FileEntry {
+  return {
+    name: entry.name,
+    path: entry.path,
+    type: entry.type,
+    size: entry.size,
+    children: entry.children ? entry.children.map(stripContent) : null,
+  };
+}
+
 export default function WorkspaceIDEPage() {
   const params = useParams();
   const router = useRouter();
@@ -53,36 +74,23 @@ export default function WorkspaceIDEPage() {
   const [showActivityPanel, setShowActivityPanel] = useState(true);
   const [recentChanges, setRecentChanges] = useState<FileChangeEvent[]>([]);
   const [currentToken, setCurrentToken] = useState("");
+  const [mounted, setMounted] = useState(false);
+  const [demoAgentRunning, setDemoAgentRunning] = useState(false);
   const wsRef = useRef<WorkspaceSocket | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const demo = mounted && isDemoMode();
 
   // Load workspace and files
   useEffect(() => {
     if (isDemoMode()) {
-      setWorkspace({
-        id: workspaceId,
-        user_id: "demo",
-        name: "Demo Workspace",
-        description: "Demo workspace",
-        path: "/demo",
-        status: "active",
-        settings: {},
-        created_at: "2026-03-20T00:00:00Z",
-        updated_at: "2026-03-23T00:00:00Z",
-      });
-      setFiles([
-        { name: "README.md", path: "README.md", type: "file", size: 256, children: null },
-        { name: "main.py", path: "main.py", type: "file", size: 1024, children: null },
-        {
-          name: "src",
-          path: "src",
-          type: "directory",
-          size: null,
-          children: [
-            { name: "app.py", path: "src/app.py", type: "file", size: 512, children: null },
-            { name: "config.json", path: "src/config.json", type: "file", size: 128, children: null },
-          ],
-        },
-      ]);
+      setWorkspace({ ...DEMO_WORKSPACE, id: workspaceId } as Workspace);
+      setFiles(
+        DEMO_WORKSPACE_TREE.map((entry) => stripContent(entry)) as FileEntry[]
+      );
       return;
     }
 
@@ -185,7 +193,8 @@ export default function WorkspaceIDEPage() {
     }
 
     if (isDemoMode()) {
-      const content = `# Demo file: ${path}\n\nThis is a demo workspace file.\nEdit it and see real-time sync in action.`;
+      const entry = findDemoFile(path);
+      const content = entry?.content ?? "";
       setOpenFiles((prev) => {
         const next = new Map(prev);
         next.set(path, { path, content, originalContent: content });
@@ -236,10 +245,8 @@ export default function WorkspaceIDEPage() {
     if (!file) return;
 
     if (isDemoMode()) {
-      setOpenFiles((prev) => {
-        const next = new Map(prev);
-        next.set(activeFile, { ...file, originalContent: file.content });
-        return next;
+      toast("Demo mode — fork the workspace to save", {
+        description: "Connect a Forge runtime to write files back to disk.",
       });
       return;
     }
@@ -257,6 +264,61 @@ export default function WorkspaceIDEPage() {
     } catch { /* save failed */ }
   }
 
+  async function runDemoAgent() {
+    if (!demo) return;
+    const targetPath = "src/output.py";
+    setDemoAgentRunning(true);
+    try {
+      const entry = findDemoFile(targetPath);
+      const baseContent = openFiles.get(targetPath)?.content ?? entry?.content ?? "";
+      const nextContent = baseContent.endsWith("\n")
+        ? baseContent + DEMO_AGENT_RUN_COMMENT
+        : baseContent + "\n" + DEMO_AGENT_RUN_COMMENT;
+
+      // Highlight the file in the tree.
+      setHighlightedPaths((prev) => {
+        const next = new Set(prev);
+        next.add(targetPath);
+        return next;
+      });
+      setTimeout(() => {
+        setHighlightedPaths((prev) => {
+          const next = new Set(prev);
+          next.delete(targetPath);
+          return next;
+        });
+      }, 2500);
+
+      // Update the open file content (or open it if not yet open).
+      setOpenFiles((prev) => {
+        const next = new Map(prev);
+        next.set(targetPath, {
+          path: targetPath,
+          content: nextContent,
+          originalContent: nextContent,
+        });
+        return next;
+      });
+      setActiveFile(targetPath);
+
+      // Surface in the activity panel.
+      const event: FileChangeEvent = {
+        type: "file_changed",
+        path: targetPath,
+        content: nextContent,
+        change_type: "modify",
+        source: "blueprint:workspace_write",
+      };
+      setRecentChanges((prev) => [event, ...prev].slice(0, 10));
+
+      toast.success("Demo agent ran", {
+        description: `workspace_write appended a comment to ${targetPath}.`,
+      });
+    } finally {
+      setDemoAgentRunning(false);
+    }
+  }
+
   const activeOpenFile = activeFile ? openFiles.get(activeFile) : null;
   const tabs = Array.from(openFiles.entries()).map(([path, file]) => ({
     path,
@@ -265,6 +327,11 @@ export default function WorkspaceIDEPage() {
 
   return (
     <div className="flex h-[calc(100vh-3.5rem)] flex-col">
+      {demo && (
+        <div className="flex items-center justify-between gap-2 border-b border-yellow-700 bg-yellow-900/40 px-3 py-1.5 text-xs text-yellow-200">
+          <span>Demo mode — fork the workspace to save. Edits stay in your browser.</span>
+        </div>
+      )}
       {/* Toolbar */}
       <div className="flex items-center gap-2 border-b border-border bg-card px-3 py-1.5">
         <Button variant="ghost" size="sm" onClick={() => router.push("/dashboard/workspace")}>
@@ -274,6 +341,18 @@ export default function WorkspaceIDEPage() {
         <span className="text-sm font-medium">{workspace?.name ?? "Loading..."}</span>
         <span className="text-xs text-muted-foreground truncate">{workspace?.path}</span>
         <div className="ml-auto flex items-center gap-1">
+          {demo && (
+            <Button
+              size="sm"
+              variant="default"
+              onClick={runDemoAgent}
+              disabled={demoAgentRunning}
+              title="Run a seeded blueprint that modifies src/output.py"
+            >
+              <Play className="h-3.5 w-3.5 mr-1" />
+              {demoAgentRunning ? "Running..." : "Run demo agent"}
+            </Button>
+          )}
           <Button variant="ghost" size="sm" onClick={() => setShowTerminal(!showTerminal)} title="Toggle terminal">
             <TerminalSquare className="h-3.5 w-3.5" />
           </Button>
@@ -338,9 +417,13 @@ export default function WorkspaceIDEPage() {
           </div>
 
           {/* Terminal panel */}
-          {showTerminal && currentToken && (
+          {showTerminal && (demo || currentToken) && (
             <div className="h-[200px] shrink-0 border-t border-border">
-              <TerminalPanel workspaceId={workspaceId} token={currentToken} />
+              {demo ? (
+                <DemoTerminal />
+              ) : (
+                <TerminalPanel workspaceId={workspaceId} token={currentToken} />
+              )}
             </div>
           )}
         </div>

--- a/frontend/app/dashboard/workspace/page.tsx
+++ b/frontend/app/dashboard/workspace/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { getToken } from "@/lib/auth-client";
 import { api, Workspace } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -23,9 +24,10 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { isDemoMode, DEMO_WORKSPACES } from "@/lib/demo-data";
+import { isDemoMode, DEMO_WORKSPACE, DEMO_WORKSPACE_ID } from "@/lib/demo-data";
 
 export default function WorkspacesPage() {
+  const router = useRouter();
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -36,7 +38,9 @@ export default function WorkspacesPage() {
 
   useEffect(() => {
     if (isDemoMode()) {
-      setWorkspaces(DEMO_WORKSPACES as Workspace[]);
+      // Demo has a single seeded workspace — drop the visitor straight into the IDE.
+      router.replace(`/dashboard/workspace/${DEMO_WORKSPACE_ID}`);
+      setWorkspaces([DEMO_WORKSPACE as Workspace]);
       setLoading(false);
       return;
     }
@@ -53,7 +57,7 @@ export default function WorkspacesPage() {
       }
     }
     load();
-  }, []);
+  }, [router]);
 
   async function handleCreate() {
     if (!newName.trim()) return;

--- a/frontend/components/workspace/AgentPanel.tsx
+++ b/frontend/components/workspace/AgentPanel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { getToken } from "@/lib/auth-client";
 import { api } from "@/lib/api";
-import { isDemoMode } from "@/lib/demo-data";
+import { isDemoMode, DEMO_RECENT_AGENT_ACTIVITY } from "@/lib/demo-data";
 import type { FileChangeEvent } from "@/lib/workspace-ws";
 import { Clock, FileEdit, FileOutput, Cpu } from "lucide-react";
 
@@ -25,11 +25,15 @@ export function AgentPanel({ workspaceId, recentChanges = [] }: AgentPanelProps)
 
   useEffect(() => {
     if (isDemoMode()) {
-      setHistory([
-        { id: "1", type: "modify", path: "src/app.py", attribution: "agent:research-bot", timestamp: "2 min ago" },
-        { id: "2", type: "create", path: "output/report.md", attribution: "agent:doc-writer", timestamp: "5 min ago" },
-        { id: "3", type: "modify", path: "config.json", attribution: "user:web", timestamp: "10 min ago" },
-      ]);
+      setHistory(
+        DEMO_RECENT_AGENT_ACTIVITY.map((entry) => ({
+          id: entry.id,
+          type: entry.type,
+          path: entry.path,
+          attribution: "agent:research-bot",
+          timestamp: formatTime(entry.timestamp),
+        }))
+      );
       return;
     }
 

--- a/frontend/components/workspace/DemoTerminal.tsx
+++ b/frontend/components/workspace/DemoTerminal.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { DEMO_TERMINAL_TRANSCRIPT } from "@/lib/demo-data";
+
+const PROMPT = "\x1b[36mforge@scraper-agent\x1b[0m:\x1b[34m~\x1b[0m$ ";
+
+/**
+ * Renders a pre-recorded terminal session inside an xterm.js instance so the
+ * Workspace IDE has a populated terminal even with no backend connection.
+ */
+export function DemoTerminal() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    let disposed = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let term: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let fit: any;
+    let timers: ReturnType<typeof setTimeout>[] = [];
+
+    async function init() {
+      const { Terminal } = await import("@xterm/xterm");
+      const { FitAddon } = await import("@xterm/addon-fit");
+
+      term = new Terminal({
+        cursorBlink: false,
+        disableStdin: true,
+        fontSize: 13,
+        fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace",
+        theme: {
+          background: "#1e1e2e",
+          foreground: "#cdd6f4",
+        },
+      });
+      fit = new FitAddon();
+      term.loadAddon(fit);
+      if (disposed) {
+        term.dispose();
+        return;
+      }
+      term.open(containerRef.current!);
+      fit.fit();
+
+      term.writeln(
+        "\x1b[2mDemo terminal — pre-recorded session. Typing is disabled until a Forge runtime is connected.\x1b[0m"
+      );
+      term.write("\r\n");
+
+      function play(line: { input?: string; output?: string; delay: number }) {
+        timers.push(
+          setTimeout(() => {
+            if (disposed) return;
+            if (line.input !== undefined) {
+              term.write(PROMPT + line.input + "\r\n");
+            }
+            if (line.output !== undefined) {
+              term.write(line.output);
+            }
+          }, line.delay)
+        );
+      }
+
+      DEMO_TERMINAL_TRANSCRIPT.forEach(play);
+      timers.push(
+        setTimeout(() => {
+          if (!disposed) term.write(PROMPT);
+        }, 2000)
+      );
+    }
+
+    init();
+
+    function handleResize() {
+      try {
+        fit?.fit();
+      } catch {
+        // ignore
+      }
+    }
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      disposed = true;
+      window.removeEventListener("resize", handleResize);
+      timers.forEach(clearTimeout);
+      timers = [];
+      term?.dispose();
+    };
+  }, []);
+
+  return <div ref={containerRef} className="h-full w-full" />;
+}

--- a/frontend/lib/demo-data.ts
+++ b/frontend/lib/demo-data.ts
@@ -10,6 +10,16 @@ export {
   findDemoBlueprint,
 } from "@/lib/demo/blueprints";
 
+export {
+  DEMO_WORKSPACE,
+  DEMO_WORKSPACE_ID,
+  DEMO_WORKSPACE_TREE,
+  DEMO_AGENT_RUN_COMMENT,
+  DEMO_RECENT_AGENT_ACTIVITY,
+  DEMO_TERMINAL_TRANSCRIPT,
+  findDemoFile,
+} from "@/lib/demo/workspace-fs";
+
 export const DEMO_STATS = {
   total_agents: 8,
   total_runs: 147,

--- a/frontend/lib/demo/workspace-fs.ts
+++ b/frontend/lib/demo/workspace-fs.ts
@@ -1,0 +1,268 @@
+/**
+ * Seeded filesystem for the demo Workspace IDE.
+ * The "scraper-agent" project demonstrates a small but realistic Python
+ * codebase that agents can navigate and modify.
+ */
+
+export interface DemoFileEntry {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  size: number | null;
+  children: DemoFileEntry[] | null;
+  content?: string;
+}
+
+const README = `# scraper-agent
+
+A small example project demonstrating the Forge agent platform.
+
+## Structure
+
+- \`src/scraper.py\` — fetches raw HTML for a target URL
+- \`src/parser.py\` — extracts structured data from the HTML
+- \`src/output.py\` — writes the structured data to disk
+- \`tests/test_scraper.py\` — smoke tests
+- \`data/sample_input.json\` — fixture for the parser
+- \`.forge/workspace.toml\` — Forge runtime configuration
+
+## Run locally
+
+\`\`\`bash
+python -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+python -m src.scraper https://example.com
+\`\`\`
+
+> Demo mode: edits stay in your browser and revert on refresh. Fork the workspace
+> to persist changes.
+`;
+
+const REQUIREMENTS = `httpx==0.27.0
+beautifulsoup4==4.12.3
+pydantic==2.7.1
+pytest==8.2.0
+`;
+
+const INIT_PY = `"""scraper-agent — a small example project for the Forge demo workspace."""
+
+__version__ = "0.1.0"
+`;
+
+const SCRAPER_PY = `"""HTTP client wrapper for fetching pages."""
+
+from __future__ import annotations
+
+import httpx
+
+
+DEFAULT_TIMEOUT = 10.0
+
+
+def fetch(url: str, *, timeout: float = DEFAULT_TIMEOUT) -> str:
+    """Fetch \`url\` and return the response body as text.
+
+    Raises:
+        httpx.HTTPStatusError: if the response status is 4xx or 5xx.
+    """
+    with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+        response = client.get(url)
+        response.raise_for_status()
+        return response.text
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print("usage: python -m src.scraper <url>", file=sys.stderr)
+        sys.exit(2)
+
+    print(fetch(sys.argv[1]))
+`;
+
+const PARSER_PY = `"""HTML parsing utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bs4 import BeautifulSoup
+
+
+@dataclass(frozen=True)
+class Article:
+    title: str
+    body: str
+
+
+def parse_article(html: str) -> Article:
+    """Extract the title and body of an article from raw HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    title = (soup.title.string or "").strip() if soup.title else ""
+    paragraphs = [p.get_text(" ", strip=True) for p in soup.find_all("p")]
+    body = "\\n\\n".join(paragraphs)
+    return Article(title=title, body=body)
+`;
+
+const OUTPUT_PY = `"""Write parsed articles to disk in JSON format."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .parser import Article
+
+
+def write_article(article: Article, destination: Path) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"title": article.title, "body": article.body}
+    destination.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return destination
+`;
+
+const TEST_SCRAPER_PY = `"""Smoke tests for the scraper module."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.scraper import fetch
+
+
+@pytest.mark.network
+def test_fetch_returns_text() -> None:
+    body = fetch("https://example.com")
+    assert "Example Domain" in body
+`;
+
+const SAMPLE_INPUT_JSON = `{
+  "url": "https://example.com",
+  "expected_title": "Example Domain",
+  "expected_keywords": ["example", "illustrative"]
+}
+`;
+
+const WORKSPACE_TOML = `# Forge workspace configuration
+[workspace]
+name = "scraper-agent"
+description = "Small example project for the Forge demo"
+runtime = "python-3.12"
+
+[agents.default_model]
+provider = "openai"
+model = "gpt-4o-mini"
+
+[tools]
+allow = ["fetch_url", "knowledge_retrieval", "workspace_write"]
+`;
+
+function file(name: string, path: string, content: string): DemoFileEntry {
+  return {
+    name,
+    path,
+    type: "file",
+    size: content.length,
+    children: null,
+    content,
+  };
+}
+
+function dir(name: string, path: string, children: DemoFileEntry[]): DemoFileEntry {
+  return { name, path, type: "directory", size: null, children };
+}
+
+export const DEMO_WORKSPACE_TREE: DemoFileEntry[] = [
+  file("README.md", "README.md", README),
+  file("requirements.txt", "requirements.txt", REQUIREMENTS),
+  dir("src", "src", [
+    file("__init__.py", "src/__init__.py", INIT_PY),
+    file("scraper.py", "src/scraper.py", SCRAPER_PY),
+    file("parser.py", "src/parser.py", PARSER_PY),
+    file("output.py", "src/output.py", OUTPUT_PY),
+  ]),
+  dir("tests", "tests", [
+    file("test_scraper.py", "tests/test_scraper.py", TEST_SCRAPER_PY),
+  ]),
+  dir("data", "data", [file("sample_input.json", "data/sample_input.json", SAMPLE_INPUT_JSON)]),
+  dir(".forge", ".forge", [file("workspace.toml", ".forge/workspace.toml", WORKSPACE_TOML)]),
+];
+
+export const DEMO_WORKSPACE_ID = "ws-demo-scraper-agent";
+
+export const DEMO_WORKSPACE = {
+  id: DEMO_WORKSPACE_ID,
+  user_id: "demo",
+  name: "scraper-agent",
+  description: "A small example project for the Forge demo workspace.",
+  path: "/workspaces/scraper-agent",
+  status: "active",
+  settings: {},
+  created_at: "2026-04-15T09:00:00Z",
+  updated_at: "2026-04-25T18:30:00Z",
+};
+
+export const DEMO_AGENT_RUN_COMMENT =
+  "# touched by the Forge demo agent — workspace_write\n";
+
+export const DEMO_RECENT_AGENT_ACTIVITY = [
+  {
+    id: "act-1",
+    timestamp: "2026-04-25T18:24:11Z",
+    type: "edit",
+    path: "src/parser.py",
+    summary: "Refactored parse_article to use BeautifulSoup string accessors.",
+  },
+  {
+    id: "act-2",
+    timestamp: "2026-04-25T18:18:42Z",
+    type: "create",
+    path: "tests/test_scraper.py",
+    summary: "Added a network-marked smoke test for fetch().",
+  },
+  {
+    id: "act-3",
+    timestamp: "2026-04-25T18:11:09Z",
+    type: "edit",
+    path: "src/scraper.py",
+    summary: "Set follow_redirects=True and configured request timeout.",
+  },
+  {
+    id: "act-4",
+    timestamp: "2026-04-25T18:02:34Z",
+    type: "edit",
+    path: "requirements.txt",
+    summary: "Pinned httpx to 0.27.0 and bumped pydantic.",
+  },
+];
+
+export const DEMO_TERMINAL_TRANSCRIPT = [
+  { input: "forge cu status", delay: 0 },
+  { output: "Steer: ✓ active (macOS)\nDrive: ✓ active (tmux session demo-mac-mini)\nOCR:   ✓ tesseract 5.4.1\n", delay: 250 },
+  { input: "forge agents list --workspace scraper-agent", delay: 600 },
+  {
+    output:
+      "  ID                   NAME                STATUS    LAST RUN\n" +
+      "  agt_research_2x     Research Agent       idle      18m ago\n" +
+      "  agt_extract_7y      Data Extractor       running   just now\n" +
+      "  agt_review_4q       Code Reviewer        idle      —\n",
+    delay: 1100,
+  },
+  { input: "", delay: 1800 },
+];
+
+export function findDemoFile(path: string): DemoFileEntry | null {
+  function walk(entries: DemoFileEntry[]): DemoFileEntry | null {
+    for (const entry of entries) {
+      if (entry.path === path) return entry;
+      if (entry.children) {
+        const found = walk(entry.children);
+        if (found) return found;
+      }
+    }
+    return null;
+  }
+  return walk(DEMO_WORKSPACE_TREE);
+}


### PR DESCRIPTION
## Summary

PR 4 of 7 from the Forge cleanup spec. The Workspace IDE now ships a coherent demo experience — seeded files, a working terminal, an active agent panel, and a one-click file-modification showcase.

- **scraper-agent project** seeds the demo file tree (`README.md`, `requirements.txt`, `src/{__init__,scraper,parser,output}.py`, `tests/test_scraper.py`, `data/sample_input.json`, `.forge/workspace.toml`). Every file ships with real Python so visitors can read a coherent project rather than placeholder strings.
- **CodeEditor** hydrates from the fixture; syntax highlighting works for `.py`, `.md`, `.json`, `.toml`. Edits stay in memory; `Cmd+S` raises a toast: *"Demo mode — fork the workspace to save."*
- **▶ Run demo agent** button (demo only): triggers a synthetic `workspace_write` against `src/output.py`. Visitor sees the file tree highlight, the editor refresh, and a `blueprint:workspace_write` entry land in the activity panel — the killer-demo from Problem 5.
- **xterm.js DemoTerminal** plays a short pre-recorded `forge cu status` / `forge agents list` session so the terminal toggle is meaningful with no backend.
- **AgentPanel** seeds with realistic past agent edits.
- **/dashboard/workspace** redirects in demo to the seeded workspace's IDE so clicking "Workspace" in the sidebar drops visitors straight into the IDE (single workspace, no list).

Live mode behavior is unchanged — the WebSocket sync, real save flow, and live terminal session still run when a Forge runtime is connected.

## Acceptance criteria (from spec, Problem 5)

- [x] Demo workspace seeds the `scraper-agent/` tree on first load
- [x] All files openable; syntax highlighting works for `.py`, `.md`, `.json`, `.toml`
- [x] Editor visually accepts edits but cannot save in demo
- [x] "Run demo agent" button triggers a seeded blueprint that modifies a file via `workspace_write`
- [x] File tree, editor, and activity panel all reflect the change in real-time
- [x] Live workspace unchanged; WebSocket sync still works in live mode

## Test plan

- [x] `bun run lint` clean (only the pre-existing CodeEditor warning)
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 21 pass
- [ ] CI green
- [ ] LastGate green
- [ ] On Vercel: navigate to `/dashboard/workspace` (demo) → lands in IDE → toggle terminal renders xterm transcript → click "Run demo agent" → `src/output.py` gets the comment appended and the activity panel logs it