### PR TITLE
feat(web): consolidate Library, Evals+Compare, Connections via tabs (PR-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,3 +464,4 @@ Forge/
 ## License
 
 MIT
+

--- a/frontend/app/dashboard/connections/page.tsx
+++ b/frontend/app/dashboard/connections/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { Suspense, useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-import { useCallback } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -10,17 +10,18 @@ import McpPage from "../mcp/page";
 import TargetsPage from "../targets/page";
 import ComputerUsePage from "../computer-use/page";
 
-/**
- * PR-4 Connections — Providers / MCP / Targets / Computer-Use config under one
- * Settings-side workspace home. The Computer-Use *live view* deep link still
- * lives at /dashboard/computer-use; this tab is the config surface for it.
- *
- * Tab persistence: ?tab=providers|mcp|targets|computer-use.
- */
 const TABS = ["providers", "mcp", "targets", "computer-use"] as const;
 type ConnectionsTab = (typeof TABS)[number];
 
 export default function ConnectionsPage() {
+  return (
+    <Suspense fallback={<ConnectionsShell tab="providers" />}>
+      <ConnectionsContent />
+    </Suspense>
+  );
+}
+
+function ConnectionsContent() {
   const params = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
@@ -39,6 +40,18 @@ export default function ConnectionsPage() {
     [pathname, router],
   );
 
+  return <ConnectionsShell tab={tab} onChange={onChange} interactive />;
+}
+
+function ConnectionsShell({
+  tab,
+  onChange,
+  interactive,
+}: {
+  tab: ConnectionsTab;
+  onChange?: (next: string) => void;
+  interactive?: boolean;
+}) {
   return (
     <div className="flex flex-col gap-4">
       <header>
@@ -48,7 +61,7 @@ export default function ConnectionsPage() {
         </p>
       </header>
 
-      <Tabs value={tab} onValueChange={onChange}>
+      <Tabs value={tab} onValueChange={onChange ?? (() => {})}>
         <TabsList>
           <TabsTrigger value="providers">Providers</TabsTrigger>
           <TabsTrigger value="mcp">MCP</TabsTrigger>
@@ -56,18 +69,22 @@ export default function ConnectionsPage() {
           <TabsTrigger value="computer-use">Computer Use</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="providers">
-          <ProvidersPage />
-        </TabsContent>
-        <TabsContent value="mcp">
-          <McpPage />
-        </TabsContent>
-        <TabsContent value="targets">
-          <TargetsPage />
-        </TabsContent>
-        <TabsContent value="computer-use">
-          <ComputerUsePage />
-        </TabsContent>
+        {interactive && (
+          <>
+            <TabsContent value="providers">
+              <ProvidersPage />
+            </TabsContent>
+            <TabsContent value="mcp">
+              <McpPage />
+            </TabsContent>
+            <TabsContent value="targets">
+              <TargetsPage />
+            </TabsContent>
+            <TabsContent value="computer-use">
+              <ComputerUsePage />
+            </TabsContent>
+          </>
+        )}
       </Tabs>
     </div>
   );

--- a/frontend/app/dashboard/connections/page.tsx
+++ b/frontend/app/dashboard/connections/page.tsx
@@ -1,10 +1,74 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useCallback } from "react";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import ProvidersPage from "../providers/page";
+import McpPage from "../mcp/page";
+import TargetsPage from "../targets/page";
+import ComputerUsePage from "../computer-use/page";
 
 /**
- * PR-3 placeholder. PR-4 replaces this with the tabbed Connections page
- * (Providers, MCP, Targets, Computer-Use config). Until then we redirect to
- * the existing Providers route so the sidebar link doesn't 404.
+ * PR-4 Connections — Providers / MCP / Targets / Computer-Use config under one
+ * Settings-side workspace home. The Computer-Use *live view* deep link still
+ * lives at /dashboard/computer-use; this tab is the config surface for it.
+ *
+ * Tab persistence: ?tab=providers|mcp|targets|computer-use.
  */
-export default function ConnectionsRedirect() {
-  redirect("/dashboard/providers");
+const TABS = ["providers", "mcp", "targets", "computer-use"] as const;
+type ConnectionsTab = (typeof TABS)[number];
+
+export default function ConnectionsPage() {
+  const params = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const raw = params?.get("tab") ?? "providers";
+  const tab: ConnectionsTab = (TABS as readonly string[]).includes(raw)
+    ? (raw as ConnectionsTab)
+    : "providers";
+
+  const onChange = useCallback(
+    (next: string) => {
+      const url = new URL(window.location.href);
+      url.searchParams.set("tab", next);
+      router.replace(`${pathname}?${url.searchParams.toString()}`, { scroll: false });
+    },
+    [pathname, router],
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Connections</h1>
+        <p className="text-sm text-muted-foreground">
+          Model providers, MCP servers, execution targets, and Computer-Use configuration.
+        </p>
+      </header>
+
+      <Tabs value={tab} onValueChange={onChange}>
+        <TabsList>
+          <TabsTrigger value="providers">Providers</TabsTrigger>
+          <TabsTrigger value="mcp">MCP</TabsTrigger>
+          <TabsTrigger value="targets">Targets</TabsTrigger>
+          <TabsTrigger value="computer-use">Computer Use</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="providers">
+          <ProvidersPage />
+        </TabsContent>
+        <TabsContent value="mcp">
+          <McpPage />
+        </TabsContent>
+        <TabsContent value="targets">
+          <TargetsPage />
+        </TabsContent>
+        <TabsContent value="computer-use">
+          <ComputerUsePage />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
 }

--- a/frontend/app/dashboard/evals/SuitesView.tsx
+++ b/frontend/app/dashboard/evals/SuitesView.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { api, EvalSuite, EvalRun, Agent, Blueprint } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { isDemoMode, DEMO_EVAL_SUITES } from "@/lib/demo-data";
+
+export function SuitesView() {
+  const [suites, setSuites] = useState<EvalSuite[]>([]);
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [blueprints, setBlueprints] = useState<Blueprint[]>([]);
+  const [runs, setRuns] = useState<Record<string, EvalRun[]>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [showCreate, setShowCreate] = useState(false);
+
+  // Create form
+  const [newName, setNewName] = useState("");
+  const [newDesc, setNewDesc] = useState("");
+  const [newTargetType, setNewTargetType] = useState<"agent" | "blueprint">("agent");
+  const [newTargetId, setNewTargetId] = useState("");
+
+  // Run state
+  const [running, setRunning] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isDemoMode()) {
+      setSuites(DEMO_EVAL_SUITES as unknown as EvalSuite[]);
+      setLoading(false);
+      return;
+    }
+    loadData();
+  }, []);
+
+  async function loadData() {
+    const { data } = await supabase.auth.getSession();
+    if (!data.session) return;
+
+    try {
+      const [suiteList, agentList, bpList] = await Promise.all([
+        api.evals.suites(data.session.access_token),
+        api.agents.list(data.session.access_token),
+        api.blueprints.list(data.session.access_token),
+      ]);
+      setSuites(suiteList);
+      setAgents(agentList);
+      setBlueprints(bpList);
+
+      // Load runs for each suite
+      const runsMap: Record<string, EvalRun[]> = {};
+      for (const suite of suiteList) {
+        try {
+          runsMap[suite.id] = await api.evals.listRuns(suite.id, data.session.access_token);
+        } catch {
+          runsMap[suite.id] = [];
+        }
+      }
+      setRuns(runsMap);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function createSuite() {
+    const { data } = await supabase.auth.getSession();
+    if (!data.session) return;
+
+    try {
+      await api.evals.createSuite(
+        { name: newName, description: newDesc, target_type: newTargetType, target_id: newTargetId },
+        data.session.access_token
+      );
+      setShowCreate(false);
+      setNewName("");
+      setNewDesc("");
+      setNewTargetId("");
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create suite");
+    }
+  }
+
+  async function runSuite(suiteId: string) {
+    const { data } = await supabase.auth.getSession();
+    if (!data.session) return;
+
+    setRunning(suiteId);
+    try {
+      await api.evals.runSuite(suiteId, undefined, data.session.access_token);
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to run suite");
+    } finally {
+      setRunning(null);
+    }
+  }
+
+  async function deleteSuite(suiteId: string) {
+    const { data } = await supabase.auth.getSession();
+    if (!data.session) return;
+
+    try {
+      await api.evals.deleteSuite(suiteId, data.session.access_token);
+      setSuites(suites.filter((s) => s.id !== suiteId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete");
+    }
+  }
+
+  const targetOptions = newTargetType === "agent" ? agents : blueprints;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Evals</h1>
+          <p className="mt-1 text-muted-foreground">
+            Test and evaluate your agents with structured test suites
+          </p>
+        </div>
+        <Button onClick={() => setShowCreate(!showCreate)}>
+          {showCreate ? "Cancel" : "New Suite"}
+        </Button>
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {showCreate && (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Create Eval Suite</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Input placeholder="Suite name" value={newName} onChange={(e) => setNewName(e.target.value)} />
+            <Input placeholder="Description" value={newDesc} onChange={(e) => setNewDesc(e.target.value)} />
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="text-sm font-medium">Target Type</label>
+                <select
+                  className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                  value={newTargetType}
+                  onChange={(e) => { setNewTargetType(e.target.value as typeof newTargetType); setNewTargetId(""); }}
+                >
+                  <option value="agent">Agent</option>
+                  <option value="blueprint">Blueprint</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium">Target</label>
+                <select
+                  className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                  value={newTargetId}
+                  onChange={(e) => setNewTargetId(e.target.value)}
+                >
+                  <option value="">Select...</option>
+                  {targetOptions.map((t) => (
+                    <option key={t.id} value={t.id}>{t.name}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <Button onClick={createSuite} disabled={!newName.trim() || !newTargetId}>
+              Create Suite
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="mt-6 space-y-4">
+        {loading ? (
+          <div className="space-y-3">
+            {[1, 2].map((i) => <div key={i} className="h-24 animate-pulse rounded-lg bg-muted" />)}
+          </div>
+        ) : suites.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No eval suites yet. Create one to start testing your agents.
+          </p>
+        ) : (
+          suites.map((suite) => {
+            const suiteRuns = runs[suite.id] || [];
+            const lastRun = suiteRuns[0];
+            return (
+              <Card key={suite.id} data-seeded="true">
+                <CardContent className="py-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="font-semibold">{suite.name}</h3>
+                      <p className="text-sm text-muted-foreground">{suite.description}</p>
+                      <div className="mt-1 flex items-center gap-2">
+                        <Badge variant="outline">{suite.target_type}</Badge>
+                        <span className="text-xs text-muted-foreground font-mono">
+                          {suite.target_id.slice(0, 8)}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="default"
+                        size="sm"
+                        onClick={() => runSuite(suite.id)}
+                        disabled={running === suite.id}
+                      >
+                        {running === suite.id ? "Running..." : "Run"}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-destructive"
+                        onClick={() => deleteSuite(suite.id)}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                  {lastRun && (
+                    <div className="mt-3 flex items-center gap-4 text-sm">
+                      <span>
+                        Last run: <Badge variant={lastRun.status === "completed" ? "default" : "secondary"}>{lastRun.status}</Badge>
+                      </span>
+                      {lastRun.pass_rate !== null && (
+                        <span className={lastRun.pass_rate >= 0.8 ? "text-green-600" : lastRun.pass_rate >= 0.5 ? "text-yellow-600" : "text-red-600"}>
+                          Pass rate: {(lastRun.pass_rate * 100).toFixed(0)}%
+                        </span>
+                      )}
+                      {lastRun.avg_score !== null && (
+                        <span className="text-muted-foreground">
+                          Avg score: {lastRun.avg_score.toFixed(2)}
+                        </span>
+                      )}
+                      <span className="text-muted-foreground">
+                        {lastRun.passed_cases}/{lastRun.total_cases} passed
+                      </span>
+                    </div>
+                  )}
+                  {suiteRuns.length > 1 && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {suiteRuns.length} total runs
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/evals/page.tsx
+++ b/frontend/app/dashboard/evals/page.tsx
@@ -1,258 +1,63 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
-import { api, EvalSuite, EvalRun, Agent, Blueprint } from "@/lib/api";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { isDemoMode, DEMO_EVAL_SUITES } from "@/lib/demo-data";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useCallback } from "react";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import { SuitesView } from "./SuitesView";
+import ComparePage from "../compare/page";
+
+/**
+ * PR-4 Evals — Suites + Compare under one workspace home.
+ *
+ * Compare keeps living at /dashboard/compare as a deep-link target; this page
+ * just hosts it as a tab. Tab persistence via ?tab=suites|compare.
+ */
+const TABS = ["suites", "compare"] as const;
+type EvalsTab = (typeof TABS)[number];
 
 export default function EvalsPage() {
-  const [suites, setSuites] = useState<EvalSuite[]>([]);
-  const [agents, setAgents] = useState<Agent[]>([]);
-  const [blueprints, setBlueprints] = useState<Blueprint[]>([]);
-  const [runs, setRuns] = useState<Record<string, EvalRun[]>>({});
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-  const [showCreate, setShowCreate] = useState(false);
+  const params = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
 
-  // Create form
-  const [newName, setNewName] = useState("");
-  const [newDesc, setNewDesc] = useState("");
-  const [newTargetType, setNewTargetType] = useState<"agent" | "blueprint">("agent");
-  const [newTargetId, setNewTargetId] = useState("");
+  const raw = params?.get("tab") ?? "suites";
+  const tab: EvalsTab = (TABS as readonly string[]).includes(raw)
+    ? (raw as EvalsTab)
+    : "suites";
 
-  // Run state
-  const [running, setRunning] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (isDemoMode()) {
-      setSuites(DEMO_EVAL_SUITES as unknown as EvalSuite[]);
-      setLoading(false);
-      return;
-    }
-    loadData();
-  }, []);
-
-  async function loadData() {
-    const { data } = await supabase.auth.getSession();
-    if (!data.session) return;
-
-    try {
-      const [suiteList, agentList, bpList] = await Promise.all([
-        api.evals.suites(data.session.access_token),
-        api.agents.list(data.session.access_token),
-        api.blueprints.list(data.session.access_token),
-      ]);
-      setSuites(suiteList);
-      setAgents(agentList);
-      setBlueprints(bpList);
-
-      // Load runs for each suite
-      const runsMap: Record<string, EvalRun[]> = {};
-      for (const suite of suiteList) {
-        try {
-          runsMap[suite.id] = await api.evals.listRuns(suite.id, data.session.access_token);
-        } catch {
-          runsMap[suite.id] = [];
-        }
-      }
-      setRuns(runsMap);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function createSuite() {
-    const { data } = await supabase.auth.getSession();
-    if (!data.session) return;
-
-    try {
-      await api.evals.createSuite(
-        { name: newName, description: newDesc, target_type: newTargetType, target_id: newTargetId },
-        data.session.access_token
-      );
-      setShowCreate(false);
-      setNewName("");
-      setNewDesc("");
-      setNewTargetId("");
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create suite");
-    }
-  }
-
-  async function runSuite(suiteId: string) {
-    const { data } = await supabase.auth.getSession();
-    if (!data.session) return;
-
-    setRunning(suiteId);
-    try {
-      await api.evals.runSuite(suiteId, undefined, data.session.access_token);
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to run suite");
-    } finally {
-      setRunning(null);
-    }
-  }
-
-  async function deleteSuite(suiteId: string) {
-    const { data } = await supabase.auth.getSession();
-    if (!data.session) return;
-
-    try {
-      await api.evals.deleteSuite(suiteId, data.session.access_token);
-      setSuites(suites.filter((s) => s.id !== suiteId));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to delete");
-    }
-  }
-
-  const targetOptions = newTargetType === "agent" ? agents : blueprints;
+  const onChange = useCallback(
+    (next: string) => {
+      const url = new URL(window.location.href);
+      url.searchParams.set("tab", next);
+      router.replace(`${pathname}?${url.searchParams.toString()}`, { scroll: false });
+    },
+    [pathname, router],
+  );
 
   return (
-    <div>
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold">Evals</h1>
-          <p className="mt-1 text-muted-foreground">
-            Test and evaluate your agents with structured test suites
-          </p>
-        </div>
-        <Button onClick={() => setShowCreate(!showCreate)}>
-          {showCreate ? "Cancel" : "New Suite"}
-        </Button>
-      </div>
+    <div className="flex flex-col gap-4">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Evals</h1>
+        <p className="text-sm text-muted-foreground">
+          Eval suites and side-by-side model comparison.
+        </p>
+      </header>
 
-      {error && (
-        <div className="mt-4 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-          {error}
-        </div>
-      )}
+      <Tabs value={tab} onValueChange={onChange}>
+        <TabsList>
+          <TabsTrigger value="suites">Suites</TabsTrigger>
+          <TabsTrigger value="compare">Compare</TabsTrigger>
+        </TabsList>
 
-      {showCreate && (
-        <Card className="mt-6">
-          <CardHeader>
-            <CardTitle>Create Eval Suite</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <Input placeholder="Suite name" value={newName} onChange={(e) => setNewName(e.target.value)} />
-            <Input placeholder="Description" value={newDesc} onChange={(e) => setNewDesc(e.target.value)} />
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div>
-                <label className="text-sm font-medium">Target Type</label>
-                <select
-                  className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
-                  value={newTargetType}
-                  onChange={(e) => { setNewTargetType(e.target.value as typeof newTargetType); setNewTargetId(""); }}
-                >
-                  <option value="agent">Agent</option>
-                  <option value="blueprint">Blueprint</option>
-                </select>
-              </div>
-              <div>
-                <label className="text-sm font-medium">Target</label>
-                <select
-                  className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
-                  value={newTargetId}
-                  onChange={(e) => setNewTargetId(e.target.value)}
-                >
-                  <option value="">Select...</option>
-                  {targetOptions.map((t) => (
-                    <option key={t.id} value={t.id}>{t.name}</option>
-                  ))}
-                </select>
-              </div>
-            </div>
-            <Button onClick={createSuite} disabled={!newName.trim() || !newTargetId}>
-              Create Suite
-            </Button>
-          </CardContent>
-        </Card>
-      )}
-
-      <div className="mt-6 space-y-4">
-        {loading ? (
-          <div className="space-y-3">
-            {[1, 2].map((i) => <div key={i} className="h-24 animate-pulse rounded-lg bg-muted" />)}
-          </div>
-        ) : suites.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No eval suites yet. Create one to start testing your agents.
-          </p>
-        ) : (
-          suites.map((suite) => {
-            const suiteRuns = runs[suite.id] || [];
-            const lastRun = suiteRuns[0];
-            return (
-              <Card key={suite.id} data-seeded="true">
-                <CardContent className="py-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h3 className="font-semibold">{suite.name}</h3>
-                      <p className="text-sm text-muted-foreground">{suite.description}</p>
-                      <div className="mt-1 flex items-center gap-2">
-                        <Badge variant="outline">{suite.target_type}</Badge>
-                        <span className="text-xs text-muted-foreground font-mono">
-                          {suite.target_id.slice(0, 8)}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        variant="default"
-                        size="sm"
-                        onClick={() => runSuite(suite.id)}
-                        disabled={running === suite.id}
-                      >
-                        {running === suite.id ? "Running..." : "Run"}
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-destructive"
-                        onClick={() => deleteSuite(suite.id)}
-                      >
-                        Delete
-                      </Button>
-                    </div>
-                  </div>
-                  {lastRun && (
-                    <div className="mt-3 flex items-center gap-4 text-sm">
-                      <span>
-                        Last run: <Badge variant={lastRun.status === "completed" ? "default" : "secondary"}>{lastRun.status}</Badge>
-                      </span>
-                      {lastRun.pass_rate !== null && (
-                        <span className={lastRun.pass_rate >= 0.8 ? "text-green-600" : lastRun.pass_rate >= 0.5 ? "text-yellow-600" : "text-red-600"}>
-                          Pass rate: {(lastRun.pass_rate * 100).toFixed(0)}%
-                        </span>
-                      )}
-                      {lastRun.avg_score !== null && (
-                        <span className="text-muted-foreground">
-                          Avg score: {lastRun.avg_score.toFixed(2)}
-                        </span>
-                      )}
-                      <span className="text-muted-foreground">
-                        {lastRun.passed_cases}/{lastRun.total_cases} passed
-                      </span>
-                    </div>
-                  )}
-                  {suiteRuns.length > 1 && (
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {suiteRuns.length} total runs
-                    </p>
-                  )}
-                </CardContent>
-              </Card>
-            );
-          })
-        )}
-      </div>
+        <TabsContent value="suites">
+          <SuitesView />
+        </TabsContent>
+        <TabsContent value="compare">
+          <ComparePage />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/frontend/app/dashboard/evals/page.tsx
+++ b/frontend/app/dashboard/evals/page.tsx
@@ -1,23 +1,25 @@
 "use client";
 
+import { Suspense, useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-import { useCallback } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { SuitesView } from "./SuitesView";
 import ComparePage from "../compare/page";
 
-/**
- * PR-4 Evals — Suites + Compare under one workspace home.
- *
- * Compare keeps living at /dashboard/compare as a deep-link target; this page
- * just hosts it as a tab. Tab persistence via ?tab=suites|compare.
- */
 const TABS = ["suites", "compare"] as const;
 type EvalsTab = (typeof TABS)[number];
 
 export default function EvalsPage() {
+  return (
+    <Suspense fallback={<EvalsShell tab="suites" />}>
+      <EvalsContent />
+    </Suspense>
+  );
+}
+
+function EvalsContent() {
   const params = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
@@ -36,6 +38,18 @@ export default function EvalsPage() {
     [pathname, router],
   );
 
+  return <EvalsShell tab={tab} onChange={onChange} interactive />;
+}
+
+function EvalsShell({
+  tab,
+  onChange,
+  interactive,
+}: {
+  tab: EvalsTab;
+  onChange?: (next: string) => void;
+  interactive?: boolean;
+}) {
   return (
     <div className="flex flex-col gap-4">
       <header>
@@ -45,18 +59,22 @@ export default function EvalsPage() {
         </p>
       </header>
 
-      <Tabs value={tab} onValueChange={onChange}>
+      <Tabs value={tab} onValueChange={onChange ?? (() => {})}>
         <TabsList>
           <TabsTrigger value="suites">Suites</TabsTrigger>
           <TabsTrigger value="compare">Compare</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="suites">
-          <SuitesView />
-        </TabsContent>
-        <TabsContent value="compare">
-          <ComparePage />
-        </TabsContent>
+        {interactive && (
+          <>
+            <TabsContent value="suites">
+              <SuitesView />
+            </TabsContent>
+            <TabsContent value="compare">
+              <ComparePage />
+            </TabsContent>
+          </>
+        )}
       </Tabs>
     </div>
   );

--- a/frontend/app/dashboard/library/page.tsx
+++ b/frontend/app/dashboard/library/page.tsx
@@ -1,10 +1,58 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useCallback } from "react";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import PromptsPage from "../prompts/page";
+import KnowledgePage from "../knowledge/page";
 
 /**
- * PR-3 placeholder. PR-4 replaces this with the tabbed Library page (Prompts +
- * Knowledge). Until then we redirect into the existing Prompts route so the
- * sidebar link doesn't 404.
+ * PR-4 Studio Library — Prompts + Knowledge as tabs. The existing standalone
+ * /dashboard/prompts and /dashboard/knowledge routes stay live as deep-link
+ * destinations; this page just hosts the two views under one workspace home.
+ *
+ * Tab persistence: ?tab=prompts | ?tab=knowledge so refreshes and bookmarks
+ * land on the right pane.
  */
-export default function LibraryRedirect() {
-  redirect("/dashboard/prompts");
+export default function LibraryPage() {
+  const params = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+  const tab = params?.get("tab") === "knowledge" ? "knowledge" : "prompts";
+
+  const onChange = useCallback(
+    (next: string) => {
+      const url = new URL(window.location.href);
+      url.searchParams.set("tab", next);
+      router.replace(`${pathname}?${url.searchParams.toString()}`, { scroll: false });
+    },
+    [pathname, router],
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Library</h1>
+        <p className="text-sm text-muted-foreground">
+          Prompts and knowledge collections — attachable to any agent in Studio.
+        </p>
+      </header>
+
+      <Tabs value={tab} onValueChange={onChange}>
+        <TabsList>
+          <TabsTrigger value="prompts">Prompts</TabsTrigger>
+          <TabsTrigger value="knowledge">Knowledge</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="prompts">
+          <PromptsPage />
+        </TabsContent>
+        <TabsContent value="knowledge">
+          <KnowledgePage />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
 }

--- a/frontend/app/dashboard/library/page.tsx
+++ b/frontend/app/dashboard/library/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { Suspense, useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-import { useCallback } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -14,9 +14,18 @@ import KnowledgePage from "../knowledge/page";
  * destinations; this page just hosts the two views under one workspace home.
  *
  * Tab persistence: ?tab=prompts | ?tab=knowledge so refreshes and bookmarks
- * land on the right pane.
+ * land on the right pane. useSearchParams must run inside a Suspense boundary
+ * so Next.js can statically generate the surrounding shell.
  */
 export default function LibraryPage() {
+  return (
+    <Suspense fallback={<LibraryShell tab="prompts" />}>
+      <LibraryContent />
+    </Suspense>
+  );
+}
+
+function LibraryContent() {
   const params = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
@@ -31,6 +40,18 @@ export default function LibraryPage() {
     [pathname, router],
   );
 
+  return <LibraryShell tab={tab} onChange={onChange} interactive />;
+}
+
+function LibraryShell({
+  tab,
+  onChange,
+  interactive,
+}: {
+  tab: "prompts" | "knowledge";
+  onChange?: (next: string) => void;
+  interactive?: boolean;
+}) {
   return (
     <div className="flex flex-col gap-4">
       <header>
@@ -40,18 +61,22 @@ export default function LibraryPage() {
         </p>
       </header>
 
-      <Tabs value={tab} onValueChange={onChange}>
+      <Tabs value={tab} onValueChange={onChange ?? (() => {})}>
         <TabsList>
           <TabsTrigger value="prompts">Prompts</TabsTrigger>
           <TabsTrigger value="knowledge">Knowledge</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="prompts">
-          <PromptsPage />
-        </TabsContent>
-        <TabsContent value="knowledge">
-          <KnowledgePage />
-        </TabsContent>
+        {interactive && (
+          <>
+            <TabsContent value="prompts">
+              <PromptsPage />
+            </TabsContent>
+            <TabsContent value="knowledge">
+              <KnowledgePage />
+            </TabsContent>
+          </>
+        )}
       </Tabs>
     </div>
   );


### PR DESCRIPTION
## Summary
PR-4 of the unified-IA spec. The new workspace homes from PR-3 stop being redirect placeholders and start hosting the consolidated surfaces under one click each.

### Library — Prompts + Knowledge as tabs
\`frontend/app/dashboard/library/page.tsx\` imports \`PromptsPage\` and \`KnowledgePage\` as-is from their existing routes and hosts them under one Library workspace home. Tab persistence via \`?tab=prompts|knowledge\` so refreshes / bookmarks land on the right pane. Old \`/dashboard/prompts\` and \`/dashboard/knowledge\` stay live as deep-link targets (PR-3's sidebar lights up Library on both).

### Connections — Providers / MCP / Targets / Computer-Use config as tabs
\`frontend/app/dashboard/connections/page.tsx\` hosts the four standalone pages inline. The Computer-Use *live view* deep link still lives at \`/dashboard/computer-use\`; this tab is the config surface for it (honours the spec's \"don't bury the flagship\" guard).

### Evals — Suites + Compare as tabs
The previous evals page body moved to \`./SuitesView.tsx\` (named export, identical behaviour); the new \`page.tsx\` renders Tabs with \`SuitesView\` + \`ComparePage\`. \`/dashboard/compare\` keeps working as a deep-link destination.

### Vocabulary alignment (matches PR-2 CLI)
- Providers (not Models)
- Team (not Teams) — sidebar label already updated in PR-3
- Library (Prompts + Knowledge)
- Connections (Providers + MCP + Targets + Computer-Use)

Tab state lives in URL search params (\`?tab=...\`) — same pattern across all three pages, so back/forward, bookmarks, and shared links work naturally.

### What's deferred
Spec §4 also asks for the Studio agent-detail enhancement (surface the blueprint and attached prompts/knowledge inline). That's a bigger touch in the agent detail view and warrants its own PR. Tracked as a follow-up; the workspace consolidation here is the higher-leverage win the spec calls out (\"cheap, high-impact merges\").

### Acceptance (spec §PR-4)
- [x] Library / Evals / Connections — each merged surface reachable in ≤1 click from its workspace
- [x] Old standalone pages still resolve (sidebar deep links + bookmarks)
- [x] Web labels match CLI namespace names (Providers, Team, Library, Connections)

## Test plan
- [x] 34/34 frontend tests green
- [x] Lint + typecheck clean
- [ ] CI green (frontend lint/test, backend test, e2e parity)