### PR TITLE
feat(api): provider verify/connect for cloud + ollama + generic

### DIFF
--- a/backend/app/routers/providers.py
+++ b/backend/app/routers/providers.py
@@ -1,6 +1,8 @@
 """Provider API routes — model listing, health, and configuration."""
 
 import logging
+from datetime import UTC, datetime
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -12,12 +14,116 @@ from app.routers.auth import get_current_user
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["providers"])
 
+DEFAULT_OLLAMA_URL = "http://localhost:11434"
+
 
 class ProviderConfigCreate(BaseModel):
     provider: str
     api_key: str | None = None
     base_url: str | None = None
     is_default: bool = False
+
+
+class ProviderVerifyRequest(BaseModel):
+    kind: Literal["cloud", "ollama", "generic"]
+    provider: str | None = None  # openai | anthropic (for cloud)
+    api_key: str | None = None
+    base_url: str | None = None
+    model: str | None = None
+
+
+class ProviderConnectRequest(BaseModel):
+    kind: Literal["cloud", "ollama", "generic"]
+    provider: str | None = None
+    api_key: str | None = None
+    base_url: str | None = None
+    model: str | None = None
+
+
+def _build_provider(req: ProviderVerifyRequest | ProviderConnectRequest):
+    """Instantiate the right provider class for a verify/connect request."""
+    if req.kind == "cloud":
+        if req.provider == "openai":
+            from app.providers.openai_provider import OpenAIProvider
+
+            return "openai", OpenAIProvider(api_key=req.api_key)
+        if req.provider == "anthropic":
+            from app.providers.anthropic_provider import AnthropicProvider
+
+            return "anthropic", AnthropicProvider(api_key=req.api_key)
+        raise HTTPException(status_code=400, detail="Unknown cloud provider")
+    if req.kind == "ollama":
+        from app.providers.ollama_provider import OllamaProvider
+
+        return "ollama", OllamaProvider(base_url=req.base_url or DEFAULT_OLLAMA_URL)
+    # generic OpenAI-compatible endpoint
+    if not req.base_url:
+        raise HTTPException(status_code=400, detail="base_url is required for a custom endpoint")
+    from app.providers.generic_provider import GenericOpenAIProvider
+
+    name = req.provider or "generic"
+    return name, GenericOpenAIProvider(api_key=req.api_key or "", base_url=req.base_url, provider_name=name)
+
+
+@router.post("/providers/verify")
+async def verify_provider(req: ProviderVerifyRequest, user=Depends(get_current_user)):  # noqa: B008
+    """Verify a provider is reachable and return its available models.
+
+    Cloud keys are validated via a health check; Ollama/generic reachability is
+    confirmed by listing models from the endpoint. Never raises on a bad
+    credential/URL — returns ok=False with an error so the UI can show it.
+    """
+    try:
+        _name, provider = _build_provider(req)
+    except HTTPException:
+        raise
+
+    try:
+        health = await provider.health_check()
+        if health.status != "healthy":
+            return {"ok": False, "error": health.error or "Provider is not reachable."}
+        models = await provider.list_models()
+        return {
+            "ok": True,
+            "models": [{"id": m.id, "name": m.name} for m in models],
+        }
+    except Exception as exc:
+        logger.info("Provider verify failed: %s", exc)
+        return {"ok": False, "error": str(exc) or "Verification failed."}
+
+
+@router.post("/providers/connect")
+async def connect_provider(req: ProviderConnectRequest, user=Depends(get_current_user)):  # noqa: B008
+    """Persist a provider config and set it as the user's default."""
+    name, _provider = _build_provider(req)
+
+    get_db().table("provider_configs").upsert(
+        {
+            "user_id": user.id,
+            "provider": name,
+            "api_key_encrypted": req.api_key or "",  # plaintext; access control via RLS
+            "base_url": req.base_url or "",
+            "is_default": True,
+            "is_enabled": True,
+        },
+        on_conflict="user_id,provider",
+    ).execute()
+
+    # Local/custom models route by an explicit "{provider}/{model}" prefix; cloud
+    # models (gpt-*, claude-*) route by their own name.
+    default_model = ""
+    if req.model:
+        default_model = f"{name}/{req.model}" if req.kind in ("ollama", "generic") else req.model
+
+    from app.routers.preferences import _get_or_create
+
+    _get_or_create(user.id)
+    patch: dict = {"default_provider": name, "updated_at": datetime.now(UTC).isoformat()}
+    if default_model:
+        patch["default_model"] = default_model
+    get_db().table("user_preferences").update(patch).eq("user_id", user.id).execute()
+
+    return {"ok": True, "provider": name, "default_model": default_model}
 
 
 class ProviderHealthResponse(BaseModel):

--- a/backend/tests/test_provider_connect.py
+++ b/backend/tests/test_provider_connect.py
@@ -1,0 +1,100 @@
+"""Onboarding PR-2 — provider verify/connect (cloud + ollama + generic)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _fake_provider(*, healthy=True, models=("gpt-4o", "gpt-4o-mini")):
+    p = MagicMock()
+    p.health_check = AsyncMock(
+        return_value=SimpleNamespace(status="healthy" if healthy else "unavailable", error=None if healthy else "bad key")
+    )
+    p.list_models = AsyncMock(return_value=[SimpleNamespace(id=m, name=m) for m in models])
+    return p
+
+
+def test_verify_cloud_openai_returns_models(auth_client):
+    fake = _fake_provider()
+    with patch("app.providers.openai_provider.OpenAIProvider", return_value=fake):
+        resp = auth_client.post("/api/providers/verify", json={"kind": "cloud", "provider": "openai", "api_key": "sk-x"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert {m["id"] for m in body["models"]} == {"gpt-4o", "gpt-4o-mini"}
+
+
+def test_verify_ollama_no_key(auth_client):
+    fake = _fake_provider(models=("llama3.2:3b", "qwen2.5:7b-instruct"))
+    with patch("app.providers.ollama_provider.OllamaProvider", return_value=fake):
+        resp = auth_client.post("/api/providers/verify", json={"kind": "ollama"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert any("llama" in m["id"] for m in body["models"])
+
+
+def test_verify_generic_requires_base_url(auth_client):
+    resp = auth_client.post("/api/providers/verify", json={"kind": "generic"})
+    assert resp.status_code == 400
+
+
+def test_verify_bad_key_returns_ok_false(auth_client):
+    fake = _fake_provider(healthy=False)
+    with patch("app.providers.openai_provider.OpenAIProvider", return_value=fake):
+        resp = auth_client.post("/api/providers/verify", json={"kind": "cloud", "provider": "openai", "api_key": "bad"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["error"]
+
+
+def test_connect_ollama_sets_prefixed_default_model(auth_client):
+    captured = {}
+    with patch("app.db._db") as mock_db, \
+         patch("app.providers.ollama_provider.OllamaProvider", return_value=_fake_provider()):
+        # preferences _get_or_create read
+        mock_db.table.return_value.select.return_value.eq.return_value.execute.return_value = MagicMock(
+            data=[{"user_id": "test-user-id-123"}]
+        )
+        mock_db.table.return_value.upsert.return_value.execute.return_value = MagicMock(data=[{"id": "c1"}])
+        mock_db.table.return_value.update.side_effect = lambda p: captured.update(p) or MagicMock(
+            eq=lambda *a, **k: MagicMock(execute=lambda: MagicMock(data=[{}]))
+        )
+
+        # auth: override is via get_current_user dependency (auth_client), but the
+        # endpoint also reads/writes through app.db._db which we patch here.
+        resp = auth_client.post(
+            "/api/providers/connect",
+            json={"kind": "ollama", "model": "qwen2.5:7b-instruct"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["provider"] == "ollama"
+    assert body["default_model"] == "ollama/qwen2.5:7b-instruct"
+    assert captured["default_provider"] == "ollama"
+
+
+def test_connect_cloud_keeps_plain_model_name(auth_client):
+    captured = {}
+    with patch("app.db._db") as mock_db, \
+         patch("app.providers.openai_provider.OpenAIProvider", return_value=_fake_provider()):
+        mock_db.table.return_value.select.return_value.eq.return_value.execute.return_value = MagicMock(
+            data=[{"user_id": "test-user-id-123"}]
+        )
+        mock_db.table.return_value.upsert.return_value.execute.return_value = MagicMock(data=[{"id": "c1"}])
+        mock_db.table.return_value.update.side_effect = lambda p: captured.update(p) or MagicMock(
+            eq=lambda *a, **k: MagicMock(execute=lambda: MagicMock(data=[{}]))
+        )
+        resp = auth_client.post(
+            "/api/providers/connect",
+            json={"kind": "cloud", "provider": "openai", "api_key": "sk-x", "model": "gpt-4o-mini"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["default_model"] == "gpt-4o-mini"

--- a/frontend/components/onboarding/ConnectModel.tsx
+++ b/frontend/components/onboarding/ConnectModel.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Cloud, HardDrive, Server } from "lucide-react";
+import { api, type ProviderKind, type ProviderVerifyBody } from "@/lib/api";
+import { getToken } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+interface ConnectModelProps {
+  onConnected: () => void;
+  onSkip: () => void;
+}
+
+type Model = { id: string; name: string };
+
+/**
+ * Onboarding "connect a model" step — cloud, local (Ollama), or a custom
+ * OpenAI-compatible endpoint. Skippable. Verify before connect; the model
+ * picker appears once verification returns models.
+ */
+export function ConnectModel({ onConnected, onSkip }: ConnectModelProps) {
+  const [tab, setTab] = useState<ProviderKind>("cloud");
+  const [cloudProvider, setCloudProvider] = useState("openai");
+  const [apiKey, setApiKey] = useState("");
+  const [ollamaUrl, setOllamaUrl] = useState("http://localhost:11434");
+  const [genericUrl, setGenericUrl] = useState("");
+  const [genericKey, setGenericKey] = useState("");
+
+  const [models, setModels] = useState<Model[]>([]);
+  const [selectedModel, setSelectedModel] = useState("");
+  const [verifying, setVerifying] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState("");
+
+  const bodyForTab = (): ProviderVerifyBody => {
+    if (tab === "cloud") return { kind: "cloud", provider: cloudProvider, api_key: apiKey };
+    if (tab === "ollama") return { kind: "ollama", base_url: ollamaUrl };
+    return { kind: "generic", base_url: genericUrl, api_key: genericKey || undefined };
+  };
+
+  const resetVerification = () => {
+    setModels([]);
+    setSelectedModel("");
+    setError("");
+  };
+
+  const verify = async () => {
+    resetVerification();
+    setVerifying(true);
+    try {
+      const token = await getToken();
+      if (!token) throw new Error("Not authenticated.");
+      const result = await api.providers.verify(bodyForTab(), token);
+      if (!result.ok) {
+        setError(result.error || "Verification failed.");
+        return;
+      }
+      const found = result.models ?? [];
+      setModels(found);
+      if (found.length > 0) setSelectedModel(found[0].id);
+      if (found.length === 0) setError("Connected, but no models were found.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Verification failed.");
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  const connect = async () => {
+    setConnecting(true);
+    setError("");
+    try {
+      const token = await getToken();
+      if (!token) throw new Error("Not authenticated.");
+      await api.providers.connect({ ...bodyForTab(), model: selectedModel }, token);
+      onConnected();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to connect.");
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Connect a model</h2>
+          <p className="text-sm text-muted-foreground">
+            Use a cloud provider, a local model, or your own endpoint. You can change this later.
+          </p>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onSkip}>
+          Skip
+        </Button>
+      </div>
+
+      <Tabs
+        value={tab}
+        onValueChange={(v) => {
+          setTab(v as ProviderKind);
+          resetVerification();
+        }}
+      >
+        <TabsList>
+          <TabsTrigger value="cloud">
+            <Cloud className="mr-1 h-4 w-4" /> Cloud
+          </TabsTrigger>
+          <TabsTrigger value="ollama">
+            <HardDrive className="mr-1 h-4 w-4" /> Local
+          </TabsTrigger>
+          <TabsTrigger value="generic">
+            <Server className="mr-1 h-4 w-4" /> Custom
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="cloud" className="space-y-3 pt-3">
+          <div className="space-y-1">
+            <Label>Provider</Label>
+            <select
+              className="flex h-9 w-full rounded-md border bg-transparent px-3 text-sm"
+              value={cloudProvider}
+              onChange={(e) => {
+                setCloudProvider(e.target.value);
+                resetVerification();
+              }}
+            >
+              <option value="openai">OpenAI</option>
+              <option value="anthropic">Anthropic</option>
+            </select>
+          </div>
+          <div className="space-y-1">
+            <Label>API key</Label>
+            <Input
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="sk-…"
+            />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="ollama" className="space-y-3 pt-3">
+          <p className="text-sm text-muted-foreground">
+            Runs on your machine, no API key, nothing leaves your network.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Detection requires this Forge backend to run on your machine (it reads your localhost).
+          </p>
+          <div className="space-y-1">
+            <Label>Ollama URL</Label>
+            <Input value={ollamaUrl} onChange={(e) => setOllamaUrl(e.target.value)} />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="generic" className="space-y-3 pt-3">
+          <p className="text-sm text-muted-foreground">
+            Any OpenAI-compatible endpoint (LM Studio, vLLM, Groq, Together…).
+          </p>
+          <div className="space-y-1">
+            <Label>Base URL</Label>
+            <Input
+              value={genericUrl}
+              onChange={(e) => setGenericUrl(e.target.value)}
+              placeholder="http://localhost:1234/v1"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>API key (optional)</Label>
+            <Input type="password" value={genericKey} onChange={(e) => setGenericKey(e.target.value)} />
+          </div>
+        </TabsContent>
+      </Tabs>
+
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={verify} disabled={verifying || connecting}>
+          {verifying ? (
+            <>
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              {tab === "ollama" ? "Detecting…" : "Verifying…"}
+            </>
+          ) : tab === "ollama" ? (
+            "Detect local models"
+          ) : (
+            "Verify"
+          )}
+        </Button>
+      </div>
+
+      {models.length > 0 && (
+        <div className="space-y-1">
+          <Label>Model</Label>
+          <select
+            aria-label="Model"
+            className="flex h-9 w-full rounded-md border bg-transparent px-3 text-sm"
+            value={selectedModel}
+            onChange={(e) => setSelectedModel(e.target.value)}
+          >
+            {models.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button onClick={connect} disabled={connecting || !selectedModel}>
+          {connecting ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
+          Connect & continue
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -77,6 +77,22 @@ export interface PreferencesUpdate {
   onboarded_at?: string;
 }
 
+export type ProviderKind = "cloud" | "ollama" | "generic";
+
+export interface ProviderVerifyBody {
+  kind: ProviderKind;
+  provider?: string;
+  api_key?: string;
+  base_url?: string;
+  model?: string;
+}
+
+export interface ProviderVerifyResult {
+  ok: boolean;
+  models?: { id: string; name: string }[];
+  error?: string;
+}
+
 export interface CatalogEntry {
   type: "agent" | "blueprint";
   id: string;
@@ -583,6 +599,14 @@ export const api = {
       request<{ ok: boolean }>("/api/providers/configs", { method: "POST", body: JSON.stringify(data), token }),
     deleteConfig: (provider: string, token: string) =>
       request<{ ok: boolean }>(`/api/providers/configs/${provider}`, { method: "DELETE", token }),
+    verify: (data: ProviderVerifyBody, token: string) =>
+      request<ProviderVerifyResult>("/api/providers/verify", { method: "POST", body: JSON.stringify(data), token }),
+    connect: (data: ProviderVerifyBody, token: string) =>
+      request<{ ok: boolean; provider: string; default_model: string }>("/api/providers/connect", {
+        method: "POST",
+        body: JSON.stringify(data),
+        token,
+      }),
   },
   compare: {
     run: (data: { prompt: string; system_prompt?: string; models: string[]; temperature?: number; max_tokens?: number }, token: string) =>

--- a/frontend/tests/connect-model.test.tsx
+++ b/frontend/tests/connect-model.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth-client", () => ({
+  getToken: vi.fn(async () => "test-token"),
+}));
+
+const verify = vi.fn();
+const connect = vi.fn();
+vi.mock("@/lib/api", () => ({
+  api: { providers: { verify: (...a: unknown[]) => verify(...a), connect: (...a: unknown[]) => connect(...a) } },
+}));
+
+describe("ConnectModel", () => {
+  beforeEach(() => {
+    verify.mockReset();
+    connect.mockReset();
+  });
+
+  it("has a Skip control that calls onSkip", async () => {
+    const { ConnectModel } = await import("@/components/onboarding/ConnectModel");
+    const onSkip = vi.fn();
+    render(<ConnectModel onConnected={vi.fn()} onSkip={onSkip} />);
+    fireEvent.click(screen.getByText("Skip"));
+    expect(onSkip).toHaveBeenCalled();
+  });
+
+  it("renders cloud / local / custom tabs", async () => {
+    const { ConnectModel } = await import("@/components/onboarding/ConnectModel");
+    render(<ConnectModel onConnected={vi.fn()} onSkip={vi.fn()} />);
+    expect(screen.getByRole("tab", { name: /cloud/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /local/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /custom/i })).toBeInTheDocument();
+  });
+
+  it("verifies, shows the model picker, and connects", async () => {
+    const { ConnectModel } = await import("@/components/onboarding/ConnectModel");
+    const onConnected = vi.fn();
+    verify.mockResolvedValue({ ok: true, models: [{ id: "gpt-4o-mini", name: "gpt-4o-mini" }] });
+    connect.mockResolvedValue({ ok: true, provider: "openai", default_model: "gpt-4o-mini" });
+
+    render(<ConnectModel onConnected={onConnected} onSkip={vi.fn()} />);
+
+    // Default tab is cloud; verify reveals the model picker.
+    fireEvent.click(screen.getByText("Verify"));
+    await waitFor(() => expect(screen.getByLabelText("Model")).toBeInTheDocument());
+    expect(verify).toHaveBeenCalledWith(expect.objectContaining({ kind: "cloud" }), "test-token");
+
+    fireEvent.click(screen.getByText("Connect & continue"));
+    await waitFor(() => expect(onConnected).toHaveBeenCalled());
+    expect(connect).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "cloud", model: "gpt-4o-mini" }),
+      "test-token",
+    );
+  });
+
+  it("shows an error when verification fails", async () => {
+    const { ConnectModel } = await import("@/components/onboarding/ConnectModel");
+    verify.mockResolvedValue({ ok: false, error: "Invalid API key" });
+
+    render(<ConnectModel onConnected={vi.fn()} onSkip={vi.fn()} />);
+    fireEvent.click(screen.getByText("Verify"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Invalid API key");
+  });
+});


### PR DESCRIPTION
## Summary

**PR-2** of the onboarding series — the one gate (connect a model), still skippable. Local models are first-class.

**Backend** (extends `routers/providers.py`):
- `POST /api/providers/verify` — builds the right provider class for `{cloud, ollama, generic}`, runs a **health check** (validates cloud keys; confirms local/custom reachability), returns available models. Never raises on a bad credential/URL → `ok:false` + `error` so the UI can show it. **Ollama needs no key.**
- `POST /api/providers/connect` — upserts `provider_configs` and sets `user_preferences.default_provider`/`default_model` (local+custom models stored as `{provider}/{model}` so the registry routes them; cloud models kept as-is).

**Frontend**:
- `api.providers.verify/connect` + types.
- `components/onboarding/ConnectModel.tsx` — Cloud / Local / Custom tabs, Verify→model-picker→Connect, **Skip**, and an honest note that local detection needs the backend to run on your machine (per the spec's caveat).

## Live verification (local stack)

- `verify {kind: ollama}` → `ok:true`, detected `["qwen2.5:7b-instruct","llama3.2:3b"]` **with no key**.
- `verify {kind: generic}` with no base_url → **400**.
- `verify {kind: cloud, openai, bad key}` → **`ok:false` + error** (no crash).

## Tests

Backend `test_provider_connect.py` (6): verify cloud/ollama/bad-key/generic-guard; connect sets `{provider}/{model}` for ollama and a plain model name for cloud. Frontend `connect-model.test.tsx` (4): Skip; tabs render; verify→picker→connect; error surfaced.

## Verification

`ruff` ✅ `mypy` ✅ `pytest` ✅ (691 + 5 pre-existing CLI). `tsc` ✅ `lint` ✅ `vitest` ✅ (51). Entropy clean (<4.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)