### PR TITLE
feat: attachments end-to-end (images multimodal + doc extraction)

### DIFF
--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -69,7 +69,9 @@ async def dispatch(
                     rationale="Target chosen by user.",
                 )
             else:
-                decision = await dispatcher.route(user_id, body.message)
+                # PR-5: let routing see attachment names + document previews.
+                attachments_summary = await dispatcher.build_attachments_summary(attachments)
+                decision = await dispatcher.route(user_id, body.message, attachments_summary)
 
             if decision.action == "clarify":
                 yield _sse({"type": "clarify", "question": decision.clarifying_question, "thread_id": body.thread_id})

--- a/backend/app/services/dispatcher.py
+++ b/backend/app/services/dispatcher.py
@@ -75,6 +75,33 @@ def build_catalog(user_id: str) -> list[CatalogEntry]:
     return entries
 
 
+async def build_attachments_summary(attachments: list[dict]) -> str:
+    """A short summary of attachments for the routing prompt.
+
+    Lists each attachment's name + kind, and for documents includes the first
+    ~500 chars of extracted text so routing can use file content (PR-5).
+    """
+    if not attachments:
+        return ""
+
+    from app.services.extract import extract_text
+
+    lines: list[str] = []
+    for att in attachments:
+        name = att.get("name") or att.get("url", "")
+        kind = att.get("kind", "file")
+        if kind == "document":
+            try:
+                text = await extract_text(att.get("url", ""))
+                preview = text[:500].strip().replace("\n", " ")
+                lines.append(f"- {name} (document): {preview}")
+            except Exception:
+                lines.append(f"- {name} (document): <unreadable>")
+        else:
+            lines.append(f"- {name} ({kind})")
+    return "\n".join(lines)
+
+
 def _format_catalog(catalog: list[CatalogEntry]) -> str:
     lines = []
     for e in catalog:

--- a/backend/tests/test_dispatcher.py
+++ b/backend/tests/test_dispatcher.py
@@ -117,6 +117,35 @@ async def test_route_tracks_tokens_with_null_run_and_agent():
     assert kwargs["step_number"] == 0
 
 
+# --- attachments summary (PR-5) -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_attachments_summary_includes_doc_preview():
+    attachments = [
+        {"url": "file:///r.pdf", "kind": "document", "name": "r.pdf", "mime": "application/pdf"},
+        {"url": "data:image/png;base64,AAA", "kind": "image", "name": "shot.png", "mime": "image/png"},
+    ]
+    with patch("app.services.extract.extract_text", new=AsyncMock(return_value="Quarterly revenue grew 20%.")):
+        summary = await dispatcher.build_attachments_summary(attachments)
+
+    assert "r.pdf (document): Quarterly revenue grew 20%." in summary
+    assert "shot.png (image)" in summary
+
+
+@pytest.mark.asyncio
+async def test_build_attachments_summary_empty():
+    assert await dispatcher.build_attachments_summary([]) == ""
+
+
+@pytest.mark.asyncio
+async def test_build_attachments_summary_handles_unreadable_doc():
+    attachments = [{"url": "file:///x.pdf", "kind": "document", "name": "x.pdf", "mime": "application/pdf"}]
+    with patch("app.services.extract.extract_text", new=AsyncMock(side_effect=OSError("nope"))):
+        summary = await dispatcher.build_attachments_summary(attachments)
+    assert "x.pdf (document): <unreadable>" in summary
+
+
 # --- /api/dispatch endpoint ---------------------------------------------------
 
 

--- a/frontend/components/dashboard/Composer.tsx
+++ b/frontend/components/dashboard/Composer.tsx
@@ -1,32 +1,48 @@
 "use client";
 
-import { useRef, useState, type KeyboardEvent } from "react";
-import { Paperclip, Mic, ArrowUp } from "lucide-react";
+import { useRef, useState, type KeyboardEvent, type ChangeEvent } from "react";
+import { Paperclip, Mic, ArrowUp, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 
 interface ComposerProps {
-  onSend: (message: string) => void;
+  onSend: (message: string, files: File[]) => void;
   busy?: boolean;
   disabled?: boolean;
   placeholder?: string;
 }
 
+// Images + the document types the upload endpoint + extractor accept.
+const ACCEPT = "image/*,.pdf,.docx,.txt,.md";
+
 /**
  * Dashboard command composer. Type a task and a dispatcher agent routes it to
  * the right agent/blueprint. Enter sends; Shift+Enter inserts a newline. The
- * attach + mic buttons are present but disabled until PR-5 (uploads) / PR-6
- * (voice) wire them up.
+ * mic button is present but disabled until PR-6 (voice) wires it up.
  */
 export function Composer({ onSend, busy = false, disabled = false, placeholder }: ComposerProps) {
   const [value, setValue] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const submit = () => {
     const message = value.trim();
-    if (!message || busy || disabled) return;
-    onSend(message);
+    if ((!message && files.length === 0) || busy || disabled) return;
+    onSend(message, files);
     setValue("");
+    setFiles([]);
+  };
+
+  const onFilesPicked = (e: ChangeEvent<HTMLInputElement>) => {
+    const picked = Array.from(e.target.files ?? []);
+    if (picked.length) setFiles((prev) => [...prev, ...picked]);
+    // Reset so picking the same file again re-fires onChange.
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const removeFile = (index: number) => {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -51,14 +67,49 @@ export function Composer({ onSend, busy = false, disabled = false, placeholder }
         className="min-h-[44px] resize-none border-0 bg-transparent p-1 shadow-none focus-visible:ring-0"
         aria-label="Command composer"
       />
+      {/* Attachment chips */}
+      {files.length > 0 && (
+        <ul className="mt-2 flex flex-wrap gap-2" aria-label="Attachments">
+          {files.map((f, i) => (
+            <li
+              key={`${f.name}-${i}`}
+              className="flex items-center gap-1 rounded-md border bg-muted px-2 py-1 text-xs"
+            >
+              <span className="max-w-[180px] truncate">{f.name}</span>
+              <button
+                type="button"
+                onClick={() => removeFile(i)}
+                disabled={busy}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label={`Remove ${f.name}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept={ACCEPT}
+        className="hidden"
+        onChange={onFilesPicked}
+        aria-hidden="true"
+        tabIndex={-1}
+      />
+
       <div className="mt-2 flex items-center justify-between">
         <div className="flex items-center gap-1">
           <Button
             type="button"
             variant="ghost"
             size="icon"
-            disabled
-            title="Attach files (coming soon)"
+            disabled={disabled || busy}
+            onClick={() => fileInputRef.current?.click()}
+            title="Attach images or documents"
             aria-label="Attach files"
           >
             <Paperclip />
@@ -78,7 +129,7 @@ export function Composer({ onSend, busy = false, disabled = false, placeholder }
           type="button"
           size="icon"
           onClick={submit}
-          disabled={busy || disabled || !value.trim()}
+          disabled={busy || disabled || (!value.trim() && files.length === 0)}
           title={disabled ? "Dispatch is disabled in demo mode" : "Send (Enter)"}
           aria-label="Send"
         >

--- a/frontend/components/dashboard/DashboardComposer.tsx
+++ b/frontend/components/dashboard/DashboardComposer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
-import { api, type DispatchEvent } from "@/lib/api";
+import { api, type Attachment, type DispatchEvent } from "@/lib/api";
 import { getToken } from "@/lib/auth-client";
 import { isDemoMode } from "@/lib/demo-data";
 import { Composer } from "./Composer";
@@ -29,7 +29,7 @@ export function DashboardComposer() {
   const abortRef = useRef<AbortController | null>(null);
   const demo = typeof window !== "undefined" && isDemoMode();
 
-  const runDispatch = useCallback(async (message: string, threadId: string) => {
+  const runDispatch = useCallback(async (message: string, threadId: string, attachments: Attachment[] = []) => {
     if (demo) {
       setThread({
         status: "error",
@@ -48,7 +48,7 @@ export function DashboardComposer() {
     }
 
     setBusy(true);
-    setThread({ status: "routing", message, steps: [], output: "", threadId });
+    setThread({ status: "routing", message, steps: [], output: "", threadId, attachments });
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -78,7 +78,12 @@ export function DashboardComposer() {
     };
 
     try {
-      await api.dispatch.send({ message, thread_id: threadId }, token, onEvent, controller.signal);
+      await api.dispatch.send(
+        { message, thread_id: threadId, attachments },
+        token,
+        onEvent,
+        controller.signal,
+      );
     } catch (err) {
       if (err instanceof Error && err.name !== "AbortError") {
         setThread((prev) =>
@@ -91,10 +96,48 @@ export function DashboardComposer() {
   }, [demo]);
 
   const handleSend = useCallback(
-    (message: string) => {
-      void runDispatch(message, newThreadId());
+    async (message: string, files: File[]) => {
+      const threadId = newThreadId();
+      if (files.length === 0) {
+        void runDispatch(message, threadId);
+        return;
+      }
+
+      if (demo) {
+        setThread({
+          status: "error",
+          message,
+          steps: [],
+          output: "",
+          errorText: "Uploads are disabled in demo mode.",
+        });
+        return;
+      }
+
+      const token = await getToken();
+      if (!token) {
+        setThread({ status: "error", message, steps: [], output: "", errorText: "Not authenticated." });
+        return;
+      }
+
+      // Upload first, then dispatch with the returned refs.
+      setBusy(true);
+      setThread({ status: "routing", message, steps: ["Uploading attachments…"], output: "", threadId });
+      try {
+        const attachments = await api.uploads.files(files, token);
+        await runDispatch(message, threadId, attachments);
+      } catch (err) {
+        setBusy(false);
+        setThread({
+          status: "error",
+          message,
+          steps: [],
+          output: "",
+          errorText: err instanceof Error ? err.message : "Upload failed.",
+        });
+      }
     },
-    [runDispatch],
+    [runDispatch, demo],
   );
 
   const handleClarifyReply = useCallback(

--- a/frontend/components/dashboard/DispatchThread.tsx
+++ b/frontend/components/dashboard/DispatchThread.tsx
@@ -2,13 +2,15 @@
 
 import { useState, type KeyboardEvent } from "react";
 import Link from "next/link";
-import { ArrowRight, Loader2 } from "lucide-react";
+import { ArrowRight, Loader2, Paperclip } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import type { Attachment } from "@/lib/api";
 
 export interface ThreadState {
   status: "idle" | "routing" | "running" | "clarify" | "none" | "error" | "done";
   message: string; // the user's submitted message
+  attachments?: Attachment[];
   target?: { type: "agent" | "blueprint"; id: string } | null;
   rationale?: string;
   steps: string[];
@@ -51,6 +53,21 @@ export function DispatchThread({ thread, onClarifyReply, busy }: DispatchThreadP
       <p className="text-sm text-muted-foreground">
         <span className="font-medium text-foreground">You:</span> {thread.message}
       </p>
+
+      {/* Attachments on the user's turn */}
+      {thread.attachments && thread.attachments.length > 0 && (
+        <ul className="mt-1 flex flex-wrap gap-2">
+          {thread.attachments.map((a, i) => (
+            <li
+              key={`${a.name}-${i}`}
+              className="flex items-center gap-1 rounded border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+            >
+              <Paperclip className="h-3 w-3" />
+              <span className="max-w-[180px] truncate">{a.name}</span>
+            </li>
+          ))}
+        </ul>
+      )}
 
       {/* Routing header */}
       {(thread.status === "routing" || thread.target) && (

--- a/frontend/tests/composer.test.tsx
+++ b/frontend/tests/composer.test.tsx
@@ -20,9 +20,9 @@ describe("Composer", () => {
     fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
     expect(onSend).not.toHaveBeenCalled();
 
-    // Enter sends.
+    // Enter sends (message + empty file list).
     fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
-    expect(onSend).toHaveBeenCalledWith("summarize failures");
+    expect(onSend).toHaveBeenCalledWith("summarize failures", []);
     expect(textarea.value).toBe("");
   });
 
@@ -48,11 +48,27 @@ describe("Composer", () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
-  it("keeps attach + mic disabled until PR-5/PR-6", async () => {
+  it("enables attach (PR-5) and keeps mic disabled until PR-6", async () => {
     const { Composer } = await import("@/components/dashboard/Composer");
     render(<Composer onSend={vi.fn()} />);
-    expect(screen.getByLabelText("Attach files")).toBeDisabled();
+    expect(screen.getByLabelText("Attach files")).not.toBeDisabled();
     expect(screen.getByLabelText("Voice input")).toBeDisabled();
+  });
+
+  it("shows a chip for an attached file and can send with attachments", async () => {
+    const { Composer } = await import("@/components/dashboard/Composer");
+    const onSend = vi.fn();
+    const { container } = render(<Composer onSend={onSend} />);
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["hello"], "notes.txt", { type: "text/plain" });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(screen.getByText("notes.txt")).toBeInTheDocument();
+
+    // Sending with only an attachment (no text) is allowed.
+    fireEvent.click(screen.getByLabelText("Send"));
+    expect(onSend).toHaveBeenCalledWith("", [file]);
   });
 });
 


### PR DESCRIPTION
## Summary

**PR-5** of the Dashboard Command Composer series — wires uploads through the composer → dispatch → run.

- **Composer**: attach button enabled (`accept` images + pdf/docx/txt/md), removable attachment chips, uploads files via `api.uploads.files` **before** dispatch and passes the returned `Attachment[]` in the dispatch body. Attachments-only (no text) sends are allowed.
- **DispatchThread**: shows the attachments on the user's turn.
- **Dispatcher**: `build_attachments_summary()` adds attachment names + kinds and the **first ~500 chars of extracted document text** to the routing prompt, so routing can use file content; the full `attachments` pass through to the chosen run (consumed by the PR-1 run path — docs → context, images → multimodal blocks for vision models).

## Live verification (local Ollama stack)

- Uploaded a TXT report → dispatched → the **routed run's output referenced the document's actual figures** ("20% increase in revenue to $4.2M", "churn to 1.1%", "hire two engineers") — proving extracted text reaches the run context.
- A generic "summarize this report" correctly **clarified** (neither seeded agent cleanly fits), and the clarify question referenced the document — proving the summary reached routing.
- Images degrade to a `[image omitted: model not multimodal]` note on the non-vision Ollama models (vision passthrough is unit-tested).

## Tests

Backend `test_dispatcher.py` +3 (`build_attachments_summary`: doc preview, empty, unreadable). Frontend `composer.test.tsx` +1 / updated (attach enabled, file chip shown, send-with-attachment); `onSend(message, files)` signature.

## Verification

`ruff` ✅ `mypy` ✅ `pytest` ✅ (674 passed; same 5 pre-existing CLI failures). `tsc` ✅ `lint` ✅ `vitest` ✅ (43). Entropy pre-check ≤4.53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)