### PR TITLE
feat(api): runs/blueprints accept attachments body (+ back-compat)

### DIFF
--- a/backend/app/models/attachment.py
+++ b/backend/app/models/attachment.py
@@ -1,0 +1,28 @@
+"""Attachment models shared by the run, blueprint, upload, and dispatch APIs."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class Attachment(BaseModel):
+    """A file carried into a run: an image (multimodal) or a document (text)."""
+
+    url: str
+    kind: Literal["image", "document"]
+    name: str
+    mime: str
+
+
+class RunRequest(BaseModel):
+    """Optional JSON body for the agent run endpoint.
+
+    Back-compat: ``input_text`` may still arrive as a query param. When a body
+    is present its ``input_text`` wins; ``attachments`` are only available via
+    the body.
+    """
+
+    input_text: str | None = None
+    attachments: list[Attachment] = []

--- a/backend/app/models/blueprint.py
+++ b/backend/app/models/blueprint.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from app.models.attachment import Attachment
+
 
 class BlueprintNode(BaseModel):
     """A single node in the blueprint DAG."""
@@ -66,6 +68,7 @@ class BlueprintRunRequest(BaseModel):
 
     input_text: str = Field("", max_length=50000)
     input_data: dict[str, Any] = Field(default_factory=dict)
+    attachments: list[Attachment] = Field(default_factory=list)
 
 
 class BlueprintRunResponse(BaseModel):

--- a/backend/app/routers/blueprints.py
+++ b/backend/app/routers/blueprints.py
@@ -185,10 +185,12 @@ async def run_blueprint(
         raise HTTPException(status_code=404, detail="Blueprint not found")
 
     # Create run record
-    input_payload = {
+    input_payload: dict = {
         "text": run_req.input_text,
         **run_req.input_data,
     }
+    if run_req.attachments:
+        input_payload["attachments"] = [a.model_dump() for a in run_req.attachments]
     run_result = get_db().table("blueprint_runs").insert({
         "blueprint_id": blueprint_id,
         "user_id": user.id,

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -3,10 +3,11 @@ import json
 import time
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 
 from app.db import get_db
+from app.models.attachment import RunRequest
 from app.models.run import RunResponse
 from app.routers.auth import get_current_user
 from app.services.agent_executor import AgentRunner
@@ -41,7 +42,17 @@ async def run_agent(
     request: Request,
     token: str = Query(...),
     input_text: str = Query(""),
+    body: RunRequest | None = Body(default=None),  # noqa: B008
 ):
+    # Optional JSON body carries attachments and (optionally) overrides the
+    # query-param input_text. Existing CLI/trigger callers POST with no body
+    # and are unaffected — the body wins only when present.
+    attachments: list[dict] = []
+    if body is not None:
+        if body.input_text is not None:
+            input_text = body.input_text
+        attachments = [a.model_dump() for a in body.attachments]
+
     # Verify token. The auth backend returns either a Supabase-style wrapper
     # (`.user`) or the user object directly (SQLite local auth) — handle both.
     try:
@@ -63,11 +74,14 @@ async def run_agent(
     if agent_config["user_id"] != user.id and not agent_config.get("is_template", False):
         raise HTTPException(status_code=403, detail="Not authorized to run this agent")
 
-    # Create run record
+    # Create run record. Persist the first attachment URL for run history;
+    # full multimodal context is reconstructed by the runner from attachments.
+    first_url = attachments[0]["url"] if attachments else None
     run_result = get_db().table("runs").insert({
         "agent_id": agent_id,
         "user_id": user.id,
         "input_text": input_text,
+        "input_file_url": first_url,
         "status": "running",
     }).execute()
     if not run_result.data:
@@ -96,7 +110,7 @@ async def run_agent(
             step_num = 0
             async for event in agent_runner.execute(
                 agent_config, input_text, heartbeat_id=heartbeat_id,
-                run_id=run_id, user_id=user.id,
+                run_id=run_id, user_id=user.id, attachments=attachments,
             ):
                 step_num += 1
                 step_start = time.time()

--- a/backend/app/services/agent_executor.py
+++ b/backend/app/services/agent_executor.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from collections.abc import AsyncIterator
+from typing import Any
 
 from dotenv import load_dotenv
 from langchain.agents import AgentExecutor, create_openai_tools_agent
@@ -26,6 +27,18 @@ TOOL_REGISTRY = {
     "data_extractor": data_extractor,
     "summarizer": summarizer,
 }
+
+# Models that accept OpenAI-style ``image_url`` content blocks. Image
+# passthrough is restricted to these so we never hand an Anthropic/Ollama
+# model a content schema it can't parse — non-matching models get a text note
+# instead (see ``_prepare_attachments``).
+_VISION_MODEL_HINTS = ("gpt-4o", "gpt-4.1", "gpt-4-turbo", "gpt-4-vision", "o1")
+
+
+def _is_vision_capable(model: str | None) -> bool:
+    """True if ``model`` accepts OpenAI-style multimodal image content blocks."""
+    m = (model or "").lower()
+    return any(hint in m for hint in _VISION_MODEL_HINTS)
 
 
 class AgentRunner:
@@ -97,6 +110,7 @@ class AgentRunner:
         heartbeat_id: str | None = None,
         run_id: str | None = None,
         user_id: str | None = None,
+        attachments: list[dict] | None = None,
     ) -> AsyncIterator[dict]:
         """Execute an agent's workflow and yield streaming events."""
         from app.services.heartbeat import heartbeat_service
@@ -114,14 +128,23 @@ class AgentRunner:
         if not workflow_steps:
             workflow_steps = ["Process the user's input according to your instructions."]
 
+        # Documents become prepended context; images become multimodal blocks
+        # (or a note for non-vision models). Done once, up front.
+        doc_context, image_blocks, notes = await self._prepare_attachments(attachments, model)
+
         if heartbeat_id:
             heartbeat_service.update(
                 heartbeat_id, state="running", current_step=0
             )
 
         yield {"type": "step", "content": f"Starting agent: {agent_config.get('name', 'Unnamed')}", "tokens": 0}
+        for note in notes:
+            yield {"type": "step", "content": note, "tokens": 0}
 
-        accumulated_context = ""
+        # Seed context with extracted document text + any attachment notes.
+        accumulated_context = doc_context
+        if notes:
+            accumulated_context = (accumulated_context + "\n\n" + "\n".join(notes)).strip()
         total_tokens = 0
 
         for i, step in enumerate(workflow_steps, 1):
@@ -132,10 +155,16 @@ class AgentRunner:
                     heartbeat_id, state="running", current_step=i
                 )
 
+            # Only send image blocks on the first step to avoid re-billing the
+            # image on every step; later steps carry forward via context.
+            step_images = image_blocks if i == 1 else None
+
             if tools:
                 result = await self._execute_with_tools(system_prompt, step, user_input, accumulated_context, tools)
             else:
-                result = await self._execute_step(system_prompt, step, user_input, accumulated_context, model=model)
+                result = await self._execute_step(
+                    system_prompt, step, user_input, accumulated_context, model=model, image_blocks=step_images,
+                )
 
             step_tokens = result.get("tokens", 0)
             total_tokens += step_tokens
@@ -196,6 +225,48 @@ class AgentRunner:
         if heartbeat_id:
             heartbeat_service.complete(heartbeat_id, tokens_used=total_tokens)
 
+    async def _prepare_attachments(
+        self, attachments: list[dict] | None, model: str | None
+    ) -> tuple[str, list[dict], list[str]]:
+        """Turn attachments into (document_context, image_blocks, notes).
+
+        - Documents are extracted to text and concatenated with a
+          ``--- file: {name} ---`` header.
+        - Images become OpenAI-style ``image_url`` content blocks for
+          vision-capable models, or a ``[image omitted ...]`` note otherwise.
+        """
+        if not attachments:
+            return "", [], []
+
+        from app.services.extract import extract_text
+
+        vision = _is_vision_capable(model)
+        doc_parts: list[str] = []
+        image_blocks: list[dict] = []
+        notes: list[str] = []
+
+        for att in attachments:
+            kind = att.get("kind")
+            name = att.get("name") or att.get("url", "")
+            url = att.get("url", "")
+            if not url:
+                continue
+
+            if kind == "image":
+                if vision:
+                    image_blocks.append({"type": "image_url", "image_url": {"url": url}})
+                else:
+                    notes.append(f"[image omitted: model not multimodal] {name}")
+            elif kind == "document":
+                try:
+                    text = await extract_text(url)
+                    doc_parts.append(f"--- file: {name} ---\n{text}")
+                except Exception:
+                    logger.warning("Failed to extract attachment %s", name, exc_info=True)
+                    notes.append(f"[document omitted: could not read {name}]")
+
+        return "\n\n".join(doc_parts), image_blocks, notes
+
     async def _execute_with_tools(
         self, system_prompt: str, step: str, user_input: str, context: str, tools: list
     ) -> dict:
@@ -226,16 +297,31 @@ class AgentRunner:
         }
 
     async def _execute_step(
-        self, system_prompt: str, step: str, user_input: str, context: str, *, model: str | None = None
+        self,
+        system_prompt: str,
+        step: str,
+        user_input: str,
+        context: str,
+        *,
+        model: str | None = None,
+        image_blocks: list[dict] | None = None,
     ) -> dict:
         """Execute a single workflow step via the provider registry."""
         full_input = user_input
         if context:
             full_input = f"{user_input}\n\nPrevious step results:\n{context}"
 
-        messages = [
+        # When images are present (vision models only), the user message uses
+        # multimodal content blocks; otherwise it's a plain string.
+        user_content: str | list[dict]
+        if image_blocks:
+            user_content = [{"type": "text", "text": full_input}, *image_blocks]
+        else:
+            user_content = full_input
+
+        messages: list[dict[str, Any]] = [
             {"role": "system", "content": f"{system_prompt}\n\nCurrent task: {step}"},
-            {"role": "user", "content": full_input},
+            {"role": "user", "content": user_content},
         ]
 
         # Use user's provider registry if available

--- a/backend/app/services/blueprint_nodes/deterministic.py
+++ b/backend/app/services/blueprint_nodes/deterministic.py
@@ -9,8 +9,8 @@ from typing import Any
 
 import httpx
 
+from app.services.extract import extract_text
 from app.services.security.url_validator import validate_url
-from app.services.tools.document_reader import document_reader
 
 
 async def execute_fetch_url(config: dict, inputs: dict[str, Any]) -> dict[str, Any]:
@@ -37,9 +37,9 @@ async def execute_fetch_document(config: dict, inputs: dict[str, Any]) -> dict[s
 
     validate_url(file_url)
 
-    # Reuse the existing document_reader tool
-    result = await document_reader.ainvoke(file_url)
-    return {"text": str(result)}
+    # Shared extractor — same code path the agent runner uses for attachments.
+    text = await extract_text(file_url)
+    return {"text": text}
 
 
 async def execute_run_linter(config: dict, inputs: dict[str, Any]) -> dict[str, Any]:

--- a/backend/app/services/extract.py
+++ b/backend/app/services/extract.py
@@ -1,0 +1,67 @@
+"""Shared document text extraction.
+
+Factored out of the ``fetch_document`` blueprint node and the
+``document_reader`` LangChain tool so the agent runner and blueprint nodes
+share a single extractor (dashboard composer spec, PR-1). Supports remote
+documents (``http``/``https``) and local files (``file://`` URIs or bare
+filesystem paths) produced by the uploads storage backend (PR-2).
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+import httpx
+from docx import Document
+from pypdf import PdfReader
+
+# Cap extracted text so a large upload can't blow up a prompt/context window.
+MAX_CHARS = 10_000
+
+
+async def extract_text(file_url: str) -> str:
+    """Read a document from ``file_url`` and return its extracted plain text.
+
+    Handles PDF, DOCX, and plain-text/markdown. Returns at most
+    :data:`MAX_CHARS` characters. Raises on download/read failure — callers
+    that need graceful degradation (the tool wrapper, the agent runner) catch
+    and substitute a note.
+    """
+    file_bytes, content_type, name = await _load(file_url)
+    lowered = name.lower()
+
+    if "pdf" in content_type or lowered.endswith(".pdf"):
+        return _extract_pdf(file_bytes)
+    if "wordprocessingml" in content_type or lowered.endswith(".docx"):
+        return _extract_docx(file_bytes)
+    # Plain text, markdown, or unknown — decode best-effort.
+    return file_bytes.decode("utf-8", errors="replace")[:MAX_CHARS]
+
+
+async def _load(file_url: str) -> tuple[bytes, str, str]:
+    """Return ``(bytes, content_type, name)`` for a remote or local document."""
+    parsed = urlparse(file_url)
+
+    if parsed.scheme in ("http", "https"):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(file_url, timeout=30.0, follow_redirects=True)
+        response.raise_for_status()
+        return response.content, response.headers.get("content-type", ""), parsed.path
+
+    # Local file: a ``file://`` URI or a bare filesystem path.
+    path = Path(unquote(parsed.path)) if parsed.scheme == "file" else Path(file_url)
+    return path.read_bytes(), "", path.name
+
+
+def _extract_pdf(file_bytes: bytes) -> str:
+    reader = PdfReader(io.BytesIO(file_bytes))
+    parts = [page.extract_text() for page in reader.pages]
+    return "\n\n".join(text for text in parts if text)[:MAX_CHARS]
+
+
+def _extract_docx(file_bytes: bytes) -> str:
+    doc = Document(io.BytesIO(file_bytes))
+    parts = [p.text for p in doc.paragraphs if p.text.strip()]
+    return "\n\n".join(parts)[:MAX_CHARS]

--- a/backend/app/services/tools/document_reader.py
+++ b/backend/app/services/tools/document_reader.py
@@ -1,47 +1,12 @@
-import io
-
-import httpx
-from docx import Document
 from langchain.tools import tool
-from pypdf import PdfReader
+
+from app.services.extract import extract_text
 
 
 @tool
 async def document_reader(file_url: str) -> str:
     """Read and extract text from a PDF or DOCX document at the given URL."""
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(file_url, timeout=30.0)
-
-        if response.status_code != 200:
-            return f"Failed to download file: HTTP {response.status_code}"
-
-        content_type = response.headers.get("content-type", "")
-        file_bytes = response.content
-
-        if "pdf" in content_type or file_url.lower().endswith(".pdf"):
-            return _extract_pdf(file_bytes)
-        elif "docx" in content_type or file_url.lower().endswith(".docx"):
-            return _extract_docx(file_bytes)
-        else:
-            # Try to decode as plain text
-            return response.text[:10000]
-
+        return await extract_text(file_url)
     except Exception as e:
         return f"Error reading document: {str(e)}"
-
-
-def _extract_pdf(file_bytes: bytes) -> str:
-    reader = PdfReader(io.BytesIO(file_bytes))
-    text_parts = []
-    for page in reader.pages:
-        text = page.extract_text()
-        if text:
-            text_parts.append(text)
-    return "\n\n".join(text_parts)[:10000]
-
-
-def _extract_docx(file_bytes: bytes) -> str:
-    doc = Document(io.BytesIO(file_bytes))
-    text_parts = [p.text for p in doc.paragraphs if p.text.strip()]
-    return "\n\n".join(text_parts)[:10000]

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -1,0 +1,233 @@
+"""PR-1 — run contract accepts attachments (images + documents).
+
+Covers the shared extractor (`services/extract.py`), the agent runner's
+attachment preparation (documents -> context, images -> multimodal blocks or a
+note), and the run endpoint's JSON-body contract with query-param back-compat.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from docx import Document
+
+from app.models.attachment import Attachment, RunRequest
+from app.services.agent_executor import AgentRunner, _is_vision_capable
+from app.services.extract import extract_text
+
+# --- Shared extractor ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_text_reads_local_txt(tmp_path):
+    f = tmp_path / "notes.txt"
+    f.write_text("hello from a text file")
+    assert await extract_text(str(f)) == "hello from a text file"
+
+
+@pytest.mark.asyncio
+async def test_extract_text_reads_local_docx(tmp_path):
+    f = tmp_path / "report.docx"
+    doc = Document()
+    doc.add_paragraph("First line of the doc")
+    doc.add_paragraph("Second line of the doc")
+    doc.save(str(f))
+
+    text = await extract_text(str(f))
+    assert "First line of the doc" in text
+    assert "Second line of the doc" in text
+
+
+@pytest.mark.asyncio
+async def test_extract_text_handles_file_uri(tmp_path):
+    f = tmp_path / "readme.md"
+    f.write_text("# Title\n\nbody")
+    assert "# Title" in await extract_text(f.as_uri())
+
+
+@pytest.mark.asyncio
+async def test_extract_text_caps_length(tmp_path):
+    f = tmp_path / "big.txt"
+    f.write_text("x" * 50_000)
+    assert len(await extract_text(str(f))) == 10_000
+
+
+# --- Vision detection ---------------------------------------------------------
+
+
+def test_vision_capable_detection():
+    assert _is_vision_capable("gpt-4o")
+    assert _is_vision_capable("gpt-4o-mini")
+    assert _is_vision_capable("gpt-4-turbo")
+    assert not _is_vision_capable("gpt-3.5-turbo")
+    assert not _is_vision_capable("ollama/llama3.2:3b")
+    assert not _is_vision_capable(None)
+
+
+# --- Attachment preparation ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_attachments_extracts_documents():
+    runner = AgentRunner(user_id="u1")
+    attachments = [{"url": "file:///tmp/r.pdf", "kind": "document", "name": "r.pdf", "mime": "application/pdf"}]
+
+    with patch("app.services.extract.extract_text", new=AsyncMock(return_value="EXTRACTED BODY")) as mock_extract:
+        doc_context, image_blocks, notes = await runner._prepare_attachments(attachments, "gpt-4o-mini")
+
+    mock_extract.assert_awaited_once()
+    assert "--- file: r.pdf ---" in doc_context
+    assert "EXTRACTED BODY" in doc_context
+    assert image_blocks == []
+    assert notes == []
+
+
+@pytest.mark.asyncio
+async def test_prepare_attachments_images_for_vision_model():
+    runner = AgentRunner(user_id="u1")
+    attachments = [{"url": "https://x/y.png", "kind": "image", "name": "y.png", "mime": "image/png"}]
+
+    doc_context, image_blocks, notes = await runner._prepare_attachments(attachments, "gpt-4o")
+
+    assert doc_context == ""
+    assert image_blocks == [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}]
+    assert notes == []
+
+
+@pytest.mark.asyncio
+async def test_prepare_attachments_images_noted_for_non_vision_model():
+    runner = AgentRunner(user_id="u1")
+    attachments = [{"url": "https://x/y.png", "kind": "image", "name": "y.png", "mime": "image/png"}]
+
+    doc_context, image_blocks, notes = await runner._prepare_attachments(attachments, "gpt-3.5-turbo")
+
+    assert image_blocks == []
+    assert len(notes) == 1
+    assert "model not multimodal" in notes[0]
+
+
+@pytest.mark.asyncio
+async def test_prepare_attachments_document_failure_degrades_to_note():
+    runner = AgentRunner(user_id="u1")
+    attachments = [{"url": "file:///nope.pdf", "kind": "document", "name": "nope.pdf", "mime": "application/pdf"}]
+
+    with patch("app.services.extract.extract_text", new=AsyncMock(side_effect=OSError("boom"))):
+        doc_context, image_blocks, notes = await runner._prepare_attachments(attachments, "gpt-4o-mini")
+
+    assert doc_context == ""
+    assert len(notes) == 1
+    assert "could not read nope.pdf" in notes[0]
+
+
+@pytest.mark.asyncio
+async def test_prepare_attachments_empty():
+    runner = AgentRunner(user_id="u1")
+    assert await runner._prepare_attachments(None, "gpt-4o") == ("", [], [])
+
+
+# --- Run endpoint contract ----------------------------------------------------
+
+
+def test_run_request_body_wins_over_query_param():
+    body = RunRequest(input_text="from body", attachments=[])
+    assert body.input_text == "from body"
+
+
+def test_run_request_parses_attachments():
+    body = RunRequest.model_validate(
+        {
+            "input_text": "review these",
+            "attachments": [
+                {"url": "https://x/a.pdf", "kind": "document", "name": "a.pdf", "mime": "application/pdf"},
+                {"url": "https://x/b.png", "kind": "image", "name": "b.png", "mime": "image/png"},
+            ],
+        }
+    )
+    assert len(body.attachments) == 2
+    assert body.attachments[0].kind == "document"
+    assert body.attachments[1].kind == "image"
+
+
+def test_attachment_rejects_unknown_kind():
+    with pytest.raises(ValueError):
+        Attachment(url="x", kind="video", name="v.mp4", mime="video/mp4")  # type: ignore[arg-type]
+
+
+def _run_endpoint_setup(mock_db, *, agent_steps=None):
+    """Wire a mock db so POST /api/agents/agent-1/run reaches the runner."""
+    mock_user = MagicMock()
+    mock_user.user = MagicMock(id="test-user-id-123")
+    mock_db.auth.get_user.return_value = mock_user
+
+    mock_agent = MagicMock()
+    mock_agent.data = {
+        "id": "agent-1",
+        "user_id": "test-user-id-123",
+        "name": "Vision Agent",
+        "system_prompt": "look",
+        "tools": [],
+        "workflow_steps": agent_steps or [],
+        "model": "gpt-4o",
+    }
+    mock_db.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = mock_agent
+    mock_db.table.return_value.insert.return_value.execute.return_value = MagicMock(data=[{"id": "run-1"}])
+
+
+def test_run_endpoint_accepts_attachments_body(client):
+    """A JSON body with attachments is parsed and forwarded to the runner."""
+    captured = {}
+
+    with patch("app.db._db") as mock_db:
+        _run_endpoint_setup(mock_db)
+
+        with patch("app.routers.runs.AgentRunner") as mock_runner_cls:
+            mock_runner = MagicMock()
+
+            async def fake_execute(agent_config, input_text, **kwargs):
+                captured["input_text"] = input_text
+                captured["attachments"] = kwargs.get("attachments")
+                yield {"type": "step", "content": "ok", "tokens": 0}
+
+            mock_runner.execute = fake_execute
+            mock_runner_cls.return_value = mock_runner
+
+            resp = client.post(
+                "/api/agents/agent-1/run?token=t&input_text=ignored",
+                json={
+                    "input_text": "from body",
+                    "attachments": [
+                        {"url": "https://x/p.pdf", "kind": "document", "name": "p.pdf", "mime": "application/pdf"}
+                    ],
+                },
+            )
+
+    assert resp.status_code == 200
+    # Body input_text wins over the query param.
+    assert captured["input_text"] == "from body"
+    assert captured["attachments"][0]["name"] == "p.pdf"
+
+
+def test_run_endpoint_backcompat_query_param_only(client):
+    """Old callers (query param, no body) still work and get no attachments."""
+    captured = {}
+
+    with patch("app.db._db") as mock_db:
+        _run_endpoint_setup(mock_db)
+
+        with patch("app.routers.runs.AgentRunner") as mock_runner_cls:
+            mock_runner = MagicMock()
+
+            async def fake_execute(agent_config, input_text, **kwargs):
+                captured["input_text"] = input_text
+                captured["attachments"] = kwargs.get("attachments")
+                yield {"type": "step", "content": "ok", "tokens": 0}
+
+            mock_runner.execute = fake_execute
+            mock_runner_cls.return_value = mock_runner
+
+            resp = client.post("/api/agents/agent-1/run?token=t&input_text=hello")
+
+    assert resp.status_code == 200
+    assert captured["input_text"] == "hello"
+    assert captured["attachments"] == []


### PR DESCRIPTION
## Summary

**PR-1** of the Dashboard Command Composer series (spec: `forge-dashboard-composer-spec.md`). Lets a run carry images + documents without breaking existing callers.

- `POST /api/agents/{id}/run` now accepts an optional JSON body `{ input_text?, attachments? }` where `Attachment = { url, kind: "image"|"document", name, mime }`. The `input_text` **query param still works** for CLI/trigger callers; the body wins when both are present.
- `BlueprintRunRequest` gains an `attachments` field (threaded into the run's `input_payload`).
- **Agent runner** (`agent_executor.py`):
  - **Documents** → text extracted and prepended to context with a `--- file: {name} ---` header.
  - **Images** → passed to vision-capable models as OpenAI-style multimodal content blocks; non-multimodal models get a `[image omitted: model not multimodal]` note instead of an error. Image passthrough is restricted to OpenAI-style models so Anthropic/Ollama never receive a content schema they can't parse.
- **Shared extractor** factored into `services/extract.py::extract_text(file_url)` — one code path for the `fetch_document` node, the `document_reader` tool, and the runner. Handles `http(s)` URLs and local file refs (`file://` / bare paths) for the uploads backend landing in PR-2.

## Tests

`tests/test_attachments.py` (15 tests): extractor over txt/docx/file-uri + length cap; vision detection; attachment prep (docs→context, images→blocks/note, failure→note); run-endpoint body parsing, **body-wins-over-query-param**, and **query-param-only back-compat**.

## Verification

- `ruff check app/` ✅  `mypy app/` ✅  `pytest tests/` ✅ (644 passed; the 5 `test_e2e_v18_v19` CLI failures are pre-existing on `main` — stale tests from the CLI workspace refactor, skipped in CI which has no `typer`).
- No frontend changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)