### PR TITLE
fix(agent): record per-step token usage so cost aggregates work

### DIFF
--- a/backend/app/services/agent_executor.py
+++ b/backend/app/services/agent_executor.py
@@ -160,6 +160,27 @@ class AgentRunner:
                 except Exception:
                     logger.warning("Failed to record trace span", exc_info=True)
 
+                # Record per-step token usage so /api/costs/* aggregates can
+                # see this run. Without this, cost-by-{agent,model,provider}
+                # breakdowns return zero on every Ollama-only stack (the
+                # blueprint engine writes here but the agent executor didn't
+                # — surfaced by QA Findings #27 and #29).
+                try:
+                    from app.services.token_tracker import token_tracker
+
+                    token_tracker.record(
+                        run_id=run_id,
+                        agent_id=agent_id,
+                        user_id=user_id,
+                        step_number=i,
+                        model=result.get("model") or model or "unknown",
+                        provider=result.get("provider") or "unknown",
+                        input_tokens=result.get("input_tokens", 0),
+                        output_tokens=result.get("output_tokens", 0),
+                    )
+                except Exception:
+                    logger.warning("Failed to record token usage", exc_info=True)
+
             if heartbeat_id:
                 heartbeat_service.update(
                     heartbeat_id,


### PR DESCRIPTION
QA Findings #27 and #29.

The blueprint engine wrote to `token_usage` after each LLM call (so `/api/costs/*` aggregated correctly) but the agent executor didn't. `/api/costs/summary` and `forge costs --period today` returned zero on every stack that ran agents instead of blueprints — i.e. most local-only QA setups, even though `runs.tokens_used` was correct.

Wires `token_tracker.record(...)` into the per-step loop right next to the existing trace-span recording.

## Verified live

- Created agent + ran with qwen2.5:7b-instruct
- `/api/costs/summary?period=today` now reports the run's tokens (34 input / 2 output / 1 request) with provider=ollama

Note: cost calculation is $0.00004 instead of $0 because Ollama returns the model id without the `ollama/` prefix that `calculate_cost` checks; tracked as a separate medium finding for the cost calculation side.