### PR TITLE
feat: inject custom_instructions into runner + dispatcher

### DIFF
--- a/backend/app/services/agent_executor.py
+++ b/backend/app/services/agent_executor.py
@@ -88,8 +88,13 @@ class AgentRunner:
         """Execute an agent's workflow and yield streaming events."""
         from app.services.heartbeat import heartbeat_service
         from app.services.observability.trace_service import trace_service
+        from app.services.tailoring import load_custom_instructions, prepend_about
 
         system_prompt = agent_config.get("system_prompt", "")
+        # Weave the user's global custom instructions into the system prompt at
+        # run time (idempotent — a seeded prompt that already carries the block
+        # isn't doubled; agents created after onboarding still benefit).
+        system_prompt = prepend_about(system_prompt, load_custom_instructions(user_id or self.user_id))
         tool_names = agent_config.get("tools", [])
         workflow_steps = agent_config.get("workflow_steps", [])
         tools, _mcp_tools = self._resolve_tools(tool_names)

--- a/backend/app/services/dispatcher.py
+++ b/backend/app/services/dispatcher.py
@@ -243,6 +243,13 @@ async def route(
         )
 
     messages = _build_messages(catalog, message, attachments_summary)
+    # Tailor routing with the user's custom instructions, too.
+    from app.services.tailoring import load_custom_instructions, prepend_about
+
+    instructions = load_custom_instructions(user_id)
+    if instructions:
+        messages[0]["content"] = prepend_about(messages[0]["content"], instructions)
+
     text, input_tokens, output_tokens, model = await _invoke(user_id, messages)
     _track(user_id, model, input_tokens, output_tokens)
 

--- a/backend/app/services/tailoring.py
+++ b/backend/app/services/tailoring.py
@@ -30,3 +30,27 @@ def prepend_about(system_prompt: str | None, instructions: str | None) -> str:
     if not block:
         return prompt
     return block + "\n\n" + prompt
+
+
+def load_custom_instructions(user_id: str | None) -> str:
+    """Read a user's stored custom_instructions (empty string when unavailable).
+
+    Read at run time so agents created after onboarding also benefit.
+    """
+    if not user_id:
+        return ""
+    try:
+        from app.db import get_db
+
+        result = (
+            get_db().table("user_preferences")
+            .select("custom_instructions")
+            .eq("user_id", user_id)
+            .single()
+            .execute()
+        )
+        if result.data:
+            return result.data.get("custom_instructions") or ""
+    except Exception:
+        return ""
+    return ""

--- a/backend/tests/test_custom_instructions.py
+++ b/backend/tests/test_custom_instructions.py
@@ -1,0 +1,86 @@
+"""Onboarding PR-4 — custom_instructions injected into the runner + dispatcher."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from app.services import dispatcher
+from app.services.agent_executor import AgentRunner
+from app.services.tailoring import ABOUT_USER_MARKER
+
+CATALOG = [
+    dispatcher.CatalogEntry(type="agent", id="agent-1", name="Reviewer", description="reviews code"),
+]
+
+AGENT_CONFIG = {
+    "id": "a1", "name": "Reviewer", "system_prompt": "You review code.",
+    "tools": [], "workflow_steps": ["Review it."], "model": "ollama/llama3.2:3b",
+}
+
+
+async def _fake_step(self, system_prompt, step, user_input, context, *, model=None, image_blocks=None):
+    _fake_step.captured = system_prompt  # type: ignore[attr-defined]
+    return {"content": "ok", "tokens": 0, "input_tokens": 0, "output_tokens": 0,
+            "latency_ms": 0, "model": model, "provider": "ollama"}
+
+
+@pytest.mark.asyncio
+async def test_runner_injects_custom_instructions():
+    runner = AgentRunner(user_id="u1")
+    with patch("app.services.tailoring.load_custom_instructions", return_value="I work in Rust, prefer terse output."), \
+         patch.object(AgentRunner, "_execute_step", new=_fake_step):
+        async for _ in runner.execute(AGENT_CONFIG, "hi", user_id="u1"):
+            pass
+
+    assert ABOUT_USER_MARKER in _fake_step.captured  # type: ignore[attr-defined]
+    assert "I work in Rust" in _fake_step.captured  # type: ignore[attr-defined]
+    assert "You review code." in _fake_step.captured  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_runner_no_block_when_instructions_empty():
+    runner = AgentRunner(user_id="u1")
+    with patch("app.services.tailoring.load_custom_instructions", return_value=""), \
+         patch.object(AgentRunner, "_execute_step", new=_fake_step):
+        async for _ in runner.execute(AGENT_CONFIG, "hi", user_id="u1"):
+            pass
+
+    assert ABOUT_USER_MARKER not in _fake_step.captured  # type: ignore[attr-defined]
+    assert _fake_step.captured == "You review code."  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_injects_custom_instructions_into_routing():
+    captured = {}
+
+    async def fake_invoke(user_id, messages):
+        captured["messages"] = messages
+        return json.dumps({"action": "none"}), 1, 1, "m"
+
+    with patch("app.services.dispatcher._invoke", new=fake_invoke), \
+         patch("app.services.tailoring.load_custom_instructions", return_value="Answer in Rust terms."), \
+         patch("app.services.token_tracker.token_tracker"):
+        await dispatcher.route("u1", "do a thing", catalog=CATALOG)
+
+    system_message = captured["messages"][0]["content"]
+    assert ABOUT_USER_MARKER in system_message
+    assert "Answer in Rust terms." in system_message
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_no_block_when_instructions_empty():
+    captured = {}
+
+    async def fake_invoke(user_id, messages):
+        captured["messages"] = messages
+        return json.dumps({"action": "none"}), 1, 1, "m"
+
+    with patch("app.services.dispatcher._invoke", new=fake_invoke), \
+         patch("app.services.tailoring.load_custom_instructions", return_value=""), \
+         patch("app.services.token_tracker.token_tracker"):
+        await dispatcher.route("u1", "do a thing", catalog=CATALOG)
+
+    assert ABOUT_USER_MARKER not in captured["messages"][0]["content"]


### PR DESCRIPTION
## Summary

**PR-4** of the onboarding series — tailoring takes effect at runtime, not just in seeded prompts.

- The **agent runner** (`AgentRunner.execute`) and the **dispatcher** (`route`) load `user_preferences.custom_instructions` and prepend it as a bounded, delimited `--- About this user ---` block — to the run's system prompt and the routing prompt respectively.
- **Read at run time**, so agents created *after* onboarding also benefit (not baked only at seed time).
- `prepend_about` is **idempotent**, so a seeded prompt that already carries the block (PR-3) isn't doubled.
- `services/tailoring.py::load_custom_instructions` is the shared reader.

## Live verification (local Ollama stack)

Set `custom_instructions` to "**end every response with the exact word PINEAPPLE**", ran an agent → output was `"No failures to summarize. PINEAPPLE"`. The instruction reaches the model at run time. ✅ Clearing it removes the block.

## Tests

`test_custom_instructions.py` (4): runner injects the block (and the seeded prompt is preserved); runner adds nothing when instructions are empty; dispatcher routing prompt includes the block; dispatcher adds nothing when empty.

## Verification

`ruff` ✅ `mypy` ✅ `pytest` ✅ (704 + 5 pre-existing CLI). Entropy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)