### PR TITLE
chore(deps): bump python-multipart from 0.0.20 to 0.0.26

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,7 @@ langchain==0.3.14
 langchain-openai==0.3.0
 openai==1.58.1
 python-dotenv==1.2.2
-python-multipart==0.0.20
+python-multipart==0.0.26
 pydantic==2.10.4
 httpx==0.28.1
 PyPDF2==3.0.1


### PR DESCRIPTION
Resolves Dependabot alerts #2 (high — arbitrary file write) and #10 (medium — DoS via large multipart preamble). Replaces conflicting Dependabot PR #39.