### PR TITLE
chore(deps): migrate from PyPDF2 to pypdf

### DIFF
--- a/backend/app/services/tools/document_reader.py
+++ b/backend/app/services/tools/document_reader.py
@@ -3,7 +3,7 @@ import io
 import httpx
 from docx import Document
 from langchain.tools import tool
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 
 
 @tool

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ python-dotenv==1.2.2
 python-multipart==0.0.26
 pydantic==2.10.4
 httpx==0.28.1
-PyPDF2==3.0.1
+pypdf==5.5.0
 python-docx==1.1.2
 slowapi==0.1.9
 anthropic==0.52.0


### PR DESCRIPTION
Resolves Dependabot alert #1.

PyPDF2 has been EOL since 2022. The upstream project renamed to `pypdf` and the API is identical for what Forge uses (`PdfReader`, `page.extract_text`). Migration is one import line + the requirements pin.

Verified locally: 523 backend tests pass, 0 fail.