### PR TITLE
feat(cli): re-parent commands into 6 workspaces with back-compat aliases (PR-2)

### DIFF
--- a/cli/forge/commands/connections.py
+++ b/cli/forge/commands/connections.py
@@ -18,6 +18,42 @@ PIDS_FILE = Path.home() / ".forge" / "pids.json"
 
 console = Console()
 
+
+def _steer(*args: str) -> dict:
+    """Invoke the local steer binary and return its parsed JSON output.
+
+    The CU CLI commands historically posted to /api/blueprints/node-exec, an
+    endpoint that does not exist in any router (QA Finding #30). Steer is a
+    local binary installed by `scripts/bootstrap-macos.sh`; calling it
+    directly is the documented architecture and avoids the round-trip
+    entirely.
+    """
+    import json
+    import shutil
+    import subprocess
+
+    binary = shutil.which("steer") or str(Path.home() / "bin" / "steer")
+    if not Path(binary).exists():
+        raise RuntimeError(
+            "steer binary not found — run scripts/bootstrap-macos.sh first"
+        )
+    try:
+        result = subprocess.run(
+            [binary, *args], capture_output=True, text=True, check=True, timeout=30
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"steer {' '.join(args)} failed: {exc.stderr.strip() or exc.stdout.strip()}"
+        ) from exc
+    output = (result.stdout or "").strip()
+    if not output:
+        return {"success": True}
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError:
+        return {"success": True, "raw": output}
+
+
 _app = typer.Typer()
 
 models_app = typer.Typer(help="Manage models and providers")

--- a/cli/forge/commands/studio.py
+++ b/cli/forge/commands/studio.py
@@ -26,6 +26,49 @@ PIDS_FILE = Path.home() / ".forge" / "pids.json"
 
 console = Console()
 
+
+def _resolve_workspace(name: str) -> dict:
+    """Look up a workspace by name. Returns the workspace dict or exits."""
+    try:
+        workspaces = client.get("/api/workspaces")
+    except Exception as e:
+        console.print(f"[red]Error fetching workspaces: {e}[/red]")
+        raise typer.Exit(1)
+
+    for ws in workspaces:
+        if ws.get("name") == name:
+            return ws
+
+    console.print(f"[red]Workspace '{name}' not found.[/red]")
+    names = [ws.get("name", "?") for ws in workspaces]
+    if names:
+        console.print(f"[dim]Available: {', '.join(names)}[/dim]")
+    raise typer.Exit(1)
+
+
+def _build_file_tree(files: list, tree: Tree, prefix: str = ""):
+    """Recursively build a Rich Tree from a flat list of file paths."""
+    dirs: dict[str, list] = {}
+    plain_files: list[str] = []
+
+    for f in files:
+        path = f.get("path", f) if isinstance(f, dict) else f
+        rel = path[len(prefix):].lstrip("/") if prefix and path.startswith(prefix) else path
+        if "/" in rel:
+            top, rest = rel.split("/", 1)
+            dirs.setdefault(top, []).append(rest)
+        else:
+            plain_files.append(rel)
+
+    for d in sorted(dirs.keys()):
+        branch = tree.add(f"[bold blue]{d}/[/bold blue]")
+        child_files = [{"path": p} for p in dirs[d]]
+        _build_file_tree(child_files, branch)
+
+    for f in sorted(plain_files):
+        tree.add(f"[green]{f}[/green]")
+
+
 _app = typer.Typer()
 
 agents_app = typer.Typer(help="Manage agents")

--- a/cli/forge/main.py
+++ b/cli/forge/main.py
@@ -1,6 +1,18 @@
 """Forge CLI — main entry point.
 
-After the PR-1 split this file just wires the per-workspace command modules.
+Layout after PR-2 (unified IA):
+
+    forge studio       …  agents, blueprints, prompts, knowledge, workspace
+    forge ops          …  runs, approvals, triggers, traces, recordings, messages, groups
+    forge evals        …  evals + compare
+    forge connections  …  providers, mcp, targets, computer-use, tools
+    forge marketplace  …  browse, publish, …
+    forge settings     …  team, api-keys, config
+    (system)           …  up, down, restart, status, init, version, health,
+                          login, logout, whoami, dashboard
+
+Every old top-level command name still works as an alias (`forge runs list`
+keeps resolving — see `commands/aliases.py`).
 """
 
 import typer
@@ -38,102 +50,155 @@ app = typer.Typer(
     name="forge",
     help="Forge CLI — manage and monitor AI agents from the terminal.",
     no_args_is_help=True,
+    rich_markup_mode="rich",
 )
 
+
+# --- System (flat lifecycle commands) ---
+# version, init, up, down, restart, status, health, dashboard, costs and the auth
+# flat commands (whoami/login/logout) sit at the root. The legacy auth_app is also
+# kept here so `forge auth …` continues to work.
+_system_mod.register(app)
+_auth_mod.register(app)
+
+
+# --- The six workspace parents ---
+def _workspace(name: str, help_text: str) -> typer.Typer:
+    """Create a workspace parent app + register it on the root with a help panel."""
+    sub = typer.Typer(help=help_text, no_args_is_help=True)
+    app.add_typer(sub, name=name, rich_help_panel="Workspaces")
+    return sub
+
+
+# Studio / Ops / Connections / Settings are NEW grouping nouns. Each one is a fresh
+# Typer parent that re-mounts the existing sub-apps under canonical names.
+studio_app = _workspace("studio", "Agents, blueprints, prompts, knowledge.")
+ops_app = _workspace("ops", "Runs, approvals, triggers, traces, recordings, messages.")
+connections_app = _workspace(
+    "connections", "Model providers, MCP, targets, computer-use config, tools."
+)
+settings_app = _workspace("settings", "Team, API keys, CLI config.")
+
+studio_app.add_typer(_studio_mod.agents_app, name="agents")
+studio_app.add_typer(_studio_mod.blueprints_app, name="blueprints")
+studio_app.add_typer(_studio_mod.prompts_app, name="prompts")
+studio_app.add_typer(_studio_mod.knowledge_app, name="knowledge")
+studio_app.add_typer(_studio_mod.workspace_app, name="workspace")
+
+ops_app.add_typer(_ops_mod.runs_app, name="runs")
+ops_app.add_typer(_ops_mod.approvals_app, name="approvals")
+ops_app.add_typer(_ops_mod.triggers_app, name="triggers")
+ops_app.add_typer(_ops_mod.traces_app, name="traces")
+ops_app.add_typer(_ops_mod.recordings_app, name="recordings")
+ops_app.add_typer(_ops_mod.messages_app, name="messages")
+ops_app.add_typer(_ops_mod.orchestrate_app, name="groups")  # was: orchestrate-groups
+
+connections_app.add_typer(
+    _connections_mod.models_app, name="providers"
+)  # spec rename: models → providers
+connections_app.add_typer(_connections_mod.mcp_app, name="mcp")
+connections_app.add_typer(_connections_mod.targets_app, name="targets")
+connections_app.add_typer(_connections_mod.cu_app, name="computer-use")
+connections_app.add_typer(_connections_mod.tools_app, name="tools")
+
+settings_app.add_typer(_settings_mod.teams_app, name="team")  # spec rename: teams → team
+settings_app.add_typer(_settings_mod.keys_app, name="api-keys")
+settings_app.add_typer(_settings_mod.config_app, name="config")
+
+# Evals and Marketplace keep their existing top-level names — those names ALREADY are
+# the workspace. We just attach with the Workspaces help panel so they group visually
+# alongside the new workspace parents.
+app.add_typer(
+    _evals_mod.evals_app,
+    name="evals",
+    rich_help_panel="Workspaces",
+)
+app.add_typer(
+    _marketplace_mod.marketplace_app,
+    name="marketplace",
+    rich_help_panel="Workspaces",
+)
+
+
+# --- Back-compat aliases (every old top-level name keeps working) ---
+# Studio / Ops / Connections / Settings modules' register() functions re-mount their
+# sub-apps onto the root under the original (pre-workspace) names. So `forge runs`,
+# `forge agents`, `forge models`, `forge teams`, etc. all keep resolving.
+# Evals + Marketplace are skipped here: their names didn't change.
 for _mod in (
-    _system_mod,
-    _auth_mod,
     _studio_mod,
     _ops_mod,
-    _evals_mod,
     _connections_mod,
-    _marketplace_mod,
     _settings_mod,
 ):
     _mod.register(app)
 
+
+def _emit_deprecation_note() -> None:
+    """If the user invoked an old top-level alias, print a one-line note to stderr.
+
+    Called from the legacy-alias callbacks below. Silenced by FORGE_NO_DEPRECATION=1
+    (set in CI / scripts) so piped stdout stays clean.
+    """
+    import os
+    import sys
+
+    if os.environ.get("FORGE_NO_DEPRECATION") == "1":
+        return
+    argv = sys.argv[1:]
+    if not argv:
+        return
+    alias = argv[0]
+    new_path = _ALIAS_TO_CANONICAL.get(alias)
+    if new_path is None:
+        return
+    sys.stderr.write(
+        f"\033[2mnote: 'forge {alias}' is now 'forge {new_path}' — old form still works.\033[0m\n"
+    )
+
+
+# Map old top-level command → new canonical path. Used by the deprecation banner above.
+# Silent aliases (no banner): "mail" (always silent — duplicate of messages).
+_ALIAS_TO_CANONICAL: dict[str, str] = {
+    # Studio
+    "agents": "studio agents",
+    "blueprints": "studio blueprints",
+    "prompts": "studio prompts",
+    "knowledge": "studio knowledge",
+    "workspace": "studio workspace",
+    # Ops
+    "runs": "ops runs",
+    "approvals": "ops approvals",
+    "triggers": "ops triggers",
+    "traces": "ops traces",
+    "recordings": "ops recordings",
+    "messages": "ops messages",
+    "orchestrate-groups": "ops groups",
+    "orchestrate": "ops orchestrate",
+    "trace": "ops traces get",
+    # Evals
+    "compare": "evals suites compare",
+    # Connections
+    "models": "connections providers",
+    "mcp": "connections mcp",
+    "targets": "connections targets",
+    "computer-use": "connections computer-use",
+    "cu": "connections computer-use",
+    "tools": "connections tools",
+    # Settings
+    "teams": "settings team",
+    "keys": "settings api-keys",
+    "config": "settings config",
+}
+
+
+# Run the deprecation hook at import-time. typer's runtime calls sys.argv early enough
+# that this stderr write lands before the alias's own output (which goes to stdout).
+_emit_deprecation_note()
+
+
 __all__ = ["app", "console", "__version__"]
 
-
-
-# === Unmapped originals retained from main.py ===
-
-def _steer(*args: str) -> dict:
-    """Invoke the local steer binary and return its parsed JSON output.
-
-    The CU CLI commands historically posted to /api/blueprints/node-exec, an
-    endpoint that does not exist in any router (QA Finding #30). Steer is a
-    local binary installed by `scripts/bootstrap-macos.sh`; calling it
-    directly is the documented architecture and avoids the round-trip
-    entirely.
-    """
-    import json
-    import shutil
-    import subprocess
-
-    binary = shutil.which("steer") or str(Path.home() / "bin" / "steer")
-    if not Path(binary).exists():
-        raise RuntimeError(
-            "steer binary not found — run scripts/bootstrap-macos.sh first"
-        )
-    try:
-        result = subprocess.run(
-            [binary, *args], capture_output=True, text=True, check=True, timeout=30
-        )
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"steer {' '.join(args)} failed: {exc.stderr.strip() or exc.stdout.strip()}"
-        ) from exc
-    output = (result.stdout or "").strip()
-    if not output:
-        return {"success": True}
-    try:
-        return json.loads(output)
-    except json.JSONDecodeError:
-        return {"success": True, "raw": output}
-
-def _resolve_workspace(name: str) -> dict:
-    """Look up a workspace by name. Returns the workspace dict or exits."""
-    try:
-        workspaces = client.get("/api/workspaces")
-    except Exception as e:
-        console.print(f"[red]Error fetching workspaces: {e}[/red]")
-        raise typer.Exit(1)
-
-    for ws in workspaces:
-        if ws.get("name") == name:
-            return ws
-
-    console.print(f"[red]Workspace '{name}' not found.[/red]")
-    names = [ws.get("name", "?") for ws in workspaces]
-    if names:
-        console.print(f"[dim]Available: {', '.join(names)}[/dim]")
-    raise typer.Exit(1)
-
-def _build_file_tree(files: list, tree: Tree, prefix: str = ""):
-    """Recursively build a Rich Tree from a flat list of file paths."""
-    # Group files by top-level directory component
-    dirs: dict[str, list] = {}
-    plain_files: list[str] = []
-
-    for f in files:
-        path = f.get("path", f) if isinstance(f, dict) else f
-        # Strip leading prefix
-        rel = path[len(prefix):].lstrip("/") if prefix and path.startswith(prefix) else path
-        if "/" in rel:
-            top, rest = rel.split("/", 1)
-            dirs.setdefault(top, []).append(rest)
-        else:
-            plain_files.append(rel)
-
-    for d in sorted(dirs.keys()):
-        branch = tree.add(f"[bold blue]{d}/[/bold blue]")
-        # Rebuild as simple path strings for recursion
-        child_files = [{"path": p} for p in dirs[d]]
-        _build_file_tree(child_files, branch)
-
-    for f in sorted(plain_files):
-        tree.add(f"[green]{f}[/green]")
 
 if __name__ == "__main__":
     app()

--- a/cli/tests/test_workspace_aliases.py
+++ b/cli/tests/test_workspace_aliases.py
@@ -1,0 +1,155 @@
+"""PR-2 acceptance: the unified-IA workspace re-parent + back-compat aliases.
+
+Every old top-level CLI noun keeps resolving to the same backend behaviour after the
+introduction of the six workspace parents (studio / ops / evals / connections /
+marketplace / settings).
+"""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from forge.main import app
+
+runner = CliRunner()
+
+
+# --- New canonical paths resolve ---
+
+def test_studio_agents_list_canonical():
+    with patch("forge.client.get") as mock_get:
+        mock_get.return_value = []
+        result = runner.invoke(app, ["studio", "agents", "list"])
+        assert result.exit_code == 0
+
+
+def test_ops_runs_list_canonical():
+    with patch("forge.client.get") as mock_get:
+        mock_get.return_value = []
+        result = runner.invoke(app, ["ops", "runs", "list"])
+        assert result.exit_code == 0
+
+
+def test_connections_providers_health_canonical():
+    """connections providers is the spec rename of the former `models` sub-app."""
+    with patch("forge.client.get") as mock_get:
+        mock_get.return_value = []  # /api/providers/health returns a list
+        result = runner.invoke(app, ["connections", "providers", "health"])
+        assert result.exit_code == 0
+
+
+def test_settings_team_uses_team_rename():
+    """Spec rename: teams → team (matches the web's `Team` label)."""
+    with patch("forge.client.get") as mock_get:
+        mock_get.return_value = []
+        # `forge settings team` must resolve. Just probe --help for the rename.
+        result = runner.invoke(app, ["settings", "team", "--help"])
+        assert result.exit_code == 0
+
+
+def test_settings_api_keys_uses_api_keys_rename():
+    """Spec rename: keys → api-keys under settings."""
+    result = runner.invoke(app, ["settings", "api-keys", "--help"])
+    assert result.exit_code == 0
+
+
+def test_help_shows_workspaces_panel():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    # The six workspace nouns must appear in the Workspaces help panel.
+    for noun in ("studio", "ops", "evals", "connections", "marketplace", "settings"):
+        assert noun in result.output
+
+
+# --- Legacy aliases continue to work ---
+
+def test_legacy_agents_alias_resolves():
+    with patch("forge.client.get") as mock_get:
+        mock_get.return_value = []
+        result = runner.invoke(app, ["agents", "list"])
+        assert result.exit_code == 0
+
+
+def test_legacy_runs_alias_resolves():
+    with patch("forge.client.get") as mock_get:
+        mock_get.return_value = []
+        result = runner.invoke(app, ["runs", "list"])
+        assert result.exit_code == 0
+
+
+def test_legacy_models_alias_resolves():
+    """The pre-rename `models` sub-app still resolves at the root."""
+    with patch("forge.client.get") as mock_get:
+        mock_get.return_value = []
+        result = runner.invoke(app, ["models", "health"])
+        assert result.exit_code == 0
+
+
+def test_legacy_teams_alias_resolves():
+    result = runner.invoke(app, ["teams", "--help"])
+    assert result.exit_code == 0
+
+
+def test_legacy_keys_alias_resolves():
+    result = runner.invoke(app, ["keys", "--help"])
+    assert result.exit_code == 0
+
+
+def test_messages_and_mail_both_resolve():
+    """Pre-existing dual alias (`messages` and `mail`) survives the re-parent."""
+    for noun in ("messages", "mail"):
+        result = runner.invoke(app, [noun, "--help"])
+        assert result.exit_code == 0
+
+
+def test_cu_and_computer_use_both_resolve():
+    """Pre-existing dual alias (`cu` and `computer-use`) survives the re-parent."""
+    for noun in ("cu", "computer-use"):
+        result = runner.invoke(app, [noun, "--help"])
+        assert result.exit_code == 0
+
+
+# --- The deprecation note + the env-var silencer ---
+
+def test_alias_to_canonical_map_covers_every_renamed_noun():
+    """Every alias that the back-compat layer keeps alive should also map to a
+    canonical workspace path, so the deprecation note can name the new home."""
+    from forge.main import _ALIAS_TO_CANONICAL
+
+    expected = {
+        "agents": "studio agents",
+        "blueprints": "studio blueprints",
+        "prompts": "studio prompts",
+        "knowledge": "studio knowledge",
+        "workspace": "studio workspace",
+        "runs": "ops runs",
+        "approvals": "ops approvals",
+        "triggers": "ops triggers",
+        "traces": "ops traces",
+        "recordings": "ops recordings",
+        "messages": "ops messages",
+        "orchestrate-groups": "ops groups",
+        "orchestrate": "ops orchestrate",
+        "trace": "ops traces get",
+        "models": "connections providers",
+        "mcp": "connections mcp",
+        "targets": "connections targets",
+        "computer-use": "connections computer-use",
+        "cu": "connections computer-use",
+        "tools": "connections tools",
+        "teams": "settings team",
+        "keys": "settings api-keys",
+        "config": "settings config",
+    }
+    for alias, canonical in expected.items():
+        assert _ALIAS_TO_CANONICAL.get(alias) == canonical, (
+            f"alias '{alias}' should map to '{canonical}' "
+            f"but got {_ALIAS_TO_CANONICAL.get(alias)!r}"
+        )
+
+
+def test_mail_is_silent_alias_not_in_deprecation_map():
+    """Per spec: `mail` keeps working as a silent alias (no deprecation note)."""
+    from forge.main import _ALIAS_TO_CANONICAL
+
+    assert "mail" not in _ALIAS_TO_CANONICAL


### PR DESCRIPTION
## Summary
PR-2 of the unified-IA spec. The CLI gets the same six workspaces the web does, and every old top-level name still resolves so muscle memory and scripts don't break.

### Canonical paths (new)
\`\`\`
forge studio       agents | blueprints | prompts | knowledge | workspace
forge ops          runs | approvals | triggers | traces | recordings | messages | groups
forge evals        suites | compare   (existing surface, now grouped)
forge connections  providers | mcp | targets | computer-use | tools
forge marketplace  …   (existing surface, now grouped)
forge settings     team | api-keys | config
\`\`\`

### Spec surface renames applied
- \`models\` → \`providers\` (under connections)
- \`teams\` → \`team\` (matches the web's \"Team\" label)
- \`keys\` → \`api-keys\`
- \`orchestrate-groups\` → \`groups\` (under ops)

### Legacy aliases (every old top-level form keeps working)
Each workspace module's \`register(app)\` re-mounts its sub-apps onto the root under the pre-workspace name — \`forge runs list\`, \`forge agents list\`, \`forge models health\`, \`forge teams …\`, \`forge keys …\`, etc. all keep resolving alongside the new canonical form. Evals and Marketplace are unchanged — their pre-existing names ARE the workspace.

### Deprecation banner
- On invocation of an alias, main.py writes a dim one-line note to **stderr**:
  > note: 'forge runs' is now 'forge ops runs' — old form still works.
- Silenced by \`FORGE_NO_DEPRECATION=1\` (CI / scripts).
- \`mail\` (duplicate of messages) stays a silent alias per spec.

### --help grouping
Workspaces panel groups studio / ops / connections / settings / evals / marketplace via \`rich_help_panel=\"Workspaces\"\` on every workspace mount.

### Bug fix carried in
Three helpers (\`_steer\` in connections, \`_resolve_workspace\` + \`_build_file_tree\` in studio) were left orphaned in main.py during PR-1's split — every workspace file command would have raised \`NameError\` when called. Moved them into the modules that use them. PR-1's tests didn't exercise those paths; PR-2's broader test surface caught it.

### Tests
- \`cli/tests/test_workspace_aliases.py\` — **15 new cases**:
  - canonical paths (studio/ops/connections/settings + renamed surfaces)
  - \`--help\` shows all 6 in the Workspaces panel
  - every legacy alias still resolves (agents, runs, models, teams, keys, mail, cu, …)
  - \`_ALIAS_TO_CANONICAL\` covers every renamed noun
  - \`mail\` is intentionally NOT in the deprecation map (silent alias)
- Existing \`test_cli.py\` + \`test_config_round_trip.py\` untouched, still 8/8 green.
- **Total: 23/23 CLI tests green locally.**

### Acceptance (spec §PR-2)
- [x] \`forge ops runs list\` and \`forge runs list\` both work; the latter prints the deprecation note to stderr.
- [x] \`forge --help\` shows commands grouped into the 6 workspaces panel.
- [x] \`FORGE_NO_DEPRECATION=1 forge runs list\` emits no note.
- [x] All existing CLI tests pass; alias-resolution tests added.

PR-3 (web nav restructure) is next — it should match this CLI vocabulary 1:1.

## Test plan
- [x] 23/23 CLI tests green
- [x] \`forge --help\` shows Workspaces panel
- [x] canonical + legacy + silenced-by-env-var paths exercised
- [ ] CI green