### PR TITLE
chore(audit): document sibling overlap decisions

### DIFF
--- a/docs/sibling-audit.md
+++ b/docs/sibling-audit.md
@@ -1,0 +1,50 @@
+# Sibling overlap audit
+
+This file records decisions about pairs of dashboard surfaces that are
+adjacent in the IA but cover overlapping ground. Each decision is checked
+into the repo so future contributors can read the reasoning rather than
+re-litigate it.
+
+## Runs vs Traces
+
+- **Runs (`/dashboard/runs`)** lists executions — one row per run.
+- **Traces (`/dashboard/traces`)** is the deep view of a single execution.
+
+A pure-IA argument says Traces should be `/dashboard/runs/[id]/trace` since
+a trace belongs to a run. We chose to keep them as siblings for now to
+preserve parity with `forge traces` in the CLI. To soften the overlap, the
+Recent Runs / Run History rows now link directly to
+`/dashboard/traces/<run id>`. If the CLI command ever drops, fold the
+trace view under `/dashboard/runs/[id]/trace` and remove the sibling.
+
+## Evals vs Compare
+
+- **Evals (`/dashboard/evals`)** runs test cases against expected outputs.
+- **Compare (`/dashboard/compare`)** runs a single prompt across multiple
+  models and shows side-by-side outputs.
+
+These are different problems. Evals answers "did my agent stay correct
+after I changed it?" Compare answers "which model should I run this on?"
+We keep both as siblings under Observe and do not rename. A lightweight
+Compare panel also lives on `/dashboard/providers` for fast multi-model
+spot checks; the dedicated Compare page is the place for the full studio
+(system prompt, temperature, max tokens, full results history).
+
+## Prompts vs Marketplace
+
+- **Prompts (`/dashboard/prompts`)** is the user's private prompt-version
+  history.
+- **Marketplace (`/dashboard/marketplace`)** is the public/shared catalog.
+
+These do not overlap in browse UI. Prompts has no public catalog of its
+own; Marketplace is where publishing happens. We keep them as separate
+top-level entries. Future work: add a "Publish to Marketplace" CTA on
+the Prompts version detail view, routing to the Marketplace publish flow.
+That is a separate change, not part of the IA cleanup.
+
+## Knowledge vs Marketplace
+
+Same shape as Prompts vs Marketplace. Knowledge is private knowledge bases
+the user owns; Marketplace is where shared knowledge bases would be
+published. We keep them as separate top-level entries. The Marketplace
+publish flow is also future work.

--- a/frontend/components/dashboard/RunHistory.tsx
+++ b/frontend/components/dashboard/RunHistory.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { api, Run } from "@/lib/api";
@@ -63,17 +64,25 @@ export function RunHistory({ limit }: { limit?: number } = {}) {
               {run.tokens_used} tokens
             </p>
           </div>
-          <Badge
-            variant={
-              run.status === "completed"
-                ? "default"
-                : run.status === "failed"
-                  ? "destructive"
-                  : "secondary"
-            }
-          >
-            {run.status}
-          </Badge>
+          <div className="flex items-center gap-3">
+            <Badge
+              variant={
+                run.status === "completed"
+                  ? "default"
+                  : run.status === "failed"
+                    ? "destructive"
+                    : "secondary"
+              }
+            >
+              {run.status}
+            </Badge>
+            <Link
+              href={`/dashboard/traces/${run.id}`}
+              className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+            >
+              Trace →
+            </Link>
+          </div>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary

PR 6 of 7 from the Forge cleanup spec. Records the IA decisions for the four sibling pairs called out in Problem 6 of the spec.

### Decisions

| Pair | Decision |
|---|---|
| **Runs vs Traces** | Keep as siblings for CLI parity (`forge traces`). Add a `Trace →` deep link to each Run row so the relationship is visible. |
| **Evals vs Compare** | Different problems (correctness vs model selection). Keep both. The lightweight compare panel on `/dashboard/providers` is for quick model spot-checks; `/dashboard/compare` stays the full studio. |
| **Prompts vs Marketplace** | No browse-UI overlap. Keep separate. Publish flow is future work. |
| **Knowledge vs Marketplace** | Same shape as Prompts. Keep separate. |

Long-form rationale lives at `docs/sibling-audit.md` so future contributors can read the reasoning rather than re-litigate it.

### Code change

- `RunHistory.tsx`: each row now includes a `Trace →` link to `/dashboard/traces/<run id>`. No other code changed; the goal of this PR is documentation.

## Test plan

- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 21 pass
- [ ] CI green
- [ ] LastGate green