### PR TITLE
feat(web): skippable onboarding stepper + post-login redirect gate

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { OnboardingGate } from "@/components/onboarding/OnboardingGate";
 import { DashboardComposer } from "@/components/dashboard/DashboardComposer";
 import { LiveStatusSection } from "@/components/dashboard/sections/LiveStatusSection";
 import { UsageCostSection } from "@/components/dashboard/sections/UsageCostSection";
@@ -29,6 +30,7 @@ export default function DashboardPage() {
 
   return (
     <div className="space-y-10">
+      <OnboardingGate />
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h1 className="text-3xl font-bold">Dashboard</h1>

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/lib/api";
+import { getToken } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { ConnectModel } from "@/components/onboarding/ConnectModel";
+import { TailorAndSeed } from "@/components/onboarding/TailorAndSeed";
+
+const STEPS = ["Connect a model", "Tailor & seed"] as const;
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+
+  // Mark onboarded and leave — used by every Skip and by Finish.
+  const completeAndExit = useCallback(async () => {
+    try {
+      const token = await getToken();
+      if (token) {
+        await api.preferences.update({ onboarded_at: new Date().toISOString() }, token);
+      }
+    } catch {
+      // Don't trap the user if the write fails — still let them into the app.
+    }
+    router.push("/dashboard");
+  }, [router]);
+
+  return (
+    <div className="mx-auto flex min-h-screen max-w-2xl flex-col px-4 py-10">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Welcome to Forge</h1>
+          <p className="text-sm text-muted-foreground">A minute of setup tailors Forge to you. Skip any time.</p>
+        </div>
+        <Button variant="ghost" size="sm" onClick={completeAndExit}>
+          Skip setup
+        </Button>
+      </div>
+
+      {/* Progress */}
+      <ol className="mb-8 flex items-center gap-2 text-sm" aria-label="Progress">
+        {STEPS.map((label, i) => (
+          <li key={label} className="flex items-center gap-2">
+            <span
+              className={`flex h-6 w-6 items-center justify-center rounded-full text-xs ${
+                i <= step ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"
+              }`}
+            >
+              {i + 1}
+            </span>
+            <span className={i === step ? "font-medium" : "text-muted-foreground"}>{label}</span>
+            {i < STEPS.length - 1 && <span className="mx-1 text-muted-foreground">→</span>}
+          </li>
+        ))}
+      </ol>
+
+      <div className="flex-1 rounded-xl border bg-card p-6 shadow-sm">
+        {step === 0 ? (
+          <ConnectModel onConnected={() => setStep(1)} onSkip={() => setStep(1)} />
+        ) : (
+          <TailorAndSeed onDone={() => router.push("/dashboard")} onSkip={completeAndExit} />
+        )}
+      </div>
+
+      {step === 1 && (
+        <button
+          type="button"
+          onClick={() => setStep(0)}
+          className="mt-4 self-start text-sm text-muted-foreground hover:text-foreground"
+        >
+          ← Back
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/onboarding/OnboardingGate.tsx
+++ b/frontend/components/onboarding/OnboardingGate.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/lib/api";
+import { getToken } from "@/lib/auth-client";
+import { useBackendMode } from "@/lib/backend-context";
+
+/**
+ * First-login onboarding gate. A logged-in user who hasn't onboarded is sent to
+ * /onboarding. Live mode only (demo has no backend). Never traps — Skip sets
+ * onboarded_at, and any error here is swallowed so the dashboard still loads.
+ * Renders nothing.
+ */
+export function OnboardingGate() {
+  const router = useRouter();
+  const { mode } = useBackendMode();
+
+  useEffect(() => {
+    if (mode !== "live") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await getToken();
+        if (!token) return;
+        const prefs = await api.preferences.get(token);
+        if (!cancelled && !prefs.onboarded_at) {
+          router.push("/onboarding");
+        }
+      } catch {
+        // Don't trap the user on a preferences hiccup.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, router]);
+
+  return null;
+}

--- a/frontend/components/onboarding/TailorAndSeed.tsx
+++ b/frontend/components/onboarding/TailorAndSeed.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { api, type Agent } from "@/lib/api";
+import { getToken } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+interface TailorAndSeedProps {
+  onDone: () => void;
+  onSkip: () => void;
+}
+
+const USE_CASES: { id: string; label: string; match: RegExp }[] = [
+  { id: "coding", label: "Coding", match: /code|review|implement/i },
+  { id: "research", label: "Research", match: /research|search|report/i },
+  { id: "data", label: "Data", match: /data|extract|json/i },
+  { id: "computer_use", label: "Computer use", match: /screen|browser|click|gui/i },
+  { id: "exploring", label: "Just exploring", match: /.*/ },
+];
+
+/**
+ * Onboarding "tailor + seed" step — pick a use case (pre-selects templates),
+ * toggle starter agents, add global custom instructions, and optionally
+ * describe an agent in plain language. Everything is optional; Skip escapes.
+ */
+export function TailorAndSeed({ onDone, onSkip }: TailorAndSeedProps) {
+  const [templates, setTemplates] = useState<Agent[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [useCase, setUseCase] = useState("");
+  const [customInstructions, setCustomInstructions] = useState("");
+  const [customAgent, setCustomAgent] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const token = await getToken();
+      if (!token) return;
+      try {
+        const tpls = await api.agents.templates(token);
+        if (cancelled) return;
+        setTemplates(tpls);
+        setSelected(new Set(tpls.map((t) => t.id))); // default all on
+      } catch {
+        // non-fatal — the step still works without templates
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const pickUseCase = (uc: { id: string; match: RegExp }) => {
+    setUseCase(uc.id);
+    // Pre-select templates that match this use case (others stay available).
+    if (uc.id !== "exploring") {
+      const matched = templates.filter((t) => uc.match.test(`${t.name} ${t.description}`));
+      if (matched.length > 0) setSelected(new Set(matched.map((t) => t.id)));
+    } else {
+      setSelected(new Set(templates.map((t) => t.id)));
+    }
+  };
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const finish = async () => {
+    setSaving(true);
+    setError("");
+    try {
+      const token = await getToken();
+      if (!token) throw new Error("Not authenticated.");
+      await api.onboarding.finish(
+        {
+          use_case: useCase || undefined,
+          custom_instructions: customInstructions.trim() || undefined,
+          template_ids: Array.from(selected),
+          custom_agents: customAgent.trim() ? [{ description: customAgent.trim() }] : [],
+        },
+        token,
+      );
+      onDone();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to finish setup.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Tailor Forge to you</h2>
+          <p className="text-sm text-muted-foreground">Seed a few agents and tell Forge about your work. All optional.</p>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onSkip}>
+          Skip
+        </Button>
+      </div>
+
+      {/* Use case */}
+      <div className="space-y-2">
+        <p className="text-sm font-medium">What are you working on?</p>
+        <div className="flex flex-wrap gap-2">
+          {USE_CASES.map((uc) => (
+            <button
+              key={uc.id}
+              type="button"
+              onClick={() => pickUseCase(uc)}
+              className={`rounded-full border px-3 py-1 text-sm ${
+                useCase === uc.id ? "border-primary bg-primary text-primary-foreground" : "hover:bg-accent"
+              }`}
+            >
+              {uc.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Starter agents */}
+      {templates.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Starter agents</p>
+          <ul className="space-y-2">
+            {templates.map((t) => (
+              <li key={t.id} className="flex items-start gap-2 rounded-md border p-2">
+                <input
+                  type="checkbox"
+                  className="mt-1"
+                  checked={selected.has(t.id)}
+                  onChange={() => toggle(t.id)}
+                  aria-label={t.name}
+                />
+                <div>
+                  <p className="text-sm font-medium">{t.name}</p>
+                  <p className="text-xs text-muted-foreground">{t.description}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Custom instructions */}
+      <div className="space-y-1">
+        <p className="text-sm font-medium">Tell Forge about you</p>
+        <p className="text-xs text-muted-foreground">
+          Your stack, domain, conventions, preferences — we weave this into every agent.
+        </p>
+        <Textarea
+          value={customInstructions}
+          onChange={(e) => setCustomInstructions(e.target.value)}
+          rows={3}
+          placeholder="e.g. I work in Rust and TypeScript, prefer terse output, and care about test coverage."
+        />
+      </div>
+
+      {/* Write your own */}
+      <div className="space-y-1">
+        <p className="text-sm font-medium">Write your own (optional)</p>
+        <Textarea
+          value={customAgent}
+          onChange={(e) => setCustomAgent(e.target.value)}
+          rows={2}
+          placeholder="Describe an agent in plain language — e.g. “watch my CI runs and summarize failures.”"
+        />
+      </div>
+
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="flex justify-end">
+        <Button onClick={finish} disabled={saving}>
+          {saving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
+          Finish setup
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -477,6 +477,21 @@ export const api = {
     update: (data: PreferencesUpdate, token: string) =>
       request<Preferences>("/api/preferences", { method: "PUT", body: JSON.stringify(data), token }),
   },
+  onboarding: {
+    finish: (
+      data: {
+        use_case?: string;
+        custom_instructions?: string;
+        template_ids?: string[];
+        custom_agents?: { name?: string; description: string }[];
+      },
+      token: string,
+    ) =>
+      request<{ ok: boolean; created_agents: number; agents: { id: string; name: string }[] }>(
+        "/api/onboarding/finish",
+        { method: "POST", body: JSON.stringify(data), token },
+      ),
+  },
   dispatch: {
     // The user's agents + blueprints, for the composer's target-override picker.
     targets: (token: string) => request<CatalogEntry[]>("/api/dispatch/targets", { token }),

--- a/frontend/tests/onboarding.test.tsx
+++ b/frontend/tests/onboarding.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  getToken: vi.fn(async () => "test-token"),
+}));
+
+const templates = vi.fn();
+const finish = vi.fn();
+const updatePrefs = vi.fn();
+vi.mock("@/lib/api", () => ({
+  api: {
+    agents: { templates: (...a: unknown[]) => templates(...a) },
+    onboarding: { finish: (...a: unknown[]) => finish(...a) },
+    preferences: { update: (...a: unknown[]) => updatePrefs(...a) },
+    // ConnectModel (rendered by the page) references these; never called in these tests.
+    providers: { verify: vi.fn(), connect: vi.fn() },
+  },
+}));
+
+describe("TailorAndSeed", () => {
+  beforeEach(() => {
+    templates.mockReset();
+    finish.mockReset();
+    push.mockReset();
+    templates.mockResolvedValue([
+      { id: "t1", name: "Code Reviewer", description: "reviews code" },
+      { id: "t2", name: "Research Agent", description: "does research" },
+    ]);
+    finish.mockResolvedValue({ ok: true, created_agents: 2, agents: [] });
+  });
+
+  it("seeds selected templates + custom instructions on finish", async () => {
+    const { TailorAndSeed } = await import("@/components/onboarding/TailorAndSeed");
+    const onDone = vi.fn();
+    render(<TailorAndSeed onDone={onDone} onSkip={vi.fn()} />);
+
+    // Templates load and default to selected.
+    await waitFor(() => expect(screen.getByLabelText("Code Reviewer")).toBeInTheDocument());
+
+    const ta = screen.getByPlaceholderText(/I work in Rust/i);
+    fireEvent.change(ta, { target: { value: "I use TypeScript." } });
+
+    fireEvent.click(screen.getByText("Finish setup"));
+
+    await waitFor(() => expect(onDone).toHaveBeenCalled());
+    const [payload, token] = finish.mock.calls[0];
+    expect(token).toBe("test-token");
+    expect(payload.custom_instructions).toBe("I use TypeScript.");
+    expect(payload.template_ids).toEqual(expect.arrayContaining(["t1", "t2"]));
+  });
+
+  it("Skip calls onSkip", async () => {
+    const { TailorAndSeed } = await import("@/components/onboarding/TailorAndSeed");
+    const onSkip = vi.fn();
+    render(<TailorAndSeed onDone={vi.fn()} onSkip={onSkip} />);
+    fireEvent.click(screen.getByText("Skip"));
+    expect(onSkip).toHaveBeenCalled();
+  });
+});
+
+describe("OnboardingPage", () => {
+  beforeEach(() => {
+    push.mockReset();
+    updatePrefs.mockReset();
+    updatePrefs.mockResolvedValue({});
+  });
+
+  it("starts on the connect step and 'Skip setup' marks onboarded + leaves", async () => {
+    const OnboardingPage = (await import("@/app/onboarding/page")).default;
+    render(<OnboardingPage />);
+
+    // The connect step is shown first (its Verify button is unique to it).
+    expect(screen.getByText("Verify")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Skip setup"));
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/dashboard"));
+    expect(updatePrefs).toHaveBeenCalledWith(
+      expect.objectContaining({ onboarded_at: expect.any(String) }),
+      "test-token",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

**PR-5** of the onboarding series — the UX shell + the skip safety net's entry point.

- **`/onboarding`** — a two-screen stepper (per the spec's "two real screens" guidance): **ConnectModel** (PR-2) → **TailorAndSeed** (use-case chips that pre-select templates, starter-agent toggles defaulting on, custom-instructions textarea, write-your-own). **Skip on every step** + a persistent **"Skip setup"** that marks `onboarded_at` and routes to the dashboard. Finish calls `/api/onboarding/finish`. Nothing is required to advance; Back is available.
- **`OnboardingGate`** — mounted on the dashboard page (the post-login landing route): redirects a logged-in, not-yet-onboarded user to `/onboarding` in **live mode only**; **never traps** (errors swallowed; Skip sets `onboarded_at`). Implemented as a small client guard rather than editing the nav layout.

## Live verification (full flow, local Ollama stack)

1. Fresh user → **redirected to `/onboarding`**.
2. Local tab → **detected `qwen2.5:7b-instruct` + `llama3.2:3b` with no key** → connected.
3. Picked "Coding" (→ pre-selected the Code Reviewer template) + custom instructions + a write-your-own agent.
4. **Finish** → seeded 2 tailored agents (both carry the `--- About this user ---` block), set `onboarded_at` + `use_case=coding` + `custom_instructions`, landed on `/dashboard`.
5. Re-visiting `/dashboard` as the onboarded user **does not redirect** (no loop).

Demo-parity `/dashboard` still loads with no fatal console errors.

## Tests

`tests/onboarding.test.tsx` (3): TailorAndSeed seeds selected templates + instructions on Finish; Skip calls onSkip; the stepper starts on Connect and "Skip setup" marks onboarded + routes to the dashboard.

## Verification

`tsc` ✅ `lint` ✅ `vitest` ✅ (54). Demo-parity e2e ✅. Entropy clean (kept the gate out of the high-entropy nav layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)