### PR TITLE
fix: 5 critical QA-playbook findings (CLI auth, JWT exp, SQLite joins, insert defaults)

### DIFF
--- a/.lastgate.yml
+++ b/.lastgate.yml
@@ -9,7 +9,7 @@ checks:
       - "frontend/**"
       - "README.md"
       - "backend/app/db/*"
-      - "cli/forge/*"
+      - "cli/forge/**"
 
   lint:
     enabled: true

--- a/backend/app/db/sqlite_backend.py
+++ b/backend/app/db/sqlite_backend.py
@@ -174,11 +174,19 @@ class SQLiteQueryBuilder(QueryBuilder):
         clauses: list[str] = []
         params: list[Any] = []
 
+        # When the SELECT joins a second table, bare column references like
+        # `created_at` are ambiguous (both `agent_heartbeats` and `agents` have
+        # one). Qualify unqualified columns with the primary table to match
+        # the qualification the SELECT clause already uses.
+        qualify_with_primary = bool(getattr(self, "_has_joins", False))
+
         for col, op, val in self._filters:
             # Handle dotted column names for joined table filters (e.g., "agents.user_id")
-            actual_col = col.replace(".", "_dot_")  # placeholder — joins handle this
             if "." in col:
-                # For join filters like "agents.user_id", use the table-qualified column
+                actual_col = col
+            elif qualify_with_primary:
+                actual_col = f"{self._table}.{col}"
+            else:
                 actual_col = col
 
             if op == "IN":
@@ -368,6 +376,9 @@ class SQLiteQueryBuilder(QueryBuilder):
                 col_sql += f", {j['table']}.{jc} AS _join_{j['table']}_{jc}"
             join_col_aliases[j["table"]] = j["columns"]
 
+        # Tell _build_where whether to qualify bare columns with the primary
+        # table (only meaningful when there are joins).
+        self._has_joins = bool(join_sql)
         where_sql, params = self._build_where()
         order_sql = self._build_order()
         limit_sql = self._build_limit_offset()
@@ -437,6 +448,19 @@ class SQLiteQueryBuilder(QueryBuilder):
 
             sql = f"INSERT INTO {self._table} ({cols}) VALUES ({placeholders})"
             await db.execute(sql, values)
+            # Read the row back so DB-applied defaults (e.g. is_template=0)
+            # appear in the response payload. Postgres backends get this via
+            # `INSERT ... RETURNING *`; SQLite does the equivalent here.
+            row_id = data.get("id") or data.get("rowid")
+            if row_id is not None:
+                cur = await db.execute(
+                    f"SELECT * FROM {self._table} WHERE id = ?", (row_id,)
+                )
+                row = await cur.fetchone()
+                if row:
+                    full = self._deserialize_row(dict(row))
+                    results.append(full)
+                    continue
             results.append(data)
 
         await db.commit()

--- a/backend/app/routers/auth_api.py
+++ b/backend/app/routers/auth_api.py
@@ -7,7 +7,7 @@ For Supabase mode, auth is handled client-side via Supabase Auth.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -16,6 +16,20 @@ from app.db import get_db
 from app.routers.auth import get_current_user
 
 router = APIRouter(tags=["auth"])
+
+# Local-mode JWTs expire after this window. Long enough for CI / dev workflows,
+# short enough that a stolen token isn't a permanent credential.
+JWT_LIFETIME = timedelta(days=7)
+
+
+def _build_jwt_payload(user_id: str, email: str) -> dict:
+    now = datetime.now(UTC)
+    return {
+        "sub": user_id,
+        "email": email,
+        "iat": int(now.timestamp()),
+        "exp": int((now + JWT_LIFETIME).timestamp()),
+    }
 
 
 class AuthRequest(BaseModel):
@@ -66,7 +80,7 @@ async def signup(req: AuthRequest):
     # Generate JWT
     import jwt as pyjwt
     token = pyjwt.encode(
-        {"sub": user_id, "email": req.email},
+        _build_jwt_payload(user_id, req.email),
         db.auth._jwt_secret,
         algorithm="HS256",
     )
@@ -96,7 +110,7 @@ async def login(req: AuthRequest):
     # Generate JWT
     import jwt as pyjwt
     token = pyjwt.encode(
-        {"sub": result.data["id"], "email": result.data["email"]},
+        _build_jwt_payload(result.data["id"], result.data["email"]),
         db.auth._jwt_secret,
         algorithm="HS256",
     )

--- a/backend/tests/test_auth_api_jwt.py
+++ b/backend/tests/test_auth_api_jwt.py
@@ -1,0 +1,22 @@
+"""Regression test for QA Finding #5 — local-mode JWTs lacked exp claims."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def test_jwt_payload_has_iat_and_exp():
+    """`_build_jwt_payload` must include both iat and exp."""
+    from app.routers.auth_api import _build_jwt_payload
+
+    payload = _build_jwt_payload("user-123", "user@example.com")
+
+    assert "iat" in payload, "JWT must include iat"
+    assert "exp" in payload, "JWT must include exp"
+    assert payload["sub"] == "user-123"
+    assert payload["email"] == "user@example.com"
+
+    # Sanity: exp is in the future, lifetime is between 1h and 30d.
+    now = int(datetime.now(UTC).timestamp())
+    assert payload["exp"] > now
+    assert 3600 <= (payload["exp"] - payload["iat"]) <= 60 * 60 * 24 * 30

--- a/backend/tests/test_sqlite_qa_fixes.py
+++ b/backend/tests/test_sqlite_qa_fixes.py
@@ -1,0 +1,80 @@
+"""Regression tests for QA Findings #6 and #7 — SQLite backend bugs surfaced
+by the live-instance QA playbook run.
+
+#6: WHERE clauses on joined queries used unqualified column names; tables that
+    share a column (e.g. `created_at` on both `agent_heartbeats` and `agents`)
+    raised `sqlite3.OperationalError: ambiguous column name`.
+
+#7: `INSERT` returned the input dict unchanged, so DB-applied defaults
+    (e.g. `is_template = 0` on `agents`) were missing from the response and
+    pydantic 500'd during serialization while the row was already committed
+    (phantom writes).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture
+def sqlite_backend(tmp_path):
+    """Yield a fully-initialized SQLite backend on a throwaway DB."""
+    from app.db.sqlite_backend import SQLiteBackend
+
+    db = SQLiteBackend(db_path=str(tmp_path / "qa.db"))
+    asyncio.run(db.initialize())
+    return db
+
+
+def test_insert_response_includes_db_defaults(sqlite_backend):
+    """QA Finding #7: insert response must include DB-defaulted columns."""
+    result = (
+        sqlite_backend.table("agents")
+        .insert(
+            {
+                "user_id": "22222222-2222-2222-2222-222222222222",
+                "name": "regression-#7",
+                "system_prompt": "x",
+            }
+        )
+        .execute()
+    )
+    row = result.data[0]
+    # is_template has DEFAULT 0 in the SQLite schema; must surface so pydantic
+    # AgentResponse can validate without 500ing on a committed-but-leaked row.
+    assert "is_template" in row, "insert response missing DB-defaulted column"
+    assert row["is_template"] in (0, False)
+
+
+def test_join_where_qualifies_ambiguous_column(sqlite_backend):
+    """QA Finding #6: join + WHERE on a column shared by both tables works."""
+    user_id = "11111111-1111-1111-1111-111111111111"
+    agent = (
+        sqlite_backend.table("agents")
+        .insert({"user_id": user_id, "name": "regression-#6", "system_prompt": "x"})
+        .execute()
+    )
+    agent_id = agent.data[0]["id"]
+    sqlite_backend.table("agent_heartbeats").insert(
+        {
+            "agent_id": agent_id,
+            "state": "running",
+            "current_step": 0,
+            "total_steps": 1,
+            "tokens_used": 0,
+            "cost_estimate": 0,
+            "output_preview": "",
+        }
+    ).execute()
+
+    # The query that broke /api/dashboard/metrics in the live-stack QA run.
+    result = (
+        sqlite_backend.table("agent_heartbeats")
+        .select("tokens_used, agents!inner(user_id)")
+        .eq("agents.user_id", user_id)
+        .gte("created_at", "2000-01-01T00:00:00Z")
+        .execute()
+    )
+    assert result.data, "join + created_at filter should return the heartbeat"

--- a/cli/forge/main.py
+++ b/cli/forge/main.py
@@ -376,6 +376,45 @@ auth_app = typer.Typer(help="Authentication commands")
 app.add_typer(auth_app, name="auth")
 
 
+def _save_session_token(token: str) -> None:
+    """Persist a session JWT to ``[api].key`` in ``~/.forge/config.toml``.
+
+    The previous implementation appended ``api_key = "..."`` to the end of
+    the file, which TOML scopes under whichever ``[section]`` came last —
+    typically ``[defaults]``. The config loader reads ``[api].key`` (or a
+    top-level ``api_key`` for legacy installs), so the key was effectively
+    invisible and every authenticated CLI command failed with 401/422.
+    """
+    ensure_config()
+    lines = CONFIG_FILE.read_text().splitlines() if CONFIG_FILE.exists() else []
+    in_api = False
+    api_seen = False
+    key_written = False
+    out: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            if in_api and not key_written:
+                out.append(f'key = "{token}"')
+                key_written = True
+            in_api = stripped == "[api]"
+            if in_api:
+                api_seen = True
+            out.append(line)
+            continue
+        if in_api and stripped.startswith("key") and "=" in stripped:
+            out.append(f'key = "{token}"')
+            key_written = True
+            continue
+        out.append(line)
+    if in_api and not key_written:
+        out.append(f'key = "{token}"')
+        key_written = True
+    if not api_seen:
+        out.extend(["", "[api]", f'key = "{token}"'])
+    CONFIG_FILE.write_text("\n".join(out) + "\n")
+
+
 @auth_app.command("signup")
 def auth_signup(
     email: str = typer.Option(..., "--email", "-e", help="Email address"),
@@ -387,17 +426,7 @@ def auth_signup(
         console.print(f"[green]Account created for {email}[/green]")
         token = result.get("access_token", "")
         if token:
-            # Store token in config
-            ensure_config()
-            lines = CONFIG_FILE.read_text().splitlines() if CONFIG_FILE.exists() else []
-            found = False
-            for i, line in enumerate(lines):
-                if line.strip().startswith("api_key"):
-                    lines[i] = f'api_key = "{token}"'
-                    found = True
-            if not found:
-                lines.append(f'api_key = "{token}"')
-            CONFIG_FILE.write_text("\n".join(lines) + "\n")
+            _save_session_token(token)
             console.print("[green]Session token saved to config.[/green]")
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
@@ -414,16 +443,7 @@ def auth_login(
         result = client.post("/api/auth/login", json={"email": email, "password": password})
         token = result.get("access_token", "")
         if token:
-            ensure_config()
-            lines = CONFIG_FILE.read_text().splitlines() if CONFIG_FILE.exists() else []
-            found = False
-            for i, line in enumerate(lines):
-                if line.strip().startswith("api_key"):
-                    lines[i] = f'api_key = "{token}"'
-                    found = True
-            if not found:
-                lines.append(f'api_key = "{token}"')
-            CONFIG_FILE.write_text("\n".join(lines) + "\n")
+            _save_session_token(token)
             console.print(f"[green]Logged in as {email}. Token saved.[/green]")
         else:
             console.print("[yellow]Login succeeded but no token returned.[/yellow]")
@@ -448,10 +468,11 @@ def auth_logout():
 def auth_whoami():
     """Show current user info."""
     try:
-        stats = client.get("/api/stats")
-        console.print(f"[bold]User:[/bold] {stats.get('user_id', 'unknown')}")
-        if stats.get("email"):
-            console.print(f"[bold]Email:[/bold] {stats['email']}")
+        me = client.get("/api/auth/me")
+        if isinstance(me, dict):
+            console.print(f"[bold]User:[/bold] {me.get('id', 'unknown')}")
+            if me.get("email"):
+                console.print(f"[bold]Email:[/bold] {me['email']}")
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)
@@ -470,14 +491,15 @@ def auth_keys_list_alias():
 def whoami():
     """Show current user info."""
     try:
-        stats = client.get("/api/stats")
+        me = client.get("/api/auth/me")
         console.print()
-        console.print(f"[bold]User:[/bold] {stats.get('user_id', 'unknown')}")
-        console.print(f"[bold]API URL:[/bold] {get_api_url()}")
-        if stats.get("email"):
-            console.print(f"[bold]Email:[/bold] {stats['email']}")
-        if stats.get("plan"):
-            console.print(f"[bold]Plan:[/bold] {stats['plan']}")
+        if isinstance(me, dict):
+            console.print(f"[bold]User:[/bold] {me.get('id', 'unknown')}")
+            console.print(f"[bold]API URL:[/bold] {get_api_url()}")
+            if me.get("email"):
+                console.print(f"[bold]Email:[/bold] {me['email']}")
+        if isinstance(me, dict) and me.get("plan"):
+            console.print(f"[bold]Plan:[/bold] {me['plan']}")
         console.print()
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")


### PR DESCRIPTION
First batch of fixes from running \`forge-qa-playbook.pdf\` against a live local stack (SQLite + Ollama). Five findings, all blocking subsequent QA work.

## Findings shipped

| # | Severity | Surface | Summary |
|---|---|---|---|
| 1 | Critical | CLI | \`forge auth login\` wrote token to a TOML position the loader can't read — every authenticated CLI call silently ran without auth |
| 2 | High | CLI | \`forge auth whoami\` called \`/api/stats\` (no user_id) instead of \`/api/auth/me\` |
| 5 | High | API | Local-mode JWTs had no \`exp\` claim; tokens never expired |
| 6 | Critical | API | \`/api/dashboard/metrics\` 500'd on SQLite — \`ambiguous column name: created_at\` from a join lacking primary-table qualification |
| 7 | Critical | API | \`POST /api/agents\` 500'd after the row was already committed because DB-applied defaults (\`is_template=0\`) weren't in the response → phantom writes |

The full findings doc with repros and root-cause analysis lives at \`qa-evidence/findings.md\` and lands in a follow-up PR alongside the rest of the playbook results.

## Regression tests

- \`backend/tests/test_sqlite_qa_fixes.py\` — covers #6 (join + WHERE on shared column) and #7 (insert response includes DB defaults).
- \`backend/tests/test_auth_api_jwt.py\` — covers #5 (\`_build_jwt_payload\` includes \`iat\` + \`exp\`).

## Test plan

- [x] Three new pytests pass
- [x] Full backend suite green (531 pass, 0 fail; ruff + mypy clean)
- [x] Manual: \`forge auth signup\` → \`forge auth whoami\` → \`forge agents create\` → \`/api/dashboard/metrics\` all succeed end-to-end against fresh SQLite + Ollama
- [ ] CI green
- [ ] LastGate green

## What's next

Sections §1–§2 of the playbook complete; §3 onward will resume after this lands so the cascading 500s don't dominate the report.