### PR TITLE
fix(sqlite): qualify ORDER BY column on joined queries

### DIFF
--- a/backend/app/db/sqlite_backend.py
+++ b/backend/app/db/sqlite_backend.py
@@ -277,7 +277,15 @@ class SQLiteQueryBuilder(QueryBuilder):
     def _build_order(self) -> str:
         if not self._order_by:
             return ""
-        parts = [f"{col} {'DESC' if desc else 'ASC'}" for col, desc in self._order_by]
+        # Qualify bare column names with the primary table when a join is in
+        # play; otherwise SQLite raises "ambiguous column name" on tables that
+        # share a column (e.g. created_at on both token_usage and agents).
+        qualify_with_primary = bool(getattr(self, "_has_joins", False))
+        parts: list[str] = []
+        for col, desc in self._order_by:
+            if "." not in col and qualify_with_primary:
+                col = f"{self._table}.{col}"
+            parts.append(f"{col} {'DESC' if desc else 'ASC'}")
         return " ORDER BY " + ", ".join(parts)
 
     def _build_limit_offset(self) -> str:

--- a/backend/tests/test_sqlite_qa_fixes.py
+++ b/backend/tests/test_sqlite_qa_fixes.py
@@ -78,3 +78,25 @@ def test_join_where_qualifies_ambiguous_column(sqlite_backend):
         .execute()
     )
     assert result.data, "join + created_at filter should return the heartbeat"
+
+
+def test_order_by_qualifies_ambiguous_column(sqlite_backend):
+    """QA Finding #28: ORDER BY on a column shared with a joined table must
+    not raise 'ambiguous column name'. The breakdown query in
+    token_tracker.get_breakdown joins agents in the SELECT and orders by
+    `created_at` — both tables have one, so the bare reference broke
+    /api/costs/all on SQLite the same way the WHERE clause did."""
+    user_id = "33333333-3333-3333-3333-333333333333"
+    sqlite_backend.table("agents").insert(
+        {"user_id": user_id, "name": "regression-#28", "system_prompt": "x"}
+    ).execute()
+
+    # Mirrors token_tracker.get_breakdown: select with a join + ORDER BY created_at.
+    result = (
+        sqlite_backend.table("token_usage")
+        .select("agent_id, model, provider, input_tokens, output_tokens, cost_usd, agents(name)")
+        .eq("user_id", user_id)
+        .order("created_at", desc=True)
+        .execute()
+    )
+    assert result.data == []  # no token_usage rows yet — important: should not raise


### PR DESCRIPTION
Follow-up to PR #59. The same ambiguous-column problem hits the ORDER BY clause when a SELECT includes a join. `/api/costs/all` 500'd on every Mac Mini local stack because `token_tracker.get_breakdown` orders by `created_at` while joining `agents`.

Also adds a third regression test in `test_sqlite_qa_fixes.py` covering the ORDER BY path.

Caught while running the QA playbook against the live stack with a larger Ollama model. Two more critical bugs surfaced in that pass — written up in the next findings PR; this one ships only the breaks-things fix.