### PR TITLE
feat: voice input (transcribe endpoint + mic composer)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,6 +35,7 @@ from app.routers import (
     runs,
     targets,
     traces,
+    transcribe,
     triggers,
     uploads,
     workspaces,
@@ -122,6 +123,7 @@ app.include_router(computer_use.router, prefix="/api")
 app.include_router(targets.router, prefix="/api")
 app.include_router(recordings.router, prefix="/api")
 app.include_router(uploads.router, prefix="/api")
+app.include_router(transcribe.router, prefix="/api")
 app.include_router(workspaces.router, prefix="/api")
 app.include_router(ws_workspace.router)  # WebSocket (no /api prefix)
 

--- a/backend/app/routers/transcribe.py
+++ b/backend/app/routers/transcribe.py
@@ -1,0 +1,55 @@
+"""Voice transcription endpoint — Whisper via the user's existing OpenAI key."""
+
+import io
+
+from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
+
+from app.db import get_db
+from app.services.llm import get_user_openai_key
+from app.services.rate_limiter import limiter
+
+router = APIRouter(tags=["transcribe"])
+
+MAX_AUDIO_BYTES = 25 * 1024 * 1024  # OpenAI's audio upload cap
+
+
+@router.post("/transcribe")
+@limiter.limit("60/hour")
+async def transcribe(
+    request: Request,
+    token: str = Query(...),
+    file: UploadFile = File(...),  # noqa: B008
+):
+    """Transcribe an uploaded audio clip to text via OpenAI Whisper."""
+    # Verify token (dual Supabase/SQLite unwrap).
+    try:
+        user_response = get_db().auth.get_user(token)
+        user = user_response.user if hasattr(user_response, "user") else user_response
+        if not user or not getattr(user, "id", None):
+            raise HTTPException(status_code=401, detail="Invalid token")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=401, detail="Invalid or expired token") from exc
+
+    api_key = await get_user_openai_key(user.id)
+    if not api_key:
+        raise HTTPException(status_code=400, detail="Connect an OpenAI provider to use voice.")
+
+    data = await file.read()
+    if len(data) > MAX_AUDIO_BYTES:
+        raise HTTPException(status_code=413, detail="Audio clip is too large.")
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty audio upload.")
+
+    from openai import AsyncOpenAI
+
+    audio = io.BytesIO(data)
+    audio.name = file.filename or "audio.webm"
+    try:
+        client = AsyncOpenAI(api_key=api_key)
+        result = await client.audio.transcriptions.create(model="whisper-1", file=audio)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail="Transcription failed.") from exc
+
+    return {"text": getattr(result, "text", "")}

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -18,18 +18,12 @@ from app.providers.registry import provider_registry
 logger = logging.getLogger(__name__)
 
 
-async def get_user_llm(
-    user_id: str | None,
-    model: str | None = None,
-    *,
-    streaming: bool = True,
-    temperature: float = 0.0,
-) -> ChatOpenAI | None:
-    """Build a ChatOpenAI client from the user's OpenAI key, or None.
+async def get_user_openai_key(user_id: str | None) -> str | None:
+    """Resolve the user's OpenAI API key, or None.
 
     Resolution order: the user's enabled ``openai`` provider config, then the
-    ``OPENAI_API_KEY`` env var. Returns None when no OpenAI key is available
-    (callers fall back to the provider registry or surface a clear message).
+    ``OPENAI_API_KEY`` env var. This is the single OpenAI key path shared by the
+    runner, the dispatcher, and transcription.
     """
     api_key = os.getenv("OPENAI_API_KEY", "")
 
@@ -51,6 +45,22 @@ async def get_user_llm(
         except Exception:
             logger.debug("No user openai provider config for %s", user_id, exc_info=True)
 
+    return api_key or None
+
+
+async def get_user_llm(
+    user_id: str | None,
+    model: str | None = None,
+    *,
+    streaming: bool = True,
+    temperature: float = 0.0,
+) -> ChatOpenAI | None:
+    """Build a ChatOpenAI client from the user's OpenAI key, or None.
+
+    Returns None when no OpenAI key is available (callers fall back to the
+    provider registry or surface a clear message).
+    """
+    api_key = await get_user_openai_key(user_id)
     if not api_key:
         return None
 

--- a/backend/tests/test_transcribe.py
+++ b/backend/tests/test_transcribe.py
@@ -1,0 +1,64 @@
+"""PR-6 — voice transcription endpoint (Whisper via the user's OpenAI key)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _auth(mock_db):
+    mock_user = MagicMock()
+    mock_user.user = MagicMock(id="user-1")
+    mock_db.auth.get_user.return_value = mock_user
+
+
+def test_transcribe_returns_text(client):
+    fake_result = MagicMock(text="summarize the latest run failures")
+    fake_client = MagicMock()
+    fake_client.audio.transcriptions.create = AsyncMock(return_value=fake_result)
+
+    with patch("app.db._db") as mock_db, \
+         patch("app.routers.transcribe.get_user_openai_key", new=AsyncMock(return_value="sk-test")), \
+         patch("openai.AsyncOpenAI", return_value=fake_client):
+        _auth(mock_db)
+        resp = client.post(
+            "/api/transcribe?token=t",
+            files=[("file", ("audio.webm", b"fake-audio-bytes", "audio/webm"))],
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["text"] == "summarize the latest run failures"
+
+
+def test_transcribe_400_without_openai_key(client):
+    with patch("app.db._db") as mock_db, \
+         patch("app.routers.transcribe.get_user_openai_key", new=AsyncMock(return_value=None)):
+        _auth(mock_db)
+        resp = client.post(
+            "/api/transcribe?token=t",
+            files=[("file", ("audio.webm", b"fake-audio-bytes", "audio/webm"))],
+        )
+
+    assert resp.status_code == 400
+    assert "OpenAI" in resp.json()["detail"]
+
+
+def test_transcribe_rejects_empty_audio(client):
+    with patch("app.db._db") as mock_db, \
+         patch("app.routers.transcribe.get_user_openai_key", new=AsyncMock(return_value="sk-test")):
+        _auth(mock_db)
+        resp = client.post(
+            "/api/transcribe?token=t",
+            files=[("file", ("audio.webm", b"", "audio/webm"))],
+        )
+
+    assert resp.status_code == 400
+
+
+def test_transcribe_rejects_bad_token(client):
+    with patch("app.db._db") as mock_db:
+        mock_db.auth.get_user.side_effect = Exception("nope")
+        resp = client.post(
+            "/api/transcribe?token=bad",
+            files=[("file", ("audio.webm", b"x", "audio/webm"))],
+        )
+    assert resp.status_code == 401

--- a/frontend/components/dashboard/Composer.tsx
+++ b/frontend/components/dashboard/Composer.tsx
@@ -7,6 +7,9 @@ import { Textarea } from "@/components/ui/textarea";
 
 interface ComposerProps {
   onSend: (message: string, files: File[]) => void;
+  // When provided, the mic button is enabled: it records audio and calls this
+  // to get a transcript (PR-6). Omitted/undefined → mic stays disabled.
+  onTranscribe?: (blob: Blob) => Promise<string>;
   busy?: boolean;
   disabled?: boolean;
   placeholder?: string;
@@ -20,11 +23,16 @@ const ACCEPT = "image/*,.pdf,.docx,.txt,.md";
  * the right agent/blueprint. Enter sends; Shift+Enter inserts a newline. The
  * mic button is present but disabled until PR-6 (voice) wires it up.
  */
-export function Composer({ onSend, busy = false, disabled = false, placeholder }: ComposerProps) {
+export function Composer({ onSend, onTranscribe, busy = false, disabled = false, placeholder }: ComposerProps) {
   const [value, setValue] = useState("");
   const [files, setFiles] = useState<File[]>([]);
+  const [recording, setRecording] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const [micError, setMicError] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
 
   const submit = () => {
     const message = value.trim();
@@ -43,6 +51,53 @@ export function Composer({ onSend, busy = false, disabled = false, placeholder }
 
   const removeFile = (index: number) => {
     setFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const startRecording = async () => {
+    setMicError("");
+    if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+      setMicError("Recording isn’t supported in this browser.");
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const recorder = new MediaRecorder(stream);
+      chunksRef.current = [];
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      recorder.onstop = async () => {
+        stream.getTracks().forEach((t) => t.stop());
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        if (!onTranscribe || blob.size === 0) return;
+        setTranscribing(true);
+        try {
+          const text = await onTranscribe(blob);
+          if (text) {
+            setValue((prev) => (prev ? `${prev} ${text}` : text));
+            textareaRef.current?.focus();
+          }
+        } catch (err) {
+          setMicError(err instanceof Error ? err.message : "Transcription failed.");
+        } finally {
+          setTranscribing(false);
+        }
+      };
+      mediaRecorderRef.current = recorder;
+      recorder.start();
+      setRecording(true);
+    } catch {
+      setMicError("Microphone permission denied.");
+    }
+  };
+
+  const toggleMic = () => {
+    if (recording) {
+      mediaRecorderRef.current?.stop();
+      setRecording(false);
+    } else {
+      void startRecording();
+    }
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -116,14 +171,33 @@ export function Composer({ onSend, busy = false, disabled = false, placeholder }
           </Button>
           <Button
             type="button"
-            variant="ghost"
+            variant={recording ? "destructive" : "ghost"}
             size="icon"
-            disabled
-            title="Voice input (coming soon)"
-            aria-label="Voice input"
+            disabled={!onTranscribe || disabled || busy || transcribing}
+            onClick={toggleMic}
+            title={
+              !onTranscribe
+                ? "Voice input unavailable"
+                : recording
+                  ? "Stop recording"
+                  : "Record a voice command"
+            }
+            aria-label={recording ? "Stop recording" : "Voice input"}
+            aria-pressed={recording}
           >
-            <Mic />
+            <Mic className={recording ? "animate-pulse" : undefined} />
           </Button>
+          {recording && (
+            <span className="ml-1 flex items-center gap-1 text-xs text-destructive" role="status">
+              <span className="h-2 w-2 animate-pulse rounded-full bg-destructive" />
+              Recording…
+            </span>
+          )}
+          {transcribing && (
+            <span className="ml-1 text-xs text-muted-foreground" role="status">
+              Transcribing…
+            </span>
+          )}
         </div>
         <Button
           type="button"
@@ -136,6 +210,11 @@ export function Composer({ onSend, busy = false, disabled = false, placeholder }
           <ArrowUp />
         </Button>
       </div>
+      {micError && (
+        <p className="mt-1 text-xs text-destructive" role="alert">
+          {micError}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/components/dashboard/DashboardComposer.tsx
+++ b/frontend/components/dashboard/DashboardComposer.tsx
@@ -140,6 +140,12 @@ export function DashboardComposer() {
     [runDispatch, demo],
   );
 
+  const handleTranscribe = useCallback(async (blob: Blob): Promise<string> => {
+    const token = await getToken();
+    if (!token) throw new Error("Not authenticated.");
+    return api.transcribe.send(blob, token);
+  }, []);
+
   const handleClarifyReply = useCallback(
     (reply: string, threadId: string | null | undefined) => {
       const original = thread?.message ? `${thread.message}\n\n${reply}` : reply;
@@ -150,7 +156,12 @@ export function DashboardComposer() {
 
   return (
     <section className="space-y-3" aria-label="Command composer">
-      <Composer onSend={handleSend} busy={busy} disabled={demo} />
+      <Composer
+        onSend={handleSend}
+        onTranscribe={demo ? undefined : handleTranscribe}
+        busy={busy}
+        disabled={demo}
+      />
       <DispatchThread thread={thread} onClarifyReply={handleClarifyReply} busy={busy} />
     </section>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -476,6 +476,25 @@ export const api = {
       }
     },
   },
+  transcribe: {
+    // Sends a recorded audio blob to Whisper (via the user's OpenAI key) and
+    // returns the transcript. Throws with a clear message when no OpenAI key
+    // is configured (HTTP 400 from the backend).
+    send: async (blob: Blob, token: string): Promise<string> => {
+      const form = new FormData();
+      form.append("file", blob, "audio.webm");
+      const res = await fetch(`${API_URL}/api/transcribe?token=${encodeURIComponent(token)}`, {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ detail: res.statusText }));
+        throw new Error(err.detail || "Transcription failed");
+      }
+      const data = (await res.json()) as { text: string };
+      return data.text;
+    },
+  },
   uploads: {
     // Multipart upload — returns stable Attachment refs for the composer to
     // pass into a dispatch/run. Token rides as a query param (the request is

--- a/frontend/tests/composer.test.tsx
+++ b/frontend/tests/composer.test.tsx
@@ -55,6 +55,23 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Voice input")).toBeDisabled();
   });
 
+  it("enables the mic only when onTranscribe is provided", async () => {
+    const { Composer } = await import("@/components/dashboard/Composer");
+    const { rerender } = render(<Composer onSend={vi.fn()} />);
+    expect(screen.getByLabelText("Voice input")).toBeDisabled();
+
+    rerender(<Composer onSend={vi.fn()} onTranscribe={vi.fn(async () => "hi")} />);
+    expect(screen.getByLabelText("Voice input")).not.toBeDisabled();
+  });
+
+  it("surfaces an error when recording is unsupported in the browser", async () => {
+    const { Composer } = await import("@/components/dashboard/Composer");
+    render(<Composer onSend={vi.fn()} onTranscribe={vi.fn(async () => "hi")} />);
+    // jsdom has no navigator.mediaDevices.getUserMedia.
+    fireEvent.click(screen.getByLabelText("Voice input"));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/isn.t supported|permission/i);
+  });
+
   it("shows a chip for an attached file and can send with attachments", async () => {
     const { Composer } = await import("@/components/dashboard/Composer");
     const onSend = vi.fn();


### PR DESCRIPTION
## Summary

**PR-6** of the Dashboard Command Composer series — speak a task; the transcript fills the composer.

- **Backend** `POST /api/transcribe` (multipart audio, `token` query) → OpenAI Whisper using the user's existing OpenAI key. The raw-key resolution is factored into `services/llm.py::get_user_openai_key`, shared with `get_user_llm` — **one key path, no new key plumbing**. No OpenAI key → clear **400** ("Connect an OpenAI provider to use voice."). Size/empty guards too.
- **Frontend** — the composer mic button records via `MediaRecorder`/`getUserMedia` with a **"Recording…"** indicator; on stop it POSTs the blob to `/api/transcribe` and drops the transcript into the textarea (editable before sending). Permission-denied / unsupported-browser / no-key errors surface **inline** (no crash). Mic is enabled only when a transcribe handler is wired (**disabled in demo mode**).

## Live verification (local Ollama-only stack)

- `POST /api/transcribe` with no OpenAI key → **`400 {"detail":"Connect an OpenAI provider to use voice."}`** ✅ (the spec's friendly-prompt path).
- Mic button renders **enabled** in live mode (disabled without a transcribe handler / in demo).

## Tests

Backend `test_transcribe.py` (4): returns text (mocked Whisper), 400 without key, empty-audio guard, bad-token 401. Frontend `composer.test.tsx` (+2): mic enabled only with `onTranscribe`; unsupported-browser surfaces an inline error.

## Verification

`ruff` ✅ `mypy` ✅ `pytest` ✅ (678 passed; same 5 pre-existing CLI failures). `tsc` ✅ `lint` ✅ `vitest` ✅. Entropy ≤4.31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)