### PR TITLE
chore(ci): install bun in Deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.x"
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
       - name: Pull Vercel project settings


### PR DESCRIPTION
vercel build picks bun from bun.lock and spawns it; the runner does
not have bun pre-installed, which broke the previous Deploy run with
`Error: spawn bun ENOENT`. Adds the same setup-bun step the CI
workflow already uses.