### PR TITLE
fix(agent): guard token_tracker.record on non-None ids

### DIFF
--- a/backend/app/services/agent_executor.py
+++ b/backend/app/services/agent_executor.py
@@ -165,21 +165,22 @@ class AgentRunner:
                 # breakdowns return zero on every Ollama-only stack (the
                 # blueprint engine writes here but the agent executor didn't
                 # — surfaced by QA Findings #27 and #29).
-                try:
-                    from app.services.token_tracker import token_tracker
+                if run_id and agent_id:
+                    try:
+                        from app.services.token_tracker import token_tracker
 
-                    token_tracker.record(
-                        run_id=run_id,
-                        agent_id=agent_id,
-                        user_id=user_id,
-                        step_number=i,
-                        model=result.get("model") or model or "unknown",
-                        provider=result.get("provider") or "unknown",
-                        input_tokens=result.get("input_tokens", 0),
-                        output_tokens=result.get("output_tokens", 0),
-                    )
-                except Exception:
-                    logger.warning("Failed to record token usage", exc_info=True)
+                        token_tracker.record(
+                            run_id=run_id,
+                            agent_id=agent_id,
+                            user_id=user_id,
+                            step_number=i,
+                            model=result.get("model") or model or "unknown",
+                            provider=result.get("provider") or "unknown",
+                            input_tokens=result.get("input_tokens", 0),
+                            output_tokens=result.get("output_tokens", 0),
+                        )
+                    except Exception:
+                        logger.warning("Failed to record token usage", exc_info=True)
 
             if heartbeat_id:
                 heartbeat_service.update(


### PR DESCRIPTION
Follow-up to PR #67. CI mypy flagged the new `token_tracker.record(...)` call because `run_id`/`agent_id` are typed `str | None` upstream. Wraps the record call in a presence check; runtime behavior unchanged (it's best-effort either way).