### PR TITLE
fix(workspace): silence stale react-hooks warning in CodeEditor

### DIFF
--- a/frontend/components/workspace/CodeEditor.tsx
+++ b/frontend/components/workspace/CodeEditor.tsx
@@ -83,7 +83,11 @@ export function CodeEditor({ content, filename, onChange, onSave }: CodeEditorPr
       state,
       parent: containerRef.current,
     });
-  }, [filename]); // Re-create when file changes
+    // setupEditor reads `content` only as the editor's initial doc; live updates
+    // are handled by the separate effect below, so we deliberately re-create only
+    // when the filename changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filename]);
 
   useEffect(() => {
     setupEditor();


### PR DESCRIPTION
Adds a targeted eslint-disable for the deliberate setupEditor dep
list. The callback re-runs only when the filename changes — live
content updates flow through the separate effect below.

Frontend lint output is now fully clean (was a long-standing
single-warning state).