### PR TITLE
feat(api): /api/onboarding/finish — clone templates, custom agents, custom instructions

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.routers import (
     marketplace,
     mcp,
     messages,
+    onboarding,
     orchestration,
     organizations,
     preferences,
@@ -124,6 +125,7 @@ app.include_router(messages.router, prefix="/api")
 app.include_router(blueprints.router, prefix="/api")
 app.include_router(providers.router, prefix="/api")
 app.include_router(preferences.router, prefix="/api")
+app.include_router(onboarding.router, prefix="/api")
 app.include_router(compare.router, prefix="/api")
 app.include_router(mcp.router, prefix="/api")
 app.include_router(triggers.router, prefix="/api")

--- a/backend/app/routers/onboarding.py
+++ b/backend/app/routers/onboarding.py
@@ -1,0 +1,139 @@
+"""Onboarding finish — clone templates, create custom agents, tailor + seed."""
+
+import logging
+import re
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.db import get_db
+from app.routers.auth import get_current_user
+from app.services.tailoring import MAX_INSTRUCTIONS, prepend_about
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["onboarding"])
+
+_EXPAND_SYSTEM = (
+    "You write concise, effective system prompts for AI agents. Given a "
+    "plain-language description of what an agent should do, output ONLY the "
+    "system prompt text — no preamble, no markdown headers. Keep it focused "
+    "and under 200 words."
+)
+
+
+class CustomAgentSpec(BaseModel):
+    name: str | None = None
+    description: str
+
+
+class OnboardingFinishRequest(BaseModel):
+    use_case: str | None = None
+    custom_instructions: str | None = None
+    template_ids: list[str] = []
+    custom_agents: list[CustomAgentSpec] = []
+
+
+def _derive_name(description: str) -> str:
+    words = re.findall(r"[A-Za-z0-9]+", description)[:4]
+    return " ".join(w.capitalize() for w in words) or "Custom Agent"
+
+
+async def _expand_or_verbatim(user_id: str, description: str) -> str:
+    """Expand a plain-language description into a system prompt via the user's
+    connected model, falling back to the raw text when no provider is set."""
+    try:
+        from app.providers.registry import create_user_registry
+
+        registry = await create_user_registry(user_id)
+        if not registry.provider_names:
+            return description
+        response = await registry.complete(
+            messages=[
+                {"role": "system", "content": _EXPAND_SYSTEM},
+                {"role": "user", "content": description},
+            ],
+            temperature=0.3,
+            max_tokens=600,
+        )
+        return (response.content or "").strip() or description
+    except Exception:
+        logger.info("Prompt expansion unavailable; using verbatim description", exc_info=True)
+        return description
+
+
+def _insert_agent(user_id: str, *, name: str, description: str, system_prompt: str,
+                  tools: list, workflow_steps: list, model: str | None) -> dict | None:
+    result = get_db().table("agents").insert({
+        "user_id": user_id,
+        "name": name,
+        "description": description,
+        "system_prompt": system_prompt,
+        "tools": tools,
+        "workflow_steps": workflow_steps,
+        "model": model,
+        "is_template": False,
+    }).execute()
+    return result.data[0] if result.data else None
+
+
+@router.post("/onboarding/finish")
+async def finish_onboarding(req: OnboardingFinishRequest, user=Depends(get_current_user)):  # noqa: B008
+    """Seed the user's chosen agents, tailored with their custom instructions."""
+    user_id = user.id
+    instructions = (req.custom_instructions or "").strip()[:MAX_INSTRUCTIONS]
+    created: list[dict] = []
+
+    # 1. Clone selected templates, embedding the user's context.
+    for template_id in req.template_ids:
+        tpl = get_db().table("agents").select("*").eq("id", template_id).single().execute()
+        if not tpl.data or not tpl.data.get("is_template"):
+            continue
+        t = tpl.data
+        agent = _insert_agent(
+            user_id,
+            name=t.get("name", "Agent"),
+            description=t.get("description", "") or "",
+            system_prompt=prepend_about(t.get("system_prompt", ""), instructions),
+            tools=t.get("tools", []) or [],
+            workflow_steps=t.get("workflow_steps", []) or [],
+            model=t.get("model"),
+        )
+        if agent:
+            created.append(agent)
+
+    # 2. Create custom agents from plain-language descriptions.
+    for spec in req.custom_agents:
+        desc = (spec.description or "").strip()
+        if not desc:
+            continue
+        system_prompt = await _expand_or_verbatim(user_id, desc)
+        agent = _insert_agent(
+            user_id,
+            name=spec.name or _derive_name(desc),
+            description=desc[:200],
+            system_prompt=prepend_about(system_prompt, instructions),
+            tools=[],
+            workflow_steps=[],
+            model=None,
+        )
+        if agent:
+            created.append(agent)
+
+    # 3. Persist use_case + custom_instructions and mark onboarded.
+    from app.routers.preferences import _get_or_create
+
+    _get_or_create(user_id)
+    now = datetime.now(UTC).isoformat()
+    patch: dict = {"onboarded_at": now, "updated_at": now}
+    if req.use_case:
+        patch["use_case"] = req.use_case
+    if instructions:
+        patch["custom_instructions"] = instructions
+    get_db().table("user_preferences").update(patch).eq("user_id", user_id).execute()
+
+    return {
+        "ok": True,
+        "created_agents": len(created),
+        "agents": [{"id": a.get("id"), "name": a.get("name")} for a in created],
+    }

--- a/backend/app/services/tailoring.py
+++ b/backend/app/services/tailoring.py
@@ -1,0 +1,32 @@
+"""Custom-instructions tailoring — shared by onboarding seeding + run time.
+
+A user's global ``custom_instructions`` are woven into agent prompts both when
+agents are seeded (onboarding finish) and at run time (the agent runner +
+dispatcher). The block is bounded and clearly delimited, and prepending is
+idempotent so a seeded prompt that already carries the block isn't doubled.
+"""
+
+ABOUT_USER_MARKER = "--- About this user ---"
+END_MARKER = "--- End ---"
+
+# Bounded so the block can't blow up every prompt it's woven into.
+MAX_INSTRUCTIONS = 4000
+
+
+def about_user_block(instructions: str | None) -> str:
+    """Return the delimited about-the-user block, or "" when there's nothing."""
+    text = (instructions or "").strip()[:MAX_INSTRUCTIONS]
+    if not text:
+        return ""
+    return ABOUT_USER_MARKER + "\n" + text + "\n" + END_MARKER
+
+
+def prepend_about(system_prompt: str | None, instructions: str | None) -> str:
+    """Prepend the about-the-user block to a system prompt (idempotent)."""
+    prompt = system_prompt or ""
+    if not instructions or ABOUT_USER_MARKER in prompt:
+        return prompt
+    block = about_user_block(instructions)
+    if not block:
+        return prompt
+    return block + "\n\n" + prompt

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -1,0 +1,125 @@
+"""Onboarding PR-3 — /api/onboarding/finish + tailoring helper."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.tailoring import ABOUT_USER_MARKER, about_user_block, prepend_about
+
+
+# --- tailoring helper ---------------------------------------------------------
+
+
+def test_about_user_block_empty():
+    assert about_user_block("") == ""
+    assert about_user_block(None) == ""
+
+
+def test_about_user_block_has_markers_and_text():
+    block = about_user_block("I work in Rust.")
+    assert ABOUT_USER_MARKER in block
+    assert "I work in Rust." in block
+
+
+def test_about_user_block_bounded():
+    assert len(about_user_block("x" * 9000)) <= 4000 + len(ABOUT_USER_MARKER) + 20
+
+
+def test_prepend_about_adds_block():
+    out = prepend_about("You review code.", "Prefer terse output.")
+    assert ABOUT_USER_MARKER in out
+    assert out.endswith("You review code.")
+
+
+def test_prepend_about_idempotent():
+    once = prepend_about("You review code.", "Prefer terse output.")
+    twice = prepend_about(once, "Prefer terse output.")
+    assert once == twice
+    assert once.count(ABOUT_USER_MARKER) == 1
+
+
+def test_prepend_about_noop_without_instructions():
+    assert prepend_about("You review code.", "") == "You review code."
+
+
+# --- /api/onboarding/finish ---------------------------------------------------
+
+
+def _wire(mock_db, *, template=None):
+    """Wire a mock db: template fetch via .single(), prefs via plain select,
+    inserts captured, prefs patch captured. Returns (inserts, prefs_patch)."""
+    inserts: list[dict] = []
+    prefs_patch: dict = {}
+
+    def insert_side(data):
+        inserts.append(data)
+        return MagicMock(execute=lambda: MagicMock(data=[{**data, "id": f"new-{len(inserts)}"}]))
+
+    mock_db.table.return_value.insert.side_effect = insert_side
+    mock_db.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = MagicMock(
+        data=template
+    )
+    mock_db.table.return_value.select.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"user_id": "test-user-id-123"}]
+    )
+    mock_db.table.return_value.update.side_effect = lambda p: prefs_patch.update(p) or MagicMock(
+        eq=lambda *a, **k: MagicMock(execute=lambda: MagicMock(data=[{}]))
+    )
+    return inserts, prefs_patch
+
+
+def test_finish_clones_template_with_about_block(auth_client):
+    template = {
+        "id": "tpl-1", "is_template": True, "name": "Code Reviewer",
+        "description": "Reviews code", "system_prompt": "You review code.",
+        "tools": ["data_extractor"], "workflow_steps": ["Review the code."], "model": None,
+    }
+    with patch("app.db._db") as mock_db:
+        inserts, prefs_patch = _wire(mock_db, template=template)
+        resp = auth_client.post(
+            "/api/onboarding/finish",
+            json={"use_case": "coding", "custom_instructions": "I work in Rust.", "template_ids": ["tpl-1"]},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["created_agents"] == 1
+    seeded = inserts[0]
+    assert seeded["name"] == "Code Reviewer"
+    assert seeded["is_template"] is False
+    assert ABOUT_USER_MARKER in seeded["system_prompt"]
+    assert "I work in Rust." in seeded["system_prompt"]
+    assert "You review code." in seeded["system_prompt"]
+    # onboarded + prefs persisted
+    assert prefs_patch["onboarded_at"]
+    assert prefs_patch["use_case"] == "coding"
+    assert prefs_patch["custom_instructions"] == "I work in Rust."
+
+
+def test_finish_custom_agent_verbatim_without_provider(auth_client):
+    with patch("app.db._db") as mock_db, \
+         patch("app.providers.registry.create_user_registry", new=AsyncMock(return_value=MagicMock(provider_names=[]))):
+        inserts, _ = _wire(mock_db, template=None)
+        resp = auth_client.post(
+            "/api/onboarding/finish",
+            json={"custom_agents": [{"description": "watch my CI and summarize failures"}]},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["created_agents"] == 1
+    agent = inserts[0]
+    # Name derived from the description; prompt uses the verbatim text.
+    assert agent["name"]
+    assert "watch my CI and summarize failures" in agent["system_prompt"]
+
+
+def test_finish_skips_non_template_ids(auth_client):
+    not_a_template = {"id": "x", "is_template": False, "name": "Someone's agent"}
+    with patch("app.db._db") as mock_db:
+        inserts, prefs_patch = _wire(mock_db, template=not_a_template)
+        resp = auth_client.post("/api/onboarding/finish", json={"template_ids": ["x"]})
+
+    assert resp.status_code == 200
+    assert resp.json()["created_agents"] == 0
+    assert inserts == []
+    # Still marks the user onboarded.
+    assert prefs_patch["onboarded_at"]


### PR DESCRIPTION
## Summary

**PR-3** of the onboarding series — the finish step where tailoring and depth live (all skippable from the UI).

`POST /api/onboarding/finish` body `{ use_case, custom_instructions, template_ids[], custom_agents[{name?, description}] }`:
- **Clone** each selected template into the user's account (`user_id`, `is_template=False`).
- **Custom agents** from plain-language text — LLM-expanded into a system prompt via the connected model, or used **verbatim when no provider is set** (graceful degradation); name derived when absent.
- **Embed `custom_instructions`** into every seeded prompt as a bounded, delimited `--- About this user ---` block.
- Persist `use_case` + `custom_instructions`; set `onboarded_at`.

New `services/tailoring.py` is the shared block helper (reused by the runner/dispatcher in PR-4); `prepend_about` is **idempotent** so a prompt already carrying the block isn't doubled.

## Live verification (local Ollama stack)

- Custom agent "Watch My Ci Runs" → prompt **expanded via Ollama** and prefixed with `--- About this user ---\nI work in Rust…`.
- Template clone (`Document Analyzer`) succeeded.
- `onboarded_at` + `use_case=coding` + `custom_instructions` persisted (confirmed via `GET /api/preferences`).

## Tests

`test_onboarding.py` (9): tailoring helper (empty / markers / bounded / idempotent / no-op); finish clones a template with the About block + persists prefs/onboarded; custom agent verbatim without a provider (name derived); non-template ids skipped (still marks onboarded).

## Verification

`ruff` ✅ `mypy` ✅ `pytest` ✅ (700 + 5 pre-existing CLI). Entropy clean (<4.45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)