### PR TITLE
docs(parity): unified web/CLI IA map + forge map command (PR-6)

### DIFF
--- a/cli/forge/main.py
+++ b/cli/forge/main.py
@@ -198,6 +198,65 @@ _ALIAS_TO_CANONICAL: dict[str, str] = {
 _emit_deprecation_note()
 
 
+# --- PR-6: workspace → command tree printer ---
+# `forge map` prints the same six-workspace structure the sidebar shows, so terminal
+# users discover the IA without having to grep through --help output for each branch.
+@app.command("map")
+def _map() -> None:
+    """Print the workspace → command tree (mirrors the dashboard sidebar)."""
+    from rich.tree import Tree as _Tree
+
+    tree = _Tree("[bold]forge[/bold] · unified IA")
+
+    def _add(parent: "_Tree", label: str, children: list[str]) -> None:
+        branch = parent.add(f"[bold]{label}[/bold]")
+        for child in children:
+            branch.add(child)
+
+    _add(
+        tree,
+        "studio",
+        ["agents", "blueprints", "prompts", "knowledge", "workspace"],
+    )
+    _add(
+        tree,
+        "ops",
+        [
+            "runs (--status queued|running|done|failed)",
+            "approvals",
+            "approve <id>  ·  reject <id>  (PR-5 shortcuts)",
+            "triggers",
+            "traces",
+            "recordings",
+            "messages",
+            "groups",
+            "orchestrate",
+        ],
+    )
+    _add(tree, "evals", ["list / run / create / add-case / compare"])
+    _add(
+        tree,
+        "connections",
+        ["providers (was: models)", "mcp", "targets", "computer-use", "tools"],
+    )
+    _add(tree, "marketplace", ["browse / publish / show / rate / fork / unpublish"])
+    _add(
+        tree,
+        "settings",
+        ["team (was: teams)", "api-keys (was: keys)", "config"],
+    )
+    _add(
+        tree,
+        "(system — flat)",
+        [
+            "init · up · down · restart · status · health · dashboard",
+            "version · costs · whoami · login · logout",
+            "auth (signup / login / logout / whoami / keys)",
+        ],
+    )
+    console.print(tree)
+
+
 __all__ = ["app", "console", "__version__"]
 
 

--- a/cli/tests/test_forge_map.py
+++ b/cli/tests/test_forge_map.py
@@ -1,0 +1,39 @@
+"""PR-6 acceptance: `forge map` prints the workspace → command tree."""
+
+from typer.testing import CliRunner
+
+from forge.main import app
+
+runner = CliRunner()
+
+
+def test_forge_map_lists_every_workspace():
+    result = runner.invoke(app, ["map"])
+    assert result.exit_code == 0
+    out = result.output
+    for noun in ("studio", "ops", "evals", "connections", "marketplace", "settings"):
+        assert noun in out, f"{noun!r} missing from `forge map` output"
+
+
+def test_forge_map_calls_out_renames():
+    result = runner.invoke(app, ["map"])
+    assert result.exit_code == 0
+    # The map surfaces the spec renames so terminal users discover them without
+    # having to read the parity doc.
+    assert "providers" in result.output
+    assert "team" in result.output
+    assert "api-keys" in result.output
+
+
+def test_forge_map_includes_pr5_shortcuts():
+    result = runner.invoke(app, ["map"])
+    assert result.exit_code == 0
+    assert "approve" in result.output
+    assert "reject" in result.output
+
+
+def test_forge_map_includes_system_layer():
+    result = runner.invoke(app, ["map"])
+    assert result.exit_code == 0
+    for cmd in ("up", "down", "status", "dashboard"):
+        assert cmd in result.output

--- a/docs/web-cli-parity.md
+++ b/docs/web-cli-parity.md
@@ -1,49 +1,156 @@
 # Web ↔ CLI parity matrix
 
-Forge's pitch is that the CLI covers every action available in the web UI. This
-file is the authoritative map between CLI command groups and their matching web
-routes. It is checked into the repo so any drift fails review.
+> The noun a user clicks is the noun they type. Six workspaces + a flat system
+> layer, two renderings.
 
-The Playwright smoke test at `frontend/e2e/demo-parity.spec.ts` walks every
-route listed below in demo mode and asserts that each one loads without an
-error fallback. Add a row here when you add a CLI command group **or** a web
-route — both must move together.
+Forge's pitch is that the CLI covers every action available in the web UI.
+Every sidebar group on the dashboard maps 1:1 to a `forge <workspace>` namespace
+in the CLI (PR-2 of the unified-IA spec), and every old top-level CLI noun
+keeps resolving as a back-compat alias so muscle memory and scripts don't
+break.
 
-## Matrix
+This file is the authoritative map between the two surfaces. It is checked
+into the repo so any drift fails review. The Playwright smoke test at
+`frontend/e2e/demo-parity.spec.ts` walks every route listed below in demo mode
+and asserts that each one loads without an error fallback. Add a row here when
+you add a CLI command group **or** a web route — both must move together.
 
-| CLI command group                                                   | Web route                                          | Status              | Notes                              |
-|---------------------------------------------------------------------|----------------------------------------------------|---------------------|------------------------------------|
-| `forge init` / `up` / `down` / `restart` / `status` / `health` / `dashboard` (TUI) | —                                                  | CLI-only            | Stack/runtime management           |
-| `forge auth signup` / `login` / `logout` / `whoami`                 | `/login`, `/dashboard/settings`                    | ✅                   |                                    |
-| `forge config show` / `set` / `set-provider` / `set-default-model`  | `/dashboard/settings`, `/dashboard/providers`      | ✅                   |                                    |
-| `forge agents list` / `create` / `run` / `history` / `templates`    | `/dashboard/agents`                                | ✅                   |                                    |
-| `forge blueprints list` / `create` / `run` / `export` / `import`    | `/dashboard/blueprints`                            | ✅                   | Demo seeds 5 blueprints (PR 3)     |
-| `forge orchestrate`                                                 | `/dashboard/orchestrate`                           | ✅                   |                                    |
-| `forge costs` (incl. `--breakdown {agent,model,provider}`)          | `/dashboard#usage`                                 | ✅                   | Provider breakdown added in PR 2   |
-| `forge models list` / `test` / `compare`                            | `/dashboard/providers`                             | ✅                   | NEW route, PR 5                    |
-| `forge evals create` / `add-case` / `run` / `results`               | `/dashboard/evals`                                 | ✅                   |                                    |
-| `forge knowledge create` / `upload` / `search`                      | `/dashboard/knowledge`                             | ✅                   |                                    |
-| `forge cu status` / `see` / `ocr` / `click` / `type` / `focus` / `find` | `/dashboard/computer-use`                       | ✅                   | NEW route, PR 5                    |
-| `forge runs list`                                                   | `/dashboard/runs`                                  | ✅                   | Each row links to its trace        |
-| `forge triggers list`                                               | `/dashboard/triggers`                              | ✅                   |                                    |
-| `forge approvals list`                                              | `/dashboard/approvals`                             | ✅                   |                                    |
-| `forge traces list`                                                 | `/dashboard/traces`                                | ✅                   |                                    |
-| `forge prompts list`                                                | `/dashboard/prompts`                               | ✅                   |                                    |
-| `forge marketplace browse`                                          | `/dashboard/marketplace`                           | ✅                   |                                    |
-| `forge mcp list`                                                    | `/dashboard/mcp`                                   | ✅                   | NEW route, PR 5                    |
-| `forge targets list`                                                | `/dashboard/targets`                               | ✅                   | NEW route, PR 5                    |
-| `forge recordings list`                                             | `/dashboard/recordings`                            | ✅                   | NEW route + `/api/recordings`, PR 5|
-| `forge keys list`                                                   | `/dashboard/settings/api-keys`                     | ✅                   | NEW route, PR 5                    |
-| Workspace operations (CodeMirror + tree + xterm)                    | `/dashboard/workspace`                             | ✅                   | Demo gets read-only sandbox (PR 4) |
+---
+
+## Studio · `forge studio`
+
+> Agents, blueprints, prompts/knowledge (library), and the embedded workspace.
+
+| Web surface | CLI canonical | CLI legacy alias | Notes |
+| --- | --- | --- | --- |
+| `/dashboard/agents` | `forge studio agents …` | `forge agents …` | list / create / run / show / edit / delete / templates |
+| `/dashboard/blueprints` | `forge studio blueprints …` | `forge blueprints …` | list / create / show / run / export / import / inspect |
+| `/dashboard/library` (tab: Prompts) | `forge studio prompts …` | `forge prompts …` | PR-4 tabbed home; `/dashboard/prompts` still resolves |
+| `/dashboard/library` (tab: Knowledge) | `forge studio knowledge …` | `forge knowledge …` | PR-4 tabbed home; `/dashboard/knowledge` still resolves |
+| `/dashboard/workspace` | `forge studio workspace …` | `forge workspace …` | files / read / write / search / open / history |
+
+---
+
+## Operations · `forge ops`
+
+> The run-lifecycle workspace. PR-5 added a kanban board (`/dashboard/ops`)
+> across **Queued · Running · Awaiting Approval · Done · Failed**; the CLI
+> mirrors the columns via `--status`.
+
+| Web surface | CLI canonical | CLI legacy alias | Notes |
+| --- | --- | --- | --- |
+| `/dashboard/ops` (board) | `forge ops runs list --status <col>` | `forge runs list --status <col>` | columns: queued, running, awaiting-approval, done, failed |
+| `/dashboard/ops` (board, single card) | `forge ops runs show <id>` | `forge runs show <id>` | run detail incl. trace + recording links |
+| `/dashboard/ops` (card cancel) | `forge ops runs cancel <id>` | `forge runs cancel <id>` |  |
+| `/dashboard/ops/approvals` | `forge ops approvals list` | `forge approvals list` | Awaiting-Approval column items |
+| inline Approve on board | `forge ops approve <id>` *or* `forge ops approvals approve <id>` | `forge approvals approve <id>` | PR-5 shortcut + legacy form |
+| inline Reject on board | `forge ops reject <id>` *or* `forge ops approvals reject <id>` | `forge approvals reject <id>` | PR-5 shortcut + legacy form |
+| `/dashboard/triggers` (deep link from board) | `forge ops triggers …` | `forge triggers …` | list / create / toggle / edit / delete / history |
+| `/dashboard/traces` (drawer) | `forge ops traces …` | `forge traces …` / `forge trace <id>` | list / stats / get |
+| `/dashboard/recordings` (drawer) | `forge ops recordings …` | `forge recordings …` | list / play / delete |
+| `/dashboard/messages` (drawer) | `forge ops messages …` | `forge messages …` / `forge mail …` | list / conversation |
+| `/dashboard/orchestrate` | `forge ops orchestrate …` | `forge orchestrate …` | submit objective |
+| `/dashboard/orchestrate` (group view) | `forge ops groups …` | `forge orchestrate-groups …` | spec rename: orchestrate-groups → groups |
+
+---
+
+## Evals · `forge evals`
+
+> Eval suites and side-by-side model comparison.
+
+| Web surface | CLI canonical | CLI legacy alias | Notes |
+| --- | --- | --- | --- |
+| `/dashboard/evals` (tab: Suites) | `forge evals list` / `run` / `create` / `add-case` | — | PR-4 tabbed home; backing route unchanged |
+| `/dashboard/evals` (tab: Compare) | `forge evals compare …` | `forge compare …` | `/dashboard/compare` still resolves as deep link |
+
+---
+
+## Connections · `forge connections`
+
+> Model providers, MCP servers, execution targets, computer-use config, tools.
+> PR-4 tabbed home; the Computer-Use **live view** is still one click away as a
+> deep link from any workspace.
+
+| Web surface | CLI canonical | CLI legacy alias | Notes |
+| --- | --- | --- | --- |
+| `/dashboard/connections` (tab: Providers) | `forge connections providers …` | `forge models …` | spec rename: models → providers |
+| `/dashboard/connections` (tab: MCP) | `forge connections mcp …` | `forge mcp …` | connect / list / test / tools |
+| `/dashboard/connections` (tab: Targets) | `forge connections targets …` | `forge targets …` |  |
+| `/dashboard/connections` (tab: Computer Use, config) | `forge connections computer-use …` | `forge computer-use …` / `forge cu …` | `backends_app` nested inside |
+| `/dashboard/computer-use` (live view) | — | — | wow feature — kept reachable in 1 click |
+| (no dedicated route) | `forge connections tools …` | `forge tools …` | list built-in + MCP tools |
+
+---
+
+## Marketplace · `forge marketplace`
+
+| Web surface | CLI canonical | CLI legacy alias | Notes |
+| --- | --- | --- | --- |
+| `/dashboard/marketplace` | `forge marketplace browse / publish / show / rate / fork / unpublish` | — | name unchanged |
+
+---
+
+## Settings · `forge settings`
+
+| Web surface | CLI canonical | CLI legacy alias | Notes |
+| --- | --- | --- | --- |
+| `/dashboard/team` | `forge settings team …` | `forge teams …` | spec rename: teams → team |
+| `/dashboard/settings/api-keys` | `forge settings api-keys …` | `forge keys …` | spec rename: keys → api-keys |
+| `/dashboard/settings` (preferences) | `forge settings config …` | `forge config …` | show / set / set-provider / set-default-model |
+| `/login` | `forge auth …` | `forge login` / `forge logout` / `forge whoami` | signup / login / logout / whoami / keys |
+
+---
+
+## System layer (flat, no workspace)
+
+> Lifecycle and observability of the local stack.
+
+| Command | Purpose |
+| --- | --- |
+| `forge init` | One-time config bootstrap |
+| `forge up` / `down` / `restart` | Start, stop, recycle backend + frontend |
+| `forge status` | Active runs table |
+| `forge health` | Service liveness summary |
+| `forge dashboard` | Rich TUI dashboard |
+| `forge version` | CLI version |
+| `forge costs` | Token + cost rollup |
+| `forge map` | Print the workspace → command tree (mirrors the sidebar). PR-6. |
+
+---
+
+## Vocabulary table (web ↔ CLI)
+
+Every label in the sidebar matches a CLI namespace. Drift is a defect.
+
+| Web label | CLI namespace | Renamed from |
+| --- | --- | --- |
+| Studio | `studio` | (new grouping) |
+| Operations | `ops` | (new grouping) |
+| Evals | `evals` | — |
+| Connections | `connections` | (new grouping) |
+| Marketplace | `marketplace` | — |
+| Settings | `settings` | (new grouping) |
+| Library | `studio` (Prompts + Knowledge tabs) | (new grouping) |
+| Providers | `connections providers` | Models |
+| Team | `settings team` | Teams |
+| API Keys | `settings api-keys` | keys |
+| Computer Use (config) | `connections computer-use` | — |
+| Computer Use (live view) | (link from any workspace) | — |
+
+---
 
 ## How to extend this matrix
 
-1. Add the row to the table above.
-2. Add the route to the `ROUTES` constant in
-   `frontend/e2e/demo-parity.spec.ts`. The test will fail if the route 404s
-   or renders an error in demo mode.
-3. If the route reads from a live API endpoint, mirror it in the demo seed in
+1. Add the row under the relevant workspace section above.
+2. If you added a web route: register it in the `ROUTES` constant in
+   `frontend/e2e/demo-parity.spec.ts` so the smoke test catches a 404 / error
+   fallback.
+3. If you added a CLI command group: put it in the right
+   `cli/forge/commands/<workspace>.py` module and mount it on the workspace
+   parent in `main.py`. If the old top-level name was already in use, keep it
+   working as an alias (`_mod.register(app)` already does this for sub-apps).
+4. If the route reads from a live API endpoint, mirror it in the demo seed in
    `frontend/lib/demo/seed.ts` (or split into a per-fixture file under
    `frontend/lib/demo/`).
-4. Mark every fixture row with `data-seeded="true"` so the smoke test can tell
-   a seeded surface from an empty one.
+5. Mark every fixture row in the web component with `data-seeded="true"` so
+   the smoke test can tell a seeded surface from an empty one.


### PR DESCRIPTION
## Summary
PR-6 of the unified-IA spec — the closer. Locks the web and CLI surfaces together so they can't silently drift.

### \`docs/web-cli-parity.md\` rewritten
- One section per workspace (Studio / Operations / Evals / Connections / Marketplace / Settings) + a flat System section.
- Every row carries: web surface, CLI canonical path, CLI legacy alias, backing notes.
- All spec renames captured in a vocabulary table: Providers (was Models), Team (was Teams), API Keys (was keys), groups (was orchestrate-groups).
- \"How to extend\" section spells out the contract for adding a row — both surfaces must move together.

### \`forge map\` command
Prints the workspace → command tree (mirrors the dashboard sidebar) so terminal users discover the IA without having to grep through \`--help\` output. Uses \`rich.tree.Tree\`, matches the structure of the parity doc 1:1. Highlights the PR-5 ops shortcuts (\`approve\` / \`reject\`) and the surface renames inline.

\`\`\`
forge · unified IA
├── studio
│   ├── agents
│   ├── blueprints
│   ├── prompts
│   ├── knowledge
│   └── workspace
├── ops
│   ├── runs (--status queued|running|done|failed)
│   ├── approve <id>  ·  reject <id>  (PR-5 shortcuts)
│   └── …
└── …
\`\`\`

### Tests
- \`cli/tests/test_forge_map.py\` (4 cases): every workspace appears, spec renames are surfaced, PR-5 shortcuts visible, system layer represented.
- **36/36 CLI tests green** (was 32; +4 for forge map).

### Acceptance (spec §PR-6)
- [x] Parity doc lists all 6 workspaces with exact command paths
- [x] \`forge map\` prints the workspace → command tree
- [x] Web labels match CLI namespace names in the vocabulary table

This is the last PR of the unified-IA spec — the IA is now load-bearing across both surfaces.

## Test plan
- [x] 36/36 CLI tests green locally
- [x] \`forge map\` prints the full tree
- [ ] CI green