### PR TITLE
chore(deps): bump pytest to 9.0.3 with pytest-asyncio 1.3.0

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-pytest==8.3.4
-pytest-asyncio==0.25.0
-pytest-cov==6.0.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
+pytest-cov==7.0.0
 ruff==0.8.6
 mypy==1.14.1


### PR DESCRIPTION
Resolves Dependabot alert #9. The Dependabot PR (#38) failed CI because pytest-asyncio 0.25 caps pytest <9; this PR co-bumps pytest-asyncio to 1.3.0 (first line with pytest 9 support) and pytest-cov to 7.0.0.