### PR TITLE
feat(web): dashboard composer + streamed dispatch thread

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { DashboardComposer } from "@/components/dashboard/DashboardComposer";
 import { LiveStatusSection } from "@/components/dashboard/sections/LiveStatusSection";
 import { UsageCostSection } from "@/components/dashboard/sections/UsageCostSection";
 import { RecentRunsSection } from "@/components/dashboard/sections/RecentRunsSection";
@@ -60,6 +61,7 @@ export default function DashboardPage() {
         </div>
       </div>
 
+      <DashboardComposer />
       <LiveStatusSection onConnectedChange={handleConnectedChange} />
       <UsageCostSection />
       <RecentRunsSection />

--- a/frontend/components/dashboard/Composer.tsx
+++ b/frontend/components/dashboard/Composer.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useRef, useState, type KeyboardEvent } from "react";
+import { Paperclip, Mic, ArrowUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+interface ComposerProps {
+  onSend: (message: string) => void;
+  busy?: boolean;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+/**
+ * Dashboard command composer. Type a task and a dispatcher agent routes it to
+ * the right agent/blueprint. Enter sends; Shift+Enter inserts a newline. The
+ * attach + mic buttons are present but disabled until PR-5 (uploads) / PR-6
+ * (voice) wire them up.
+ */
+export function Composer({ onSend, busy = false, disabled = false, placeholder }: ComposerProps) {
+  const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const submit = () => {
+    const message = value.trim();
+    if (!message || busy || disabled) return;
+    onSend(message);
+    setValue("");
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <div className="rounded-xl border bg-card p-3 shadow-sm">
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        rows={2}
+        placeholder={
+          placeholder ?? "Describe a task — e.g. “summarize the latest run failures” — and it’ll route to the right agent."
+        }
+        className="min-h-[44px] resize-none border-0 bg-transparent p-1 shadow-none focus-visible:ring-0"
+        aria-label="Command composer"
+      />
+      <div className="mt-2 flex items-center justify-between">
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            disabled
+            title="Attach files (coming soon)"
+            aria-label="Attach files"
+          >
+            <Paperclip />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            disabled
+            title="Voice input (coming soon)"
+            aria-label="Voice input"
+          >
+            <Mic />
+          </Button>
+        </div>
+        <Button
+          type="button"
+          size="icon"
+          onClick={submit}
+          disabled={busy || disabled || !value.trim()}
+          title={disabled ? "Dispatch is disabled in demo mode" : "Send (Enter)"}
+          aria-label="Send"
+        >
+          <ArrowUp />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/DashboardComposer.tsx
+++ b/frontend/components/dashboard/DashboardComposer.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { api, type DispatchEvent } from "@/lib/api";
+import { getToken } from "@/lib/auth-client";
+import { isDemoMode } from "@/lib/demo-data";
+import { Composer } from "./Composer";
+import { DispatchThread, type ThreadState } from "./DispatchThread";
+
+function newThreadId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
+  return `th-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+function stepText(data: { step: number; result: string } | string): string {
+  if (typeof data === "string") return data;
+  return data.result || `Step ${data.step}`;
+}
+
+/**
+ * Owns the dispatch turn: sends the message to /api/dispatch, consumes the
+ * typed SSE events, and feeds <Composer/> + <DispatchThread/>. Routed runs go
+ * through the normal run path, so the metric sections below refresh on their
+ * own existing stream.
+ */
+export function DashboardComposer() {
+  const [thread, setThread] = useState<ThreadState | null>(null);
+  const [busy, setBusy] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const demo = typeof window !== "undefined" && isDemoMode();
+
+  const runDispatch = useCallback(async (message: string, threadId: string) => {
+    if (demo) {
+      setThread({
+        status: "error",
+        message,
+        steps: [],
+        output: "",
+        errorText: "Dispatch is disabled in demo mode — connect a backend to route tasks.",
+      });
+      return;
+    }
+
+    const token = await getToken();
+    if (!token) {
+      setThread({ status: "error", message, steps: [], output: "", errorText: "Not authenticated." });
+      return;
+    }
+
+    setBusy(true);
+    setThread({ status: "routing", message, steps: [], output: "", threadId });
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const onEvent = (event: DispatchEvent) => {
+      setThread((prev) => {
+        if (!prev) return prev;
+        switch (event.type) {
+          case "routing":
+            return { ...prev, status: "running", target: event.target, rationale: event.rationale };
+          case "step":
+            return { ...prev, status: "running", steps: [...prev.steps, stepText(event.data)] };
+          case "token":
+            return { ...prev, status: "running", output: prev.output + event.data };
+          case "clarify":
+            return { ...prev, status: "clarify", clarifyQuestion: event.question, threadId: event.thread_id ?? prev.threadId };
+          case "none":
+            return { ...prev, status: "none", noneMessage: event.message };
+          case "done":
+            return { ...prev, status: "done", runId: event.run_id };
+          case "error":
+            return { ...prev, status: "error", errorText: event.data };
+          default:
+            return prev;
+        }
+      });
+    };
+
+    try {
+      await api.dispatch.send({ message, thread_id: threadId }, token, onEvent, controller.signal);
+    } catch (err) {
+      if (err instanceof Error && err.name !== "AbortError") {
+        setThread((prev) =>
+          prev ? { ...prev, status: "error", errorText: err.message } : prev,
+        );
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [demo]);
+
+  const handleSend = useCallback(
+    (message: string) => {
+      void runDispatch(message, newThreadId());
+    },
+    [runDispatch],
+  );
+
+  const handleClarifyReply = useCallback(
+    (reply: string, threadId: string | null | undefined) => {
+      const original = thread?.message ? `${thread.message}\n\n${reply}` : reply;
+      void runDispatch(original, threadId || newThreadId());
+    },
+    [runDispatch, thread?.message],
+  );
+
+  return (
+    <section className="space-y-3" aria-label="Command composer">
+      <Composer onSend={handleSend} busy={busy} disabled={demo} />
+      <DispatchThread thread={thread} onClarifyReply={handleClarifyReply} busy={busy} />
+    </section>
+  );
+}

--- a/frontend/components/dashboard/DispatchThread.tsx
+++ b/frontend/components/dashboard/DispatchThread.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, type KeyboardEvent } from "react";
+import Link from "next/link";
+import { ArrowRight, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+export interface ThreadState {
+  status: "idle" | "routing" | "running" | "clarify" | "none" | "error" | "done";
+  message: string; // the user's submitted message
+  target?: { type: "agent" | "blueprint"; id: string } | null;
+  rationale?: string;
+  steps: string[];
+  output: string;
+  runId?: string | null;
+  clarifyQuestion?: string;
+  threadId?: string | null;
+  errorText?: string;
+  noneMessage?: string;
+}
+
+interface DispatchThreadProps {
+  thread: ThreadState | null;
+  onClarifyReply: (reply: string, threadId: string | null | undefined) => void;
+  busy: boolean;
+}
+
+/**
+ * Renders a single dispatch turn: the routing decision, live step/token
+ * output, and a link to the full run — plus clarify / none / error states.
+ */
+export function DispatchThread({ thread, onClarifyReply, busy }: DispatchThreadProps) {
+  const [reply, setReply] = useState("");
+
+  if (!thread) return null;
+
+  const handleReplyKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      const r = reply.trim();
+      if (!r) return;
+      onClarifyReply(r, thread.threadId);
+      setReply("");
+    }
+  };
+
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm" data-testid="dispatch-thread">
+      {/* The user's message */}
+      <p className="text-sm text-muted-foreground">
+        <span className="font-medium text-foreground">You:</span> {thread.message}
+      </p>
+
+      {/* Routing header */}
+      {(thread.status === "routing" || thread.target) && (
+        <div className="mt-3 flex items-start gap-2 text-sm">
+          {thread.status === "routing" ? (
+            <span className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Routing…
+            </span>
+          ) : (
+            <span className="flex flex-wrap items-center gap-1">
+              <span className="text-muted-foreground">Routing</span>
+              <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="rounded bg-accent px-1.5 py-0.5 font-medium capitalize">
+                {thread.target?.type}: {thread.target?.id?.slice(0, 8)}
+              </span>
+              {thread.rationale && (
+                <span className="text-muted-foreground">— {thread.rationale}</span>
+              )}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Step log */}
+      {thread.steps.length > 0 && (
+        <ul className="mt-3 space-y-1 text-xs text-muted-foreground">
+          {thread.steps.map((s, i) => (
+            <li key={i} className="flex items-center gap-2">
+              <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" />
+              {s}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Streamed output */}
+      {thread.output && (
+        <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-sm">
+          {thread.output}
+        </pre>
+      )}
+
+      {/* Running indicator */}
+      {thread.status === "running" && (
+        <p className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" /> Running…
+        </p>
+      )}
+
+      {/* Clarify */}
+      {thread.status === "clarify" && (
+        <div className="mt-3 space-y-2">
+          <p className="text-sm">{thread.clarifyQuestion}</p>
+          <div className="flex gap-2">
+            <Textarea
+              value={reply}
+              onChange={(e) => setReply(e.target.value)}
+              onKeyDown={handleReplyKey}
+              rows={1}
+              placeholder="Reply…"
+              className="min-h-[40px] resize-none"
+              aria-label="Clarify reply"
+            />
+            <Button
+              type="button"
+              disabled={busy || !reply.trim()}
+              onClick={() => {
+                onClarifyReply(reply.trim(), thread.threadId);
+                setReply("");
+              }}
+            >
+              Reply
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* No match */}
+      {thread.status === "none" && (
+        <p className="mt-3 text-sm text-muted-foreground">
+          {thread.noneMessage || "No matching agent or blueprint."}
+        </p>
+      )}
+
+      {/* Error */}
+      {thread.status === "error" && (
+        <p className="mt-3 text-sm text-destructive">{thread.errorText || "Something went wrong."}</p>
+      )}
+
+      {/* Done — link to the full run in Operations */}
+      {thread.status === "done" && thread.runId && (
+        <div className="mt-3">
+          <Link
+            href={`/dashboard/runs/${thread.runId}`}
+            className="text-sm font-medium text-primary hover:underline"
+          >
+            View full run →
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/DispatchThread.tsx
+++ b/frontend/components/dashboard/DispatchThread.tsx
@@ -140,14 +140,14 @@ export function DispatchThread({ thread, onClarifyReply, busy }: DispatchThreadP
         <p className="mt-3 text-sm text-destructive">{thread.errorText || "Something went wrong."}</p>
       )}
 
-      {/* Done — link to the full run in Operations */}
+      {/* Done — link to the run in the Operations workspace. There is no
+          per-run detail route, so we deep-link to Operations (the run shows in
+          its list) rather than a 404. */}
       {thread.status === "done" && thread.runId && (
-        <div className="mt-3">
-          <Link
-            href={`/dashboard/runs/${thread.runId}`}
-            className="text-sm font-medium text-primary hover:underline"
-          >
-            View full run →
+        <div className="mt-3 flex items-center gap-3">
+          <span className="text-xs text-muted-foreground">Run {thread.runId.slice(0, 8)}</span>
+          <Link href="/dashboard/ops" className="text-sm font-medium text-primary hover:underline">
+            View in Operations →
           </Link>
         </div>
       )}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -60,6 +60,23 @@ export interface Attachment {
   mime: string;
 }
 
+export type DispatchEvent =
+  | { type: "routing"; target: { type: "agent" | "blueprint"; id: string }; rationale: string }
+  | { type: "step"; data: { step: number; result: string; duration_ms?: number } | string }
+  | { type: "token"; data: string }
+  | { type: "clarify"; question: string; thread_id?: string | null }
+  | { type: "none"; message: string }
+  | { type: "done"; run_id: string }
+  | { type: "error"; data: string };
+
+export interface DispatchBody {
+  message: string;
+  attachments?: Attachment[];
+  thread_id?: string | null;
+  target_type?: "agent" | "blueprint";
+  target_id?: string;
+}
+
 export interface AgentCreate {
   name: string;
   description: string;
@@ -413,6 +430,50 @@ export const api = {
     get: (id: string, token: string) => request<Run>(`/api/runs/${id}`, { token }),
     start: (agentId: string, input: { text?: string; file_url?: string }, token: string) => {
       return `${API_URL}/api/agents/${agentId}/run?token=${encodeURIComponent(token)}&input_text=${encodeURIComponent(input.text || "")}`;
+    },
+  },
+  dispatch: {
+    // Routes a message and streams the resulting run back. Parses typed SSE
+    // events (`data: {json}\n\n`) and invokes onEvent for each. Resolves when
+    // the stream ends; throws on a non-OK response (rate limit, provider error).
+    send: async (
+      body: DispatchBody,
+      token: string,
+      onEvent: (event: DispatchEvent) => void,
+      signal?: AbortSignal,
+    ): Promise<void> => {
+      const res = await fetch(`${API_URL}/api/dispatch?token=${encodeURIComponent(token)}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ detail: res.statusText }));
+        throw new Error(err.detail || "Dispatch failed");
+      }
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error("No response stream");
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const data = line.slice(6).trim();
+          if (!data || data === "[DONE]") continue;
+          try {
+            onEvent(JSON.parse(data) as DispatchEvent);
+          } catch {
+            // Skip malformed frames.
+          }
+        }
+      }
     },
   },
   uploads: {

--- a/frontend/tests/composer.test.tsx
+++ b/frontend/tests/composer.test.tsx
@@ -86,8 +86,8 @@ describe("DispatchThread", () => {
     expect(screen.getByText(/summarize failures/)).toBeInTheDocument();
     expect(screen.getByText(/it summarizes failures/)).toBeInTheDocument();
     expect(screen.getByText("All clear.")).toBeInTheDocument();
-    const link = screen.getByText("View full run →").closest("a");
-    expect(link).toHaveAttribute("href", "/dashboard/runs/run-9");
+    const link = screen.getByText("View in Operations →").closest("a");
+    expect(link).toHaveAttribute("href", "/dashboard/ops");
   });
 
   it("renders a clarify reply box and submits the reply", async () => {

--- a/frontend/tests/composer.test.tsx
+++ b/frontend/tests/composer.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe("Composer", () => {
+  it("sends on Enter and clears, but not on Shift+Enter", async () => {
+    const { Composer } = await import("@/components/dashboard/Composer");
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+
+    const textarea = screen.getByLabelText("Command composer") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "summarize failures" } });
+
+    // Shift+Enter inserts a newline (does not send).
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+
+    // Enter sends.
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+    expect(onSend).toHaveBeenCalledWith("summarize failures");
+    expect(textarea.value).toBe("");
+  });
+
+  it("does not send empty/whitespace messages", async () => {
+    const { Composer } = await import("@/components/dashboard/Composer");
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} />);
+
+    const textarea = screen.getByLabelText("Command composer");
+    fireEvent.change(textarea, { target: { value: "   " } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("disables sending when disabled (e.g. demo mode)", async () => {
+    const { Composer } = await import("@/components/dashboard/Composer");
+    const onSend = vi.fn();
+    render(<Composer onSend={onSend} disabled />);
+
+    const textarea = screen.getByLabelText("Command composer");
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("keeps attach + mic disabled until PR-5/PR-6", async () => {
+    const { Composer } = await import("@/components/dashboard/Composer");
+    render(<Composer onSend={vi.fn()} />);
+    expect(screen.getByLabelText("Attach files")).toBeDisabled();
+    expect(screen.getByLabelText("Voice input")).toBeDisabled();
+  });
+});
+
+describe("DispatchThread", () => {
+  it("renders nothing when there is no thread", async () => {
+    const { DispatchThread } = await import("@/components/dashboard/DispatchThread");
+    const { container } = render(
+      <DispatchThread thread={null} onClarifyReply={vi.fn()} busy={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows routing header, output, and a run link when done", async () => {
+    const { DispatchThread } = await import("@/components/dashboard/DispatchThread");
+    render(
+      <DispatchThread
+        thread={{
+          status: "done",
+          message: "summarize failures",
+          target: { type: "agent", id: "agent-123456789" },
+          rationale: "it summarizes failures",
+          steps: ["Step 1: read logs"],
+          output: "All clear.",
+          runId: "run-9",
+        }}
+        onClarifyReply={vi.fn()}
+        busy={false}
+      />,
+    );
+
+    expect(screen.getByText(/summarize failures/)).toBeInTheDocument();
+    expect(screen.getByText(/it summarizes failures/)).toBeInTheDocument();
+    expect(screen.getByText("All clear.")).toBeInTheDocument();
+    const link = screen.getByText("View full run →").closest("a");
+    expect(link).toHaveAttribute("href", "/dashboard/runs/run-9");
+  });
+
+  it("renders a clarify reply box and submits the reply", async () => {
+    const { DispatchThread } = await import("@/components/dashboard/DispatchThread");
+    const onClarifyReply = vi.fn();
+    render(
+      <DispatchThread
+        thread={{
+          status: "clarify",
+          message: "make a report",
+          steps: [],
+          output: "",
+          clarifyQuestion: "Which report?",
+          threadId: "th-1",
+        }}
+        onClarifyReply={onClarifyReply}
+        busy={false}
+      />,
+    );
+
+    expect(screen.getByText("Which report?")).toBeInTheDocument();
+    const reply = screen.getByLabelText("Clarify reply");
+    fireEvent.change(reply, { target: { value: "the weekly one" } });
+    fireEvent.click(screen.getByText("Reply"));
+    expect(onClarifyReply).toHaveBeenCalledWith("the weekly one", "th-1");
+  });
+
+  it("shows the none and error states", async () => {
+    const { DispatchThread } = await import("@/components/dashboard/DispatchThread");
+    const { rerender } = render(
+      <DispatchThread
+        thread={{ status: "none", message: "x", steps: [], output: "", noneMessage: "No agent fits." }}
+        onClarifyReply={vi.fn()}
+        busy={false}
+      />,
+    );
+    expect(screen.getByText("No agent fits.")).toBeInTheDocument();
+
+    rerender(
+      <DispatchThread
+        thread={{ status: "error", message: "x", steps: [], output: "", errorText: "Boom." }}
+        onClarifyReply={vi.fn()}
+        busy={false}
+      />,
+    );
+    expect(screen.getByText("Boom.")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

**PR-4** of the Dashboard Command Composer series — the first end-to-end, visible text dispatch on the dashboard.

- **`Composer.tsx`** — textarea + send; **Enter sends, Shift+Enter newline**; attach + mic buttons present but **disabled** until PR-5 (uploads) / PR-6 (voice).
- **`DispatchThread.tsx`** — `Routing → {target} ({rationale})` header, live step/token output, a **"View full run →"** link into Operations, plus an inline **clarify** reply box (reuses `thread_id`) and `none`/`error` states.
- **`DashboardComposer.tsx`** — container that owns the turn: consumes the typed `/api/dispatch` SSE events and feeds both components. **Disabled in demo mode** (no backend to route to).
- **`lib/api.ts`** — `api.dispatch.send(body, token, onEvent, signal)` SSE consumer mirroring the existing run-stream reader, + `DispatchEvent`/`DispatchBody` types.
- Mounted **above** `LiveStatusSection`. The metric sections are untouched — they refresh from their existing `/api/dashboard/stream` as the routed run runs (the dispatch goes through the normal run path, so heartbeats fire).

## Tests

`tests/composer.test.tsx` (8): Composer Enter-sends / Shift+Enter-newline / empty-guard / disabled-in-demo / attach+mic disabled; DispatchThread null-render / done-with-run-link / clarify-reply submit / none+error states.

## Verification

- `tsc --noEmit` ✅  `bun run lint` ✅  `bun run test` ✅ (42 passed).
- **Demo-parity e2e** run locally against a `NEXT_PUBLIC_FORCE_DEMO=true` production build: `/dashboard loads with seed data` ✅ — the composer mounts with **no fatal console errors** in demo mode.
- Live end-to-end (backend + Ollama routing) validated separately on the local stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)