### PR TITLE
chore(deps): bump pypdf to 6.10.2

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ python-dotenv==1.2.2
 python-multipart==0.0.26
 pydantic==2.10.4
 httpx==0.28.1
-pypdf==5.5.0
+pypdf==6.10.2
 python-docx==1.1.2
 slowapi==0.1.9
 anthropic==0.52.0


### PR DESCRIPTION
Resolves 22 newly-detected pypdf advisories (RAM exhaustion in stream decoders, infinite loops in malformed structures, long-runtime parsing). 6.10.2 is above the patched-version marker for all of them.

Backend tests pass against 6.10.2 with no source changes — the `PdfReader` API is identical across the 5.x → 6.x line.