### PR TITLE
feat(routes): build out computer-use, providers, mcp, targets, recordings, api-keys

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,7 @@ from app.routers import (
     organizations,
     prompt_versions,
     providers,
+    recordings,
     runs,
     targets,
     traces,
@@ -116,6 +117,7 @@ app.include_router(marketplace.router, prefix="/api")
 app.include_router(organizations.router, prefix="/api")
 app.include_router(computer_use.router, prefix="/api")
 app.include_router(targets.router, prefix="/api")
+app.include_router(recordings.router, prefix="/api")
 app.include_router(workspaces.router, prefix="/api")
 app.include_router(ws_workspace.router)  # WebSocket (no /api prefix)
 

--- a/backend/app/routers/recordings.py
+++ b/backend/app/routers/recordings.py
@@ -1,0 +1,51 @@
+"""Screen recording listing API."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import APIRouter, Depends
+
+from app.routers.auth import get_current_user
+
+router = APIRouter(tags=["recordings"])
+
+
+@router.get("/recordings")
+async def list_recordings(_user=Depends(get_current_user)):  # noqa: B008
+    """List recordings stored on disk.
+
+    Mirrors the CLI's `forge recordings list` view. Recordings live on the
+    filesystem at `AF_RECORDING_STORAGE` (defaults to /tmp/forge-recordings).
+    Returns an empty list when the directory does not exist or is empty.
+    """
+    storage = os.getenv("AF_RECORDING_STORAGE", "/tmp/forge-recordings")
+    if not os.path.isdir(storage):
+        return []
+
+    entries = []
+    for name in sorted(os.listdir(storage), reverse=True)[:50]:
+        path = os.path.join(storage, name)
+        try:
+            stat = os.stat(path)
+        except OSError:
+            continue
+        entries.append(
+            {
+                "id": name,
+                "blueprint": name.split("__", 1)[0] if "__" in name else "unknown",
+                "target": "local",
+                "duration_ms": 0,
+                "started_at": _iso(stat.st_mtime),
+                "trace_id": name.rsplit(".", 1)[0],
+                "thumbnail_caption": name,
+                "size_bytes": stat.st_size,
+            }
+        )
+    return entries
+
+
+def _iso(ts: float) -> str:
+    from datetime import UTC, datetime
+
+    return datetime.fromtimestamp(ts, tz=UTC).isoformat()

--- a/backend/tests/test_recordings.py
+++ b/backend/tests/test_recordings.py
@@ -1,0 +1,41 @@
+"""Tests for the recordings listing endpoint."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def test_recordings_requires_auth(client):
+    response = client.get("/api/recordings")
+    assert response.status_code == 422
+
+
+def test_recordings_empty_when_storage_missing(auth_client, monkeypatch):
+    monkeypatch.setenv("AF_RECORDING_STORAGE", "/nonexistent/path/forge-recordings")
+    response = auth_client.get(
+        "/api/recordings",
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_recordings_lists_files(auth_client, monkeypatch):
+    with tempfile.TemporaryDirectory() as storage:
+        Path(storage, "Computer-Use-demo__abc123.mp4").write_bytes(b"x" * 64)
+        Path(storage, "Test-runner__def456.mp4").write_bytes(b"x" * 32)
+        monkeypatch.setenv("AF_RECORDING_STORAGE", storage)
+
+        response = auth_client.get(
+            "/api/recordings",
+            headers={"Authorization": "Bearer test-token"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        names = {entry["id"] for entry in data}
+        assert names == {"Computer-Use-demo__abc123.mp4", "Test-runner__def456.mp4"}
+        assert all("started_at" in entry for entry in data)
+        assert all("size_bytes" in entry for entry in data)

--- a/frontend/app/dashboard/computer-use/page.tsx
+++ b/frontend/app/dashboard/computer-use/page.tsx
@@ -1,13 +1,299 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Monitor } from "lucide-react";
-import { RouteStub } from "@/components/dashboard/RouteStub";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  isDemoMode,
+  DEMO_CU_CAPABILITY,
+  DEMO_CU_SESSIONS,
+  DEMO_CU_AUDIT,
+  DEMO_CU_SAFETY,
+  DEMO_CU_SCREENSHOTS,
+} from "@/lib/demo-data";
+import { supabase } from "@/lib/supabase";
+import { API_URL } from "@/lib/constants";
+
+interface CapabilityRow {
+  platform: "macos" | "linux" | "windows";
+  steer: "ok" | "missing" | "n/a";
+  drive: "ok" | "missing" | "n/a";
+  ocr: "ok" | "missing" | "n/a";
+  notes: string;
+}
+
+interface AuditEntry {
+  ts: string;
+  action: string;
+  target: string;
+  blueprint: string;
+  result: string;
+  note?: string;
+}
+
+interface SessionEntry {
+  id: string;
+  target: string;
+  kind: string;
+  focus: string;
+  started_at: string;
+}
+
+interface ScreenshotEntry {
+  id: string;
+  ts: string;
+  target: string;
+  thumb_caption: string;
+}
+
+function StatusPill({ value }: { value: "ok" | "missing" | "n/a" }) {
+  const map = {
+    ok: "bg-emerald-500/15 text-emerald-300 border-emerald-700",
+    missing: "bg-red-500/15 text-red-300 border-red-700",
+    "n/a": "bg-muted text-muted-foreground border-border",
+  } as const;
+  return (
+    <span
+      className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${map[value]}`}
+    >
+      {value}
+    </span>
+  );
+}
+
+function fmtTime(iso: string) {
+  return new Date(iso).toLocaleString();
+}
 
 export default function ComputerUsePage() {
+  const [capability, setCapability] = useState<CapabilityRow[]>([]);
+  const [sessions, setSessions] = useState<SessionEntry[]>([]);
+  const [audit, setAudit] = useState<AuditEntry[]>([]);
+  const [screenshots, setScreenshots] = useState<ScreenshotEntry[]>([]);
+  const [seeded, setSeeded] = useState(false);
+
+  useEffect(() => {
+    if (isDemoMode()) {
+      setCapability(DEMO_CU_CAPABILITY);
+      setSessions(DEMO_CU_SESSIONS);
+      setAudit(DEMO_CU_AUDIT);
+      setScreenshots(DEMO_CU_SCREENSHOTS);
+      setSeeded(true);
+      return;
+    }
+    async function load() {
+      const { data } = await supabase.auth.getSession();
+      if (!data.session) return;
+      try {
+        const res = await fetch(`${API_URL}/api/computer-use/status`, {
+          headers: { Authorization: `Bearer ${data.session.access_token}` },
+        });
+        if (res.ok) {
+          const status = await res.json();
+          // Map a single-host status into the same shape as the multi-platform table.
+          setCapability([
+            {
+              platform: status.platform ?? "macos",
+              steer: status.steer_available ? "ok" : "missing",
+              drive: status.drive_available ? "ok" : "missing",
+              ocr: status.tmux_available ? "ok" : "missing",
+              notes: `tmux ${status.tmux_version ?? "—"}`,
+            },
+          ]);
+        }
+      } catch {
+        // Backend may be unreachable; render empty state
+      }
+    }
+    load();
+  }, []);
+
   return (
-    <RouteStub
-      title="Computer Use"
-      description="Status and audit of the Steer (GUI) and Drive (Terminal) capability layer."
-      icon={Monitor}
-      cliCommand="forge cu status"
-    />
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <Monitor className="mt-1 h-6 w-6 text-muted-foreground" aria-hidden="true" />
+        <div>
+          <h1 className="text-3xl font-bold">Computer Use</h1>
+          <p className="mt-1 text-muted-foreground">
+            Status and audit of the Steer (GUI) and Drive (Terminal) capability layer.
+          </p>
+        </div>
+      </div>
+
+      {seeded && (
+        <div className="rounded-lg border border-yellow-700 bg-yellow-900/30 px-3 py-2 text-xs text-yellow-200" data-seeded="true">
+          Connect a local Forge runtime to enable computer use. Demo data shown below.
+        </div>
+      )}
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Capability report</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="py-2 pr-4 font-medium">Platform</th>
+                <th className="py-2 pr-4 font-medium">Steer</th>
+                <th className="py-2 pr-4 font-medium">Drive</th>
+                <th className="py-2 pr-4 font-medium">OCR</th>
+                <th className="py-2 pr-4 font-medium">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {capability.map((row) => (
+                <tr key={row.platform} data-seeded={seeded}>
+                  <td className="py-2 pr-4 font-mono">{row.platform}</td>
+                  <td className="py-2 pr-4"><StatusPill value={row.steer} /></td>
+                  <td className="py-2 pr-4"><StatusPill value={row.drive} /></td>
+                  <td className="py-2 pr-4"><StatusPill value={row.ocr} /></td>
+                  <td className="py-2 pr-4 text-muted-foreground">{row.notes}</td>
+                </tr>
+              ))}
+              {capability.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="py-3 text-sm text-muted-foreground">
+                    No capability data yet. Connect a Forge runtime to populate this report.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Active sessions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {sessions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No active sessions.</p>
+          ) : (
+            <div className="space-y-2">
+              {sessions.map((s) => (
+                <div key={s.id} className="flex items-center justify-between rounded border border-border p-3 text-sm" data-seeded={seeded}>
+                  <div>
+                    <p className="font-medium">{s.target}</p>
+                    <p className="text-xs text-muted-foreground">
+                      <Badge variant="outline" className="mr-2">{s.kind}</Badge>
+                      {s.focus}
+                    </p>
+                  </div>
+                  <span className="text-xs text-muted-foreground">since {fmtTime(s.started_at)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Audit log</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="py-2 pr-4 font-medium">Time</th>
+                <th className="py-2 pr-4 font-medium">Action</th>
+                <th className="py-2 pr-4 font-medium">Target</th>
+                <th className="py-2 pr-4 font-medium">Blueprint</th>
+                <th className="py-2 pr-4 font-medium">Result</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {audit.map((row) => (
+                <tr key={row.ts + row.action} data-seeded={seeded}>
+                  <td className="py-2 pr-4 font-mono text-xs">{fmtTime(row.ts)}</td>
+                  <td className="py-2 pr-4 font-mono">{row.action}</td>
+                  <td className="py-2 pr-4">{row.target}</td>
+                  <td className="py-2 pr-4 text-muted-foreground">{row.blueprint}</td>
+                  <td className="py-2 pr-4">
+                    <Badge variant={row.result === "ok" ? "default" : "destructive"}>
+                      {row.result}
+                    </Badge>
+                    {row.note && (
+                      <span className="ml-2 text-xs text-muted-foreground">{row.note}</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {audit.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="py-3 text-sm text-muted-foreground">
+                    No audit entries yet. Run a Computer Use blueprint to see actions here.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Safety config</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+            <div>
+              <dt className="text-xs uppercase tracking-wide text-muted-foreground">App blocklist</dt>
+              <dd className="mt-1 flex flex-wrap gap-1">
+                {DEMO_CU_SAFETY.app_blocklist.map((app) => (
+                  <Badge key={app} variant="outline" className="font-mono text-[10px]">{app}</Badge>
+                ))}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wide text-muted-foreground">Command blocklist</dt>
+              <dd className="mt-1 flex flex-wrap gap-1">
+                {DEMO_CU_SAFETY.command_blocklist.map((cmd) => (
+                  <Badge key={cmd} variant="outline" className="font-mono text-[10px]">{cmd}</Badge>
+                ))}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wide text-muted-foreground">Rate limit</dt>
+              <dd className="mt-1 font-mono text-sm">
+                {DEMO_CU_SAFETY.rate_limit_per_minute} actions / minute
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wide text-muted-foreground">Approval gates</dt>
+              <dd className="mt-1 flex flex-wrap gap-1">
+                {DEMO_CU_SAFETY.approval_gates.map((gate) => (
+                  <Badge key={gate} variant="outline" className="font-mono text-[10px]">{gate}</Badge>
+                ))}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Recent screenshots</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {screenshots.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No screenshots yet.</p>
+          ) : (
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              {screenshots.map((s) => (
+                <div key={s.id} className="rounded border border-border p-2" data-seeded={seeded}>
+                  <div className="aspect-video rounded bg-gradient-to-br from-slate-800 to-slate-900" />
+                  <p className="mt-2 truncate text-xs">{s.thumb_caption}</p>
+                  <p className="text-[10px] text-muted-foreground">{s.target} · {fmtTime(s.ts)}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/frontend/app/dashboard/mcp/page.tsx
+++ b/frontend/app/dashboard/mcp/page.tsx
@@ -1,13 +1,244 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Plug } from "lucide-react";
-import { RouteStub } from "@/components/dashboard/RouteStub";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  isDemoMode,
+  DEMO_MCP_SERVERS,
+  DEMO_MCP_LOGS,
+} from "@/lib/demo-data";
+import { supabase } from "@/lib/supabase";
+import { API_URL } from "@/lib/constants";
+
+interface ServerRow {
+  id: string;
+  name: string;
+  transport: "stdio" | "sse";
+  status: "connected" | "degraded" | "disconnected";
+  tool_count: number;
+  last_seen: string;
+  tools: { name: string; description: string; schema: string }[];
+}
+
+interface LogRow {
+  ts: string;
+  server: string;
+  level: string;
+  message: string;
+}
+
+function StatusPill({ status }: { status: ServerRow["status"] }) {
+  const tone = {
+    connected: "bg-emerald-500/15 text-emerald-300 border-emerald-700",
+    degraded: "bg-yellow-500/15 text-yellow-300 border-yellow-700",
+    disconnected: "bg-red-500/15 text-red-300 border-red-700",
+  } as const;
+  return (
+    <span className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${tone[status]}`}>
+      {status}
+    </span>
+  );
+}
 
 export default function McpPage() {
+  const [servers, setServers] = useState<ServerRow[]>([]);
+  const [logs, setLogs] = useState<LogRow[]>([]);
+  const [demo, setDemo] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newUrl, setNewUrl] = useState("");
+
+  useEffect(() => {
+    if (isDemoMode()) {
+      setDemo(true);
+      setServers(DEMO_MCP_SERVERS);
+      setLogs(DEMO_MCP_LOGS);
+      return;
+    }
+    async function load() {
+      const { data } = await supabase.auth.getSession();
+      if (!data.session) return;
+      const token = data.session.access_token;
+      try {
+        const res = await fetch(`${API_URL}/api/mcp/connections`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const list = (await res.json()) as Array<{ id: string; name: string; server_url: string; tools: unknown[] }>;
+          setServers(
+            list.map((c) => ({
+              id: c.id,
+              name: c.name,
+              transport: "stdio",
+              status: "connected" as const,
+              tool_count: c.tools.length,
+              last_seen: new Date().toISOString(),
+              tools: c.tools as { name: string; description: string; schema: string }[],
+            }))
+          );
+        }
+      } catch {
+        // ignore
+      }
+    }
+    load();
+  }, []);
+
+  function handleAdd() {
+    if (demo) {
+      toast("Demo mode — connect a Forge runtime to add servers");
+      setDialogOpen(false);
+      return;
+    }
+    if (!newName.trim() || !newUrl.trim()) return;
+    toast.message("Connecting to MCP server...");
+    setDialogOpen(false);
+  }
+
   return (
-    <RouteStub
-      title="MCP"
-      description="Model Context Protocol connection management — connected servers, tool inventory, and add-connection flow."
-      icon={Plug}
-      cliCommand="forge mcp list"
-    />
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <Plug className="mt-1 h-6 w-6 text-muted-foreground" aria-hidden="true" />
+        <div>
+          <h1 className="text-3xl font-bold">MCP</h1>
+          <p className="mt-1 text-muted-foreground">
+            Model Context Protocol connection management — servers, tool inventory, and logs.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger asChild>
+            <Button>+ Add connection</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Add MCP server</DialogTitle>
+              <DialogDescription>
+                Register an MCP server. Forge will perform a handshake and register its tools.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="mcp-name">Name</Label>
+                <Input
+                  id="mcp-name"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="filesystem"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="mcp-url">Server URL</Label>
+                <Input
+                  id="mcp-url"
+                  value={newUrl}
+                  onChange={(e) => setNewUrl(e.target.value)}
+                  placeholder="stdio:///opt/mcp/filesystem.sh or https://..."
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleAdd}>Connect</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Connected servers</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {servers.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No MCP servers connected.</p>
+          ) : (
+            <div className="divide-y divide-border">
+              {servers.map((server) => (
+                <div key={server.id} data-seeded={demo}>
+                  <button
+                    className="flex w-full items-center justify-between py-3 text-left"
+                    onClick={() =>
+                      setExpanded((prev) => (prev === server.id ? null : server.id))
+                    }
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="font-mono text-sm">{server.name}</span>
+                      <StatusPill status={server.status} />
+                      <Badge variant="outline" className="text-[10px]">
+                        {server.transport}
+                      </Badge>
+                      <span className="text-xs text-muted-foreground">
+                        {server.tool_count} tool{server.tool_count === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      {expanded === server.id ? "▾" : "▸"}
+                    </span>
+                  </button>
+                  {expanded === server.id && (
+                    <div className="space-y-2 border-l-2 border-border pl-4 pb-3">
+                      {server.tools.map((tool) => (
+                        <div key={tool.name} className="text-sm">
+                          <p className="font-mono">{tool.name}</p>
+                          <p className="text-xs text-muted-foreground">{tool.description}</p>
+                          <pre className="mt-1 overflow-x-auto rounded bg-muted px-2 py-1 text-[11px]">
+                            {tool.schema}
+                          </pre>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Connection logs</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {logs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No connection events yet.</p>
+          ) : (
+            <ul className="space-y-2 text-sm">
+              {logs.map((log) => (
+                <li key={log.ts + log.server} data-seeded={demo} className="font-mono text-xs">
+                  <span className="text-muted-foreground">{new Date(log.ts).toLocaleString()}</span>{" "}
+                  <Badge variant={log.level === "warn" ? "destructive" : "outline"} className="ml-1">
+                    {log.level}
+                  </Badge>{" "}
+                  <span className="ml-1 text-muted-foreground">[{log.server}]</span>{" "}
+                  <span>{log.message}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/frontend/app/dashboard/providers/page.tsx
+++ b/frontend/app/dashboard/providers/page.tsx
@@ -1,13 +1,281 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Cpu } from "lucide-react";
-import { RouteStub } from "@/components/dashboard/RouteStub";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { isDemoMode, DEMO_PROVIDERS, DEMO_MODEL_CATALOG } from "@/lib/demo-data";
+import { supabase } from "@/lib/supabase";
+import { API_URL } from "@/lib/constants";
+
+interface ProviderRow {
+  provider: string;
+  status: "healthy" | "degraded" | "down";
+  latency_ms: number;
+  default_model: string;
+  api_key_masked: string;
+}
+
+interface ModelRow {
+  provider: string;
+  name: string;
+  context: number;
+  input_cost: number;
+  output_cost: number;
+  supports_streaming: boolean;
+}
+
+function StatusBadge({ status }: { status: ProviderRow["status"] }) {
+  const variant: Record<ProviderRow["status"], string> = {
+    healthy: "bg-emerald-500/15 text-emerald-300 border-emerald-700",
+    degraded: "bg-yellow-500/15 text-yellow-300 border-yellow-700",
+    down: "bg-red-500/15 text-red-300 border-red-700",
+  };
+  return (
+    <span className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${variant[status]}`}>
+      {status}
+    </span>
+  );
+}
 
 export default function ProvidersPage() {
+  const [providers, setProviders] = useState<ProviderRow[]>([]);
+  const [models, setModels] = useState<ModelRow[]>([]);
+  const [demo, setDemo] = useState(false);
+  const [filter, setFilter] = useState("");
+  const [comparePrompt, setComparePrompt] = useState("Summarize the request to refactor scraper.py for clarity.");
+  const [selectedModels, setSelectedModels] = useState<string[]>([
+    "openai:gpt-4o-mini",
+    "anthropic:claude-haiku-4-5",
+  ]);
+
+  useEffect(() => {
+    if (isDemoMode()) {
+      setDemo(true);
+      setProviders(DEMO_PROVIDERS);
+      setModels(DEMO_MODEL_CATALOG);
+      return;
+    }
+    async function load() {
+      const { data } = await supabase.auth.getSession();
+      if (!data.session) return;
+      const token = data.session.access_token;
+      try {
+        const [healthRes, modelsRes] = await Promise.all([
+          fetch(`${API_URL}/api/providers/health`, { headers: { Authorization: `Bearer ${token}` } }),
+          fetch(`${API_URL}/api/providers/models`, { headers: { Authorization: `Bearer ${token}` } }),
+        ]);
+        if (healthRes.ok) {
+          const healthList = await healthRes.json();
+          setProviders(
+            healthList.map((h: { provider: string; status: string; latency_ms?: number }) => ({
+              provider: h.provider,
+              status: (h.status === "healthy" || h.status === "degraded" || h.status === "down" ? h.status : "down") as ProviderRow["status"],
+              latency_ms: h.latency_ms ?? 0,
+              default_model: "—",
+              api_key_masked: "configured",
+            }))
+          );
+        }
+        if (modelsRes.ok) {
+          const list = (await modelsRes.json()) as Array<{
+            provider: string;
+            name: string;
+            context_window?: number;
+            input_cost_per_token?: number;
+            output_cost_per_token?: number;
+            supports_streaming?: boolean;
+          }>;
+          setModels(
+            list.map((m) => ({
+              provider: m.provider,
+              name: m.name,
+              context: m.context_window ?? 0,
+              input_cost: m.input_cost_per_token ?? 0,
+              output_cost: m.output_cost_per_token ?? 0,
+              supports_streaming: m.supports_streaming ?? false,
+            }))
+          );
+        }
+      } catch {
+        // backend may be unreachable
+      }
+    }
+    load();
+  }, []);
+
+  const filteredModels = models.filter((m) => {
+    const q = filter.toLowerCase();
+    return !q || m.name.toLowerCase().includes(q) || m.provider.toLowerCase().includes(q);
+  });
+
+  function toggleModel(key: string) {
+    setSelectedModels((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]
+    );
+  }
+
+  function handleTest(provider: string) {
+    if (demo) {
+      toast("Add your own key to test", {
+        description: "Demo provider keys are read-only.",
+      });
+      return;
+    }
+    toast.message(`Testing ${provider}...`);
+  }
+
+  function handleCompare() {
+    if (demo) {
+      toast("Compare runs against pre-recorded outputs", {
+        description: "Connect a Forge runtime to run live comparisons.",
+      });
+      return;
+    }
+    toast.message("Running comparison...");
+  }
+
   return (
-    <RouteStub
-      title="Providers"
-      description="Multi-model provider registry, health checks, and side-by-side comparison."
-      icon={Cpu}
-      cliCommand="forge models list"
-    />
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <Cpu className="mt-1 h-6 w-6 text-muted-foreground" aria-hidden="true" />
+        <div>
+          <h1 className="text-3xl font-bold">Providers</h1>
+          <p className="mt-1 text-muted-foreground">
+            Multi-model provider registry, health checks, and side-by-side comparison.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {providers.map((p) => (
+          <Card key={p.provider} data-seeded={demo}>
+            <CardHeader className="pb-2">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-sm font-mono">{p.provider}</CardTitle>
+                <StatusBadge status={p.status} />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2 text-xs">
+              <p className="text-muted-foreground">Default · {p.default_model}</p>
+              <p className="font-mono text-muted-foreground">{p.api_key_masked}</p>
+              <p className="text-muted-foreground">{p.latency_ms || "—"} ms</p>
+              <Button size="sm" variant="outline" className="w-full" onClick={() => handleTest(p.provider)}>
+                Test
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+        {providers.length === 0 && (
+          <p className="col-span-full text-sm text-muted-foreground">
+            No providers configured. Add an API key in Settings to register one.
+          </p>
+        )}
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-sm font-medium">Model catalog</CardTitle>
+            <Input
+              type="search"
+              placeholder="Filter models..."
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              className="h-8 w-48 text-xs"
+            />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="py-2 pr-4 font-medium">Provider</th>
+                <th className="py-2 pr-4 font-medium">Model</th>
+                <th className="py-2 pr-4 font-medium">Context</th>
+                <th className="py-2 pr-4 font-medium">Input $/Mtok</th>
+                <th className="py-2 pr-4 font-medium">Output $/Mtok</th>
+                <th className="py-2 pr-4 font-medium">Streaming</th>
+                <th className="py-2 pr-4 font-medium">Compare</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {filteredModels.map((m) => {
+                const key = `${m.provider}:${m.name}`;
+                const checked = selectedModels.includes(key);
+                return (
+                  <tr key={key} data-seeded={demo}>
+                    <td className="py-2 pr-4 font-mono text-xs">{m.provider}</td>
+                    <td className="py-2 pr-4 font-medium">{m.name}</td>
+                    <td className="py-2 pr-4 text-muted-foreground">
+                      {m.context.toLocaleString()}
+                    </td>
+                    <td className="py-2 pr-4 font-mono text-xs">
+                      ${(m.input_cost * 1_000_000).toFixed(2)}
+                    </td>
+                    <td className="py-2 pr-4 font-mono text-xs">
+                      ${(m.output_cost * 1_000_000).toFixed(2)}
+                    </td>
+                    <td className="py-2 pr-4">
+                      {m.supports_streaming ? (
+                        <Badge variant="outline" className="text-[10px]">yes</Badge>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">no</span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleModel(key)}
+                        aria-label={`Compare ${m.name}`}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+              {filteredModels.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="py-3 text-sm text-muted-foreground">
+                    No models match the filter.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Compare</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Textarea
+            value={comparePrompt}
+            onChange={(e) => setComparePrompt(e.target.value)}
+            rows={3}
+            placeholder="Prompt to compare across selected models..."
+          />
+          <div className="flex flex-wrap gap-2 text-xs">
+            <span className="text-muted-foreground">Selected:</span>
+            {selectedModels.length === 0 ? (
+              <span className="text-muted-foreground">none</span>
+            ) : (
+              selectedModels.map((m) => (
+                <Badge key={m} variant="outline" className="font-mono text-[10px]">
+                  {m}
+                </Badge>
+              ))
+            )}
+          </div>
+          <Button onClick={handleCompare}>Run comparison</Button>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/frontend/app/dashboard/recordings/page.tsx
+++ b/frontend/app/dashboard/recordings/page.tsx
@@ -1,13 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
 import { Video } from "lucide-react";
-import { RouteStub } from "@/components/dashboard/RouteStub";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { isDemoMode, DEMO_RECORDINGS } from "@/lib/demo-data";
+import { supabase } from "@/lib/supabase";
+import { API_URL } from "@/lib/constants";
+
+interface RecordingRow {
+  id: string;
+  blueprint: string;
+  target: string;
+  duration_ms: number;
+  started_at: string;
+  trace_id: string;
+  thumbnail_caption: string;
+}
+
+function formatDuration(ms: number) {
+  const total = Math.round(ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
 
 export default function RecordingsPage() {
+  const [recordings, setRecordings] = useState<RecordingRow[]>([]);
+  const [demo, setDemo] = useState(false);
+  const [active, setActive] = useState<RecordingRow | null>(null);
+  const [filter, setFilter] = useState("");
+
+  useEffect(() => {
+    if (isDemoMode()) {
+      setDemo(true);
+      setRecordings(DEMO_RECORDINGS);
+      setActive(DEMO_RECORDINGS[0] ?? null);
+      return;
+    }
+    async function load() {
+      const { data } = await supabase.auth.getSession();
+      if (!data.session) return;
+      try {
+        const res = await fetch(`${API_URL}/api/recordings`, {
+          headers: { Authorization: `Bearer ${data.session.access_token}` },
+        });
+        if (res.ok) {
+          const list = (await res.json()) as RecordingRow[];
+          setRecordings(list);
+          setActive(list[0] ?? null);
+        }
+      } catch {
+        // backend may not yet expose recordings
+      }
+    }
+    load();
+  }, []);
+
+  const filtered = recordings.filter((r) => {
+    const q = filter.toLowerCase();
+    return (
+      !q ||
+      r.blueprint.toLowerCase().includes(q) ||
+      r.target.toLowerCase().includes(q)
+    );
+  });
+
+  function handleExport() {
+    if (demo) {
+      toast("Demo mode — export disabled", {
+        description: "Connect a Forge runtime to export recording files.",
+      });
+      return;
+    }
+    toast.message("Export starting...");
+  }
+
   return (
-    <RouteStub
-      title="Recordings"
-      description="Screen recordings from Computer Use sessions — gallery, scrubbing player, trace links."
-      icon={Video}
-      cliCommand="forge recordings list"
-    />
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <Video className="mt-1 h-6 w-6 text-muted-foreground" aria-hidden="true" />
+        <div>
+          <h1 className="text-3xl font-bold">Recordings</h1>
+          <p className="mt-1 text-muted-foreground">
+            Screen recordings from Computer Use sessions.
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-sm font-medium">Player</CardTitle>
+            <Button size="sm" variant="outline" onClick={handleExport}>
+              Export
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {active ? (
+            <div className="space-y-3">
+              <div className="relative aspect-video w-full overflow-hidden rounded bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950">
+                <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+                  <Video className="h-10 w-10 opacity-60" aria-hidden="true" />
+                  <p className="text-sm">{active.thumbnail_caption}</p>
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">{active.blueprint}</Badge>
+                  <Badge variant="outline">{active.target}</Badge>
+                  <span className="text-muted-foreground">{formatDuration(active.duration_ms)}</span>
+                </div>
+                <Link href={`/dashboard/traces/${active.trace_id}`}>
+                  <Button variant="ghost" size="sm">
+                    Jump to trace →
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No recording selected.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-sm font-medium">Gallery</CardTitle>
+            <input
+              type="search"
+              placeholder="Filter by blueprint or target..."
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              className="h-8 w-48 rounded border border-input bg-transparent px-2 text-xs"
+            />
+          </div>
+        </CardHeader>
+        <CardContent>
+          {filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No recordings match the filter.</p>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {filtered.map((rec) => (
+                <button
+                  key={rec.id}
+                  onClick={() => setActive(rec)}
+                  data-seeded={demo}
+                  className={`group rounded-lg border p-3 text-left transition-colors ${
+                    active?.id === rec.id ? "border-primary" : "border-border hover:border-primary/50"
+                  }`}
+                >
+                  <div className="aspect-video rounded bg-gradient-to-br from-slate-800 to-slate-950" />
+                  <p className="mt-2 truncate text-sm">{rec.blueprint}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {rec.target} · {formatDuration(rec.duration_ms)}
+                  </p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {new Date(rec.started_at).toLocaleString()}
+                  </p>
+                </button>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/frontend/app/dashboard/settings/api-keys/page.tsx
+++ b/frontend/app/dashboard/settings/api-keys/page.tsx
@@ -1,13 +1,205 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Key } from "lucide-react";
-import { RouteStub } from "@/components/dashboard/RouteStub";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { isDemoMode, DEMO_API_KEYS_DETAILED } from "@/lib/demo-data";
+import { api } from "@/lib/api";
+import { supabase } from "@/lib/supabase";
+
+interface ApiKeyRow {
+  id: string;
+  name: string;
+  masked: string;
+  created_at: string;
+  last_used_at: string | null;
+}
 
 export default function ApiKeysPage() {
+  const [keys, setKeys] = useState<ApiKeyRow[]>([]);
+  const [demo, setDemo] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    if (isDemoMode()) {
+      setDemo(true);
+      setKeys(DEMO_API_KEYS_DETAILED);
+      return;
+    }
+    async function load() {
+      const { data } = await supabase.auth.getSession();
+      if (!data.session) return;
+      try {
+        const list = await api.keys.list(data.session.access_token);
+        setKeys(
+          list.map((k) => ({
+            id: k.id,
+            name: k.name,
+            masked: "fge_•••• ••••",
+            created_at: k.created_at,
+            last_used_at: k.last_used_at,
+          }))
+        );
+      } catch {
+        // ignore
+      }
+    }
+    load();
+  }, []);
+
+  async function handleCreate() {
+    if (demo) {
+      toast("Demo mode — sign in to create API keys");
+      setDialogOpen(false);
+      return;
+    }
+    if (!newName.trim()) return;
+    setCreating(true);
+    try {
+      const { data } = await supabase.auth.getSession();
+      if (!data.session) return;
+      const result = await api.keys.create(newName.trim(), data.session.access_token);
+      toast.success("API key created", {
+        description: result.key,
+      });
+      setNewName("");
+      setDialogOpen(false);
+      const list = await api.keys.list(data.session.access_token);
+      setKeys(
+        list.map((k) => ({
+          id: k.id,
+          name: k.name,
+          masked: "fge_•••• ••••",
+          created_at: k.created_at,
+          last_used_at: k.last_used_at,
+        }))
+      );
+    } catch {
+      toast.error("Failed to create API key");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleRevoke(id: string) {
+    if (demo) {
+      toast("Demo mode — keys are read-only");
+      return;
+    }
+    const { data } = await supabase.auth.getSession();
+    if (!data.session) return;
+    try {
+      await api.keys.delete(id, data.session.access_token);
+      setKeys((prev) => prev.filter((k) => k.id !== id));
+      toast.success("API key revoked");
+    } catch {
+      toast.error("Failed to revoke API key");
+    }
+  }
+
   return (
-    <RouteStub
-      title="API Keys"
-      description="Manage API keys for accessing Forge from external systems."
-      icon={Key}
-      cliCommand="forge keys list"
-    />
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <Key className="mt-1 h-6 w-6 text-muted-foreground" aria-hidden="true" />
+        <div>
+          <h1 className="text-3xl font-bold">API Keys</h1>
+          <p className="mt-1 text-muted-foreground">
+            Manage API keys for accessing Forge from external systems.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger asChild>
+            <Button>+ New API key</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create API key</DialogTitle>
+              <DialogDescription>
+                Give the key a memorable name. Forge will display the secret once on creation.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="key-name">Name</Label>
+                <Input
+                  id="key-name"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="ci-pipeline"
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleCreate} disabled={creating || !newName.trim()}>
+                {creating ? "Creating..." : "Create"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Active keys</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {keys.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No API keys yet.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <th className="py-2 pr-4 font-medium">Name</th>
+                  <th className="py-2 pr-4 font-medium">Key</th>
+                  <th className="py-2 pr-4 font-medium">Created</th>
+                  <th className="py-2 pr-4 font-medium">Last used</th>
+                  <th className="py-2 pr-4 font-medium" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {keys.map((k) => (
+                  <tr key={k.id} data-seeded={demo}>
+                    <td className="py-2 pr-4 font-medium">{k.name}</td>
+                    <td className="py-2 pr-4 font-mono text-xs">{k.masked}</td>
+                    <td className="py-2 pr-4 text-xs text-muted-foreground">
+                      {new Date(k.created_at).toLocaleDateString()}
+                    </td>
+                    <td className="py-2 pr-4 text-xs text-muted-foreground">
+                      {k.last_used_at ? new Date(k.last_used_at).toLocaleDateString() : "—"}
+                    </td>
+                    <td className="py-2 pr-4 text-right">
+                      <Button size="sm" variant="ghost" onClick={() => handleRevoke(k.id)}>
+                        Revoke
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/frontend/app/dashboard/targets/page.tsx
+++ b/frontend/app/dashboard/targets/page.tsx
@@ -1,13 +1,232 @@
-import { Target } from "lucide-react";
-import { RouteStub } from "@/components/dashboard/RouteStub";
+"use client";
+
+import { useEffect, useState } from "react";
+import { Target as TargetIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { isDemoMode, DEMO_TARGETS } from "@/lib/demo-data";
+import { supabase } from "@/lib/supabase";
+import { API_URL } from "@/lib/constants";
+
+interface TargetRow {
+  id: string;
+  name: string;
+  platform: "macos" | "linux" | "windows";
+  capabilities: string[];
+  status: "healthy" | "idle" | "down";
+  last_seen: string;
+}
+
+function StatusPill({ status }: { status: TargetRow["status"] }) {
+  const tone = {
+    healthy: "bg-emerald-500/15 text-emerald-300 border-emerald-700",
+    idle: "bg-yellow-500/15 text-yellow-300 border-yellow-700",
+    down: "bg-red-500/15 text-red-300 border-red-700",
+  } as const;
+  return (
+    <span className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${tone[status]}`}>
+      {status}
+    </span>
+  );
+}
 
 export default function TargetsPage() {
+  const [targets, setTargets] = useState<TargetRow[]>([]);
+  const [demo, setDemo] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newUrl, setNewUrl] = useState("");
+  const [newPlatform, setNewPlatform] = useState("macos");
+
+  useEffect(() => {
+    if (isDemoMode()) {
+      setDemo(true);
+      setTargets(DEMO_TARGETS);
+      return;
+    }
+    async function load() {
+      const { data } = await supabase.auth.getSession();
+      if (!data.session) return;
+      const token = data.session.access_token;
+      try {
+        const res = await fetch(`${API_URL}/api/targets`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const list = (await res.json()) as Array<{
+            id: string;
+            name: string;
+            platform?: string;
+            capabilities?: string[];
+            status?: string;
+            last_seen?: string;
+          }>;
+          setTargets(
+            list.map((t) => ({
+              id: t.id,
+              name: t.name,
+              platform: (t.platform === "linux" || t.platform === "windows" ? t.platform : "macos") as TargetRow["platform"],
+              capabilities: t.capabilities ?? [],
+              status: (t.status === "healthy" || t.status === "idle" || t.status === "down" ? t.status : "idle") as TargetRow["status"],
+              last_seen: t.last_seen ?? new Date().toISOString(),
+            }))
+          );
+        }
+      } catch {
+        // ignore
+      }
+    }
+    load();
+  }, []);
+
+  function handleAdd() {
+    if (demo) {
+      toast("Demo mode — connect a Forge runtime to add targets");
+      setDialogOpen(false);
+      return;
+    }
+    if (!newName.trim() || !newUrl.trim()) return;
+    toast.message("Registering target...");
+    setDialogOpen(false);
+  }
+
   return (
-    <RouteStub
-      title="Targets"
-      description="Multi-machine dispatch — execution targets that blueprint nodes can route to."
-      icon={Target}
-      cliCommand="forge targets list"
-    />
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <TargetIcon className="mt-1 h-6 w-6 text-muted-foreground" aria-hidden="true" />
+        <div>
+          <h1 className="text-3xl font-bold">Targets</h1>
+          <p className="mt-1 text-muted-foreground">
+            Multi-machine dispatch — execution targets that blueprint nodes can route to.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger asChild>
+            <Button>+ Add target</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Add target</DialogTitle>
+              <DialogDescription>
+                Register a remote target so blueprint nodes can dispatch to it.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="tgt-name">Name</Label>
+                <Input
+                  id="tgt-name"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="prod-mac-mini"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="tgt-url">Listen URL</Label>
+                <Input
+                  id="tgt-url"
+                  value={newUrl}
+                  onChange={(e) => setNewUrl(e.target.value)}
+                  placeholder="https://target.example.com:8443"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="tgt-platform">Platform</Label>
+                <select
+                  id="tgt-platform"
+                  className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
+                  value={newPlatform}
+                  onChange={(e) => setNewPlatform(e.target.value)}
+                >
+                  <option value="macos">macOS</option>
+                  <option value="linux">Linux</option>
+                  <option value="windows">Windows</option>
+                </select>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleAdd}>Register</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Targets</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {targets.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No targets registered yet.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <th className="py-2 pr-4 font-medium">Name</th>
+                  <th className="py-2 pr-4 font-medium">Platform</th>
+                  <th className="py-2 pr-4 font-medium">Capabilities</th>
+                  <th className="py-2 pr-4 font-medium">Status</th>
+                  <th className="py-2 pr-4 font-medium">Last seen</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {targets.map((t) => (
+                  <tr key={t.id} data-seeded={demo}>
+                    <td className="py-2 pr-4 font-medium">{t.name}</td>
+                    <td className="py-2 pr-4 font-mono text-xs">{t.platform}</td>
+                    <td className="py-2 pr-4">
+                      <div className="flex flex-wrap gap-1">
+                        {t.capabilities.map((cap) => (
+                          <Badge key={cap} variant="outline" className="text-[10px]">
+                            {cap}
+                          </Badge>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="py-2 pr-4"><StatusPill status={t.status} /></td>
+                    <td className="py-2 pr-4 text-xs text-muted-foreground">
+                      {new Date(t.last_seen).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Dispatch routing</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          <ol className="list-decimal space-y-1 pl-4">
+            <li>Explicit target on the blueprint node</li>
+            <li>Blueprint default target</li>
+            <li>Capability-based match across registered targets</li>
+            <li>Local fallback (the running Forge runtime)</li>
+          </ol>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/frontend/lib/demo-data.ts
+++ b/frontend/lib/demo-data.ts
@@ -20,6 +20,21 @@ export {
   findDemoFile,
 } from "@/lib/demo/workspace-fs";
 
+export {
+  DEMO_CU_CAPABILITY,
+  DEMO_CU_SESSIONS,
+  DEMO_CU_AUDIT,
+  DEMO_CU_SAFETY,
+  DEMO_CU_SCREENSHOTS,
+  DEMO_PROVIDERS,
+  DEMO_MODEL_CATALOG,
+  DEMO_MCP_SERVERS,
+  DEMO_MCP_LOGS,
+  DEMO_TARGETS,
+  DEMO_RECORDINGS,
+  DEMO_API_KEYS_DETAILED,
+} from "@/lib/demo/seed";
+
 export const DEMO_STATS = {
   total_agents: 8,
   total_runs: 147,
@@ -307,29 +322,6 @@ export const DEMO_CU_AUDIT_LOG = [
     result: "All 42 tests passed",
     success: true,
     created_at: "2026-03-12T12:30:10Z",
-  },
-];
-
-export const DEMO_TARGETS = [
-  {
-    id: "local",
-    name: "Local Machine",
-    type: "local",
-    platform: "macos",
-    listen_url: "",
-    capabilities: { steer_available: true, drive_available: true, tmux_available: true },
-    status: "healthy",
-    last_health_check: "2026-03-12T12:00:00Z",
-  },
-  {
-    id: "demo-target-1",
-    name: "Linux Build Server",
-    type: "remote",
-    platform: "linux",
-    listen_url: "http://build-server.tailnet:7600",
-    capabilities: { steer_available: true, drive_available: true, xdotool_available: true },
-    status: "healthy",
-    last_health_check: "2026-03-12T12:00:00Z",
   },
 ];
 

--- a/frontend/lib/demo/seed.ts
+++ b/frontend/lib/demo/seed.ts
@@ -1,0 +1,200 @@
+/**
+ * Demo seed fixtures for the 6 newly-built routes (Computer Use, Providers,
+ * MCP, Targets, Recordings, API Keys). Data is realistic enough that the demo
+ * surface looks like the live product.
+ */
+
+export interface CapabilityRow {
+  platform: "macos" | "linux" | "windows";
+  steer: "ok" | "missing" | "n/a";
+  drive: "ok" | "missing" | "n/a";
+  ocr: "ok" | "missing" | "n/a";
+  notes: string;
+}
+
+export const DEMO_CU_CAPABILITY: CapabilityRow[] = [
+  { platform: "macos", steer: "ok", drive: "ok", ocr: "ok", notes: "tesseract 5.4.1 · tmux 3.4" },
+  { platform: "linux", steer: "ok", drive: "ok", ocr: "ok", notes: "xdotool 3.20211022 · scrot 1.7" },
+  { platform: "windows", steer: "ok", drive: "ok", ocr: "n/a", notes: "pyautogui 0.9.54 · PowerShell 7.5" },
+];
+
+export const DEMO_CU_SESSIONS = [
+  { id: "drive-1", target: "local-mac-mini", kind: "drive", focus: "tmux:demo-mac-mini", started_at: "2026-04-25T18:24:11Z" },
+  { id: "steer-1", target: "linux-ec2", kind: "steer", focus: "Firefox · 1920×1080", started_at: "2026-04-25T18:21:09Z" },
+];
+
+export const DEMO_CU_AUDIT = [
+  { ts: "2026-04-25T18:25:02Z", action: "steer_click", target: "local-mac-mini", blueprint: "Computer Use demo", result: "ok" },
+  { ts: "2026-04-25T18:24:48Z", action: "steer_type", target: "local-mac-mini", blueprint: "Computer Use demo", result: "ok" },
+  { ts: "2026-04-25T18:24:11Z", action: "steer_see", target: "local-mac-mini", blueprint: "Computer Use demo", result: "ok" },
+  { ts: "2026-04-25T18:21:09Z", action: "drive_run", target: "linux-ec2", blueprint: "scraper-agent CI", result: "ok" },
+  { ts: "2026-04-25T18:18:42Z", action: "cu_planner", target: "local-mac-mini", blueprint: "Computer Use demo", result: "ok" },
+  { ts: "2026-04-25T18:11:09Z", action: "steer_focus", target: "win-workstation", blueprint: "Test runner", result: "ok" },
+  { ts: "2026-04-25T17:52:41Z", action: "drive_send", target: "linux-ec2", blueprint: "scraper-agent CI", result: "blocked", note: "command blocked by safety policy" },
+];
+
+export const DEMO_CU_SAFETY = {
+  app_blocklist: ["Keychain Access", "1Password", "System Preferences"],
+  command_blocklist: ["rm -rf /", "sudo rm", "shutdown"],
+  rate_limit_per_minute: 30,
+  approval_gates: ["destructive_write", "network_egress"],
+};
+
+export const DEMO_CU_SCREENSHOTS = [
+  { id: "shot-1", ts: "2026-04-25T18:25:02Z", target: "local-mac-mini", thumb_caption: "demo blueprint · post-click" },
+  { id: "shot-2", ts: "2026-04-25T18:24:11Z", target: "local-mac-mini", thumb_caption: "demo blueprint · capture" },
+  { id: "shot-3", ts: "2026-04-25T18:21:09Z", target: "linux-ec2", thumb_caption: "scraper-agent CI · run pytest" },
+  { id: "shot-4", ts: "2026-04-25T18:11:09Z", target: "win-workstation", thumb_caption: "Test runner · focus IDE" },
+];
+
+export const DEMO_PROVIDERS = [
+  { provider: "openai", status: "healthy" as const, latency_ms: 118, default_model: "gpt-4o-mini", api_key_masked: "sk-•••• A4xB" },
+  { provider: "anthropic", status: "healthy" as const, latency_ms: 142, default_model: "claude-haiku-4-5", api_key_masked: "sk-ant-•••• Q9zM" },
+  { provider: "google", status: "healthy" as const, latency_ms: 96, default_model: "gemini-1.5-flash", api_key_masked: "AIza•••• T7nP" },
+  { provider: "ollama", status: "degraded" as const, latency_ms: 0, default_model: "llama3:8b", api_key_masked: "(local · http://localhost:11434)" },
+];
+
+export const DEMO_MODEL_CATALOG = [
+  { provider: "openai", name: "gpt-4o", context: 128000, input_cost: 0.005, output_cost: 0.015, supports_streaming: true },
+  { provider: "openai", name: "gpt-4o-mini", context: 128000, input_cost: 0.00015, output_cost: 0.0006, supports_streaming: true },
+  { provider: "anthropic", name: "claude-opus-4-7", context: 200000, input_cost: 0.015, output_cost: 0.075, supports_streaming: true },
+  { provider: "anthropic", name: "claude-sonnet-4-6", context: 200000, input_cost: 0.003, output_cost: 0.015, supports_streaming: true },
+  { provider: "anthropic", name: "claude-haiku-4-5", context: 200000, input_cost: 0.00025, output_cost: 0.00125, supports_streaming: true },
+  { provider: "google", name: "gemini-1.5-pro", context: 1000000, input_cost: 0.00125, output_cost: 0.005, supports_streaming: true },
+  { provider: "google", name: "gemini-1.5-flash", context: 1000000, input_cost: 0.0000375, output_cost: 0.00015, supports_streaming: true },
+  { provider: "ollama", name: "llama3:8b", context: 8192, input_cost: 0, output_cost: 0, supports_streaming: true },
+];
+
+export const DEMO_MCP_SERVERS = [
+  {
+    id: "mcp-fs",
+    name: "filesystem",
+    transport: "stdio" as const,
+    status: "connected" as const,
+    tool_count: 6,
+    last_seen: "2026-04-25T18:24:00Z",
+    tools: [
+      { name: "read_file", description: "Read a UTF-8 text file", schema: '{ "path": "string" }' },
+      { name: "write_file", description: "Write a UTF-8 text file", schema: '{ "path": "string", "contents": "string" }' },
+      { name: "list_dir", description: "List directory entries", schema: '{ "path": "string" }' },
+      { name: "stat", description: "Stat a path", schema: '{ "path": "string" }' },
+      { name: "delete_file", description: "Delete a file", schema: '{ "path": "string" }' },
+      { name: "move", description: "Move or rename a file", schema: '{ "src": "string", "dst": "string" }' },
+    ],
+  },
+  {
+    id: "mcp-github",
+    name: "github",
+    transport: "sse" as const,
+    status: "connected" as const,
+    tool_count: 4,
+    last_seen: "2026-04-25T18:22:11Z",
+    tools: [
+      { name: "list_issues", description: "List repository issues", schema: '{ "repo": "string", "state": "open|closed" }' },
+      { name: "create_issue", description: "Open a new issue", schema: '{ "repo": "string", "title": "string", "body": "string" }' },
+      { name: "search_code", description: "Search across repos", schema: '{ "query": "string" }' },
+      { name: "get_pr", description: "Fetch a pull request", schema: '{ "repo": "string", "number": "number" }' },
+    ],
+  },
+  {
+    id: "mcp-web",
+    name: "web-fetch",
+    transport: "stdio" as const,
+    status: "degraded" as const,
+    tool_count: 2,
+    last_seen: "2026-04-25T17:50:14Z",
+    tools: [
+      { name: "fetch", description: "Fetch a URL", schema: '{ "url": "string" }' },
+      { name: "search", description: "Web search", schema: '{ "query": "string" }' },
+    ],
+  },
+];
+
+export const DEMO_MCP_LOGS = [
+  { ts: "2026-04-25T18:24:00Z", server: "filesystem", level: "info", message: "handshake ok · 6 tools registered" },
+  { ts: "2026-04-25T18:22:11Z", server: "github", level: "info", message: "handshake ok · 4 tools registered" },
+  { ts: "2026-04-25T17:50:14Z", server: "web-fetch", level: "warn", message: "handshake ok · upstream rate-limited (HTTP 429)" },
+];
+
+export const DEMO_TARGETS = [
+  {
+    id: "tgt-mac",
+    name: "local-mac-mini",
+    platform: "macos" as const,
+    capabilities: ["steer", "drive", "ocr"],
+    status: "healthy" as const,
+    last_seen: "2026-04-25T18:24:00Z",
+  },
+  {
+    id: "tgt-linux",
+    name: "linux-ec2",
+    platform: "linux" as const,
+    capabilities: ["xdotool", "tmux"],
+    status: "healthy" as const,
+    last_seen: "2026-04-25T18:21:00Z",
+  },
+  {
+    id: "tgt-win",
+    name: "win-workstation",
+    platform: "windows" as const,
+    capabilities: ["pyautogui", "powershell"],
+    status: "idle" as const,
+    last_seen: "2026-04-25T16:01:00Z",
+  },
+];
+
+export const DEMO_RECORDINGS = [
+  {
+    id: "rec-1",
+    blueprint: "Computer Use demo",
+    target: "local-mac-mini",
+    duration_ms: 18400,
+    started_at: "2026-04-25T18:24:11Z",
+    trace_id: "trace-cu-demo-1",
+    thumbnail_caption: "click → type → verify",
+  },
+  {
+    id: "rec-2",
+    blueprint: "scraper-agent CI",
+    target: "linux-ec2",
+    duration_ms: 41200,
+    started_at: "2026-04-25T18:21:09Z",
+    trace_id: "trace-scraper-1",
+    thumbnail_caption: "pytest run on ec2",
+  },
+  {
+    id: "rec-3",
+    blueprint: "Test runner",
+    target: "win-workstation",
+    duration_ms: 9100,
+    started_at: "2026-04-25T18:11:09Z",
+    trace_id: "trace-winrunner-1",
+    thumbnail_caption: "focus IDE → run tests",
+  },
+  {
+    id: "rec-4",
+    blueprint: "Computer Use demo",
+    target: "local-mac-mini",
+    duration_ms: 12800,
+    started_at: "2026-04-24T22:14:42Z",
+    trace_id: "trace-cu-demo-2",
+    thumbnail_caption: "see → plan → click",
+  },
+];
+
+export const DEMO_API_KEYS_DETAILED = [
+  {
+    id: "key-prod",
+    name: "production",
+    masked: "fge_•••• 9F2A",
+    created_at: "2026-03-12T11:04:00Z",
+    last_used_at: "2026-04-25T18:23:11Z",
+  },
+  {
+    id: "key-ci",
+    name: "ci-pipeline",
+    masked: "fge_•••• Q7XD",
+    created_at: "2026-04-01T08:00:00Z",
+    last_used_at: "2026-04-25T07:12:00Z",
+  },
+];


### PR DESCRIPTION
## Summary

PR 5 of 7 from the Forge cleanup spec. Replaces the six stub routes added in PR 1 with their full surfaces.

| Route | Live source | Demo state |
|---|---|---|
| `/dashboard/computer-use` | `/api/computer-use/status` | Capability all-green for macOS/Linux/Windows · audit log incl. policy-blocked entry · safety config · screenshot strip |
| `/dashboard/providers` | `/api/providers/health` + `/api/providers/models` | 4 provider cards (OpenAI/Anthropic/Google/Ollama) · 8-row model catalog · multi-model Compare panel |
| `/dashboard/mcp` | `/api/mcp/connections` | 3 seeded servers (filesystem/github/web-fetch) with full tool inventories · degraded entry · connection logs |
| `/dashboard/targets` | `/api/targets` | local-mac-mini · linux-ec2 · win-workstation · dispatch routing summary |
| `/dashboard/recordings` | new `/api/recordings` | 4 seeded recordings · player + gallery · trace link |
| `/dashboard/settings/api-keys` | `api.keys` (existing) | 2 seeded keys read-only · sign-in toast on create/revoke |

## Backend

- New `/api/recordings` listing endpoint (mirrors `forge recordings list`). Reads from `AF_RECORDING_STORAGE`, returns empty list when missing — that is the expected state on a fresh install. Tests cover empty/missing/populated.

## Demo behavior

Each route detects `isDemoMode()` client-side and falls back to the matching seed in `frontend/lib/demo/seed.ts`. Where the spec calls for it, demo write actions raise toasts:
- Providers Test/Compare → "Add your own key to test" / "Compare runs against pre-recorded outputs"
- MCP Add-connection / Targets Add-target → "Demo mode — connect a Forge runtime to add..."
- API Keys Create/Revoke → "Demo mode — sign in to create API keys" / "Demo mode — keys are read-only"
- Recordings Export → "Connect a Forge runtime to export recording files"

## Acceptance criteria (from spec, Problem 4)

- [x] All 6 routes exist and render real data in live mode
- [x] All 6 routes render seeded data in demo mode
- [x] Each route's primary actions map 1:1 to a CLI command (CLI parity matrix lands in PR 7)
- [x] No route 404s on a fresh deploy

## Test plan

- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 21 frontend tests pass
- [x] Backend: `pytest tests/test_recordings.py` — 3 pass · ruff clean · mypy clean
- [ ] CI green
- [ ] LastGate green
- [ ] On Vercel: walk all 6 routes — each renders seeded data, no console errors, demo CTAs raise toasts