### PR TITLE
fix: agent run end-to-end on SQLite + bigger Ollama model unblocks LLM sections

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -91,14 +91,16 @@ async def stream_dashboard_updates(
         raise HTTPException(status_code=401, detail="Token required")
     try:
         user_response = get_db().auth.get_user(token)
-        if not user_response or not user_response.user:
+        # Supabase wraps in `.user`; SQLite returns the user object directly.
+        user = user_response.user if hasattr(user_response, "user") else user_response
+        if not user or not getattr(user, "id", None):
             raise HTTPException(status_code=401, detail="Invalid token")
     except HTTPException:
         raise
     except Exception as exc:
         raise HTTPException(status_code=401, detail="Invalid or expired token") from exc
 
-    user_id = user_response.user.id
+    user_id = user.id
 
     async def event_generator():
         while True:

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -42,12 +42,15 @@ async def run_agent(
     token: str = Query(...),
     input_text: str = Query(""),
 ):
-    # Verify token
+    # Verify token. The auth backend returns either a Supabase-style wrapper
+    # (`.user`) or the user object directly (SQLite local auth) — handle both.
     try:
         user_response = get_db().auth.get_user(token)
-        if not user_response or not user_response.user:
+        user = user_response.user if hasattr(user_response, "user") else user_response
+        if not user or not getattr(user, "id", None):
             raise HTTPException(status_code=401, detail="Invalid token")
-        user = user_response.user
+    except HTTPException:
+        raise
     except Exception as exc:
         raise HTTPException(status_code=401, detail="Invalid or expired token") from exc
 

--- a/backend/tests/test_query_token_auth_dual_mode.py
+++ b/backend/tests/test_query_token_auth_dual_mode.py
@@ -1,0 +1,50 @@
+"""Regression test for the agent-run / dashboard-stream auth pattern.
+
+Both endpoints accept the JWT in a query parameter (so the EventSource
+handshake can carry it) and call `db.auth.get_user(token)` directly. Supabase
+returns a wrapper with `.user`; the SQLite local-auth backend returns the
+user object directly. The hand-written shim in each endpoint must accept
+both shapes — it didn't, so /api/agents/<id>/run and the SSE stream both
+401'd on every SQLite stack until the QA playbook flagged it.
+"""
+
+from __future__ import annotations
+
+
+class _FakeSupabaseUser:
+    def __init__(self, id: str) -> None:
+        self.id = id
+        self.email = "user@example.com"
+
+
+class _FakeSupabaseResponse:
+    """Mimics supabase-py: response.user.id."""
+    def __init__(self, id: str) -> None:
+        self.user = _FakeSupabaseUser(id)
+
+
+class _FakeSqliteUser:
+    """Mimics SQLiteAuthBackend.get_user(token) which returns the user directly."""
+    def __init__(self, id: str) -> None:
+        self.id = id
+        self.email = "user@example.com"
+
+
+def _resolve_user(user_response):
+    """Replicates the shim used in routers/runs.py and routers/dashboard.py."""
+    user = user_response.user if hasattr(user_response, "user") else user_response
+    if not user or not getattr(user, "id", None):
+        raise AssertionError("invalid token shape")
+    return user
+
+
+def test_supabase_response_shape():
+    response = _FakeSupabaseResponse("user-1")
+    user = _resolve_user(response)
+    assert user.id == "user-1"
+
+
+def test_sqlite_response_shape():
+    response = _FakeSqliteUser("user-2")
+    user = _resolve_user(response)
+    assert user.id == "user-2"

--- a/cli/forge/main.py
+++ b/cli/forge/main.py
@@ -814,10 +814,13 @@ def agents_run(
     console.print(f"[bold]Running agent {agent_id[:8]}...[/bold]")
 
     try:
-        for data_str in client.stream_sse(
-            f"/api/agents/{agent_id}/run",
-            params={"token": get_api_key(), "input_text": input_text},
-        ):
+        # The /api/agents/<id>/run endpoint is a POST that takes the token
+        # and input_text as query parameters. Using stream_sse (GET) returned
+        # 405 Method Not Allowed, so the CLI run flow never produced any
+        # output. Build the query string and use stream_sse_post.
+        from urllib.parse import urlencode
+        qs = urlencode({"token": get_api_key(), "input_text": input_text})
+        for data_str in client.stream_sse_post(f"/api/agents/{agent_id}/run?{qs}"):
             try:
                 event = json.loads(data_str)
                 event_type = event.get("type", "")


### PR DESCRIPTION
Two more critical bugs discovered while running the QA playbook with a larger LLM (qwen2.5:7b-instruct, ~4.7GB) and the macOS bootstrap completed.

## Findings shipped

| # | Severity | What |
|---|---|---|
| 24 | Critical | `POST /api/agents/{id}/run` and `GET /api/dashboard/stream` dereferenced `user_response.user.id` directly. Works on Supabase but the SQLite local-auth backend returns the user object itself, so every authenticated request 401'd on local stacks. Same dual-shape shim that `get_current_user` already uses now applies here too. |
| 25 | Critical | `forge agents run` called `stream_sse` (GET) against the run endpoint, which is registered as POST. Every CLI agent run hit 405 Method Not Allowed before any work happened. |

Together these meant **no agent could ever execute via the CLI on SQLite** even though the agent and run rows were happily created. After fix: end-to-end run with qwen2.5:7b-instruct returned the expected output in 19s on a Mac Mini.

## Regression test

`backend/tests/test_query_token_auth_dual_mode.py` — covers both Supabase and SQLite user-response shapes through the same shim.

## Test plan

- [x] Backend: 531 pass · ruff clean · mypy clean
- [x] Manual: `forge agents run <id> --input 'say hello'` returns "hello" with a run id
- [ ] CI green
- [ ] LastGate green

## What this unblocks

The bigger model (qwen2.5:7b-instruct) supports tool calling reliably enough for §2.2-2.4, §3, §6.2-6.4, §7.2-7.3, §13, §14 of the QA playbook to run. Pairs with the recent macOS bootstrap completion (steer/drive daemons live, accessibility + screen-recording permissions in place) to unblock §10 too.