### PR TITLE
feat(web): dashboard getting-started checklist + disabled-composer state

### DIFF
--- a/backend/app/db/sqlite_schema.py
+++ b/backend/app/db/sqlite_schema.py
@@ -537,6 +537,7 @@ CREATE TABLE IF NOT EXISTS user_preferences (
     onboarded_at        TEXT,
     use_case            TEXT,
     custom_instructions TEXT,
+    getting_started_dismissed INTEGER DEFAULT 0,
     created_at          TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     updated_at          TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
@@ -735,4 +736,5 @@ COLUMN_MIGRATIONS: list[tuple[str, str, str]] = [
     ("user_preferences", "onboarded_at", "TEXT"),
     ("user_preferences", "use_case", "TEXT"),
     ("user_preferences", "custom_instructions", "TEXT"),
+    ("user_preferences", "getting_started_dismissed", "INTEGER DEFAULT 0"),
 ]

--- a/backend/app/routers/preferences.py
+++ b/backend/app/routers/preferences.py
@@ -20,6 +20,7 @@ class PreferencesUpdate(BaseModel):
     use_case: str | None = None
     custom_instructions: str | None = None
     onboarded_at: str | None = None
+    getting_started_dismissed: bool | None = None
 
 
 def _get_or_create(user_id: str) -> dict:

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { OnboardingGate } from "@/components/onboarding/OnboardingGate";
+import { GettingStarted } from "@/components/dashboard/GettingStarted";
 import { DashboardComposer } from "@/components/dashboard/DashboardComposer";
 import { LiveStatusSection } from "@/components/dashboard/sections/LiveStatusSection";
 import { UsageCostSection } from "@/components/dashboard/sections/UsageCostSection";
@@ -63,6 +64,7 @@ export default function DashboardPage() {
         </div>
       </div>
 
+      <GettingStarted />
       <DashboardComposer />
       <LiveStatusSection onConnectedChange={handleConnectedChange} />
       <UsageCostSection />

--- a/frontend/components/dashboard/DashboardComposer.tsx
+++ b/frontend/components/dashboard/DashboardComposer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { api, type Attachment, type CatalogEntry, type DispatchEvent } from "@/lib/api";
 import { getToken } from "@/lib/auth-client";
 import { isDemoMode } from "@/lib/demo-data";
@@ -32,10 +33,12 @@ export function DashboardComposer() {
   const [thread, setThread] = useState<ThreadState | null>(null);
   const [busy, setBusy] = useState(false);
   const [targets, setTargets] = useState<CatalogEntry[]>([]);
+  const [hasProvider, setHasProvider] = useState(true); // assume yes until checked, to avoid a flash
   const abortRef = useRef<AbortController | null>(null);
   const demo = typeof window !== "undefined" && isDemoMode();
 
-  // Load the user's agents/blueprints once, for the override picker.
+  // Load the user's agents/blueprints (override picker) + whether a provider is
+  // connected (drives the disabled-composer state) once.
   useEffect(() => {
     if (demo) return;
     let cancelled = false;
@@ -48,11 +51,19 @@ export function DashboardComposer() {
       } catch {
         // Non-fatal — the override picker just won't show.
       }
+      try {
+        const providers = await api.providers.list(token);
+        if (!cancelled) setHasProvider((providers.providers?.length ?? 0) > 0);
+      } catch {
+        // Non-fatal — leave the composer enabled rather than block the user.
+      }
     })();
     return () => {
       cancelled = true;
     };
   }, [demo]);
+
+  const noProvider = !demo && !hasProvider;
 
   const runDispatch = useCallback(async (
     message: string,
@@ -205,11 +216,22 @@ export function DashboardComposer() {
 
   return (
     <section className="space-y-3" aria-label="Command composer">
+      {noProvider && (
+        <div
+          className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dashed bg-muted/40 p-3 text-sm"
+          data-testid="composer-no-provider"
+        >
+          <span className="text-muted-foreground">Connect a model to start dispatching tasks.</span>
+          <Link href="/dashboard/connections" className="font-medium text-primary hover:underline">
+            Connect a model →
+          </Link>
+        </div>
+      )}
       <Composer
         onSend={handleSend}
-        onTranscribe={demo ? undefined : handleTranscribe}
+        onTranscribe={demo || noProvider ? undefined : handleTranscribe}
         busy={busy}
-        disabled={demo}
+        disabled={demo || noProvider}
       />
       <DispatchThread
         thread={thread}

--- a/frontend/components/dashboard/GettingStarted.tsx
+++ b/frontend/components/dashboard/GettingStarted.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { CheckCircle2, Circle, X } from "lucide-react";
+import { api, type Preferences } from "@/lib/api";
+import { getToken } from "@/lib/auth-client";
+import { useBackendMode } from "@/lib/backend-context";
+
+type Item = {
+  label: string;
+  done: boolean;
+  core: boolean;
+  href?: string;
+  onClick?: () => void;
+};
+
+function focusComposer() {
+  const el = document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Command composer"]');
+  if (el) {
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.focus();
+  }
+}
+
+/**
+ * Dashboard "Getting started" checklist — the safety net for anyone who skipped
+ * onboarding. Items are live-computed; the card auto-hides when the core items
+ * are done or when dismissed (persisted to user_preferences). Live mode only.
+ */
+export function GettingStarted() {
+  const { mode } = useBackendMode();
+  const [prefs, setPrefs] = useState<Preferences | null>(null);
+  const [hasProvider, setHasProvider] = useState(false);
+  const [hasAgent, setHasAgent] = useState(false);
+  const [hasRun, setHasRun] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (mode !== "live") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await getToken();
+        if (!token) return;
+        const [p, providers, agents, runs] = await Promise.all([
+          api.preferences.get(token),
+          api.providers.list(token).catch(() => ({ providers: [] as string[] })),
+          api.agents.list(token).catch(() => []),
+          api.runs.list(token).catch(() => []),
+        ]);
+        if (cancelled) return;
+        setPrefs(p);
+        setHasProvider((providers.providers?.length ?? 0) > 0);
+        setHasAgent(agents.length > 0);
+        setHasRun(runs.length > 0);
+      } catch {
+        // non-fatal — just don't show the checklist
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mode]);
+
+  if (mode !== "live" || !loaded || dismissed) return null;
+  if (prefs?.getting_started_dismissed) return null;
+
+  const items: Item[] = [
+    { label: "Connect a model", done: hasProvider, core: true, href: "/dashboard/connections" },
+    { label: "Choose what you're working on", done: !!prefs?.use_case, core: false, href: "/onboarding" },
+    { label: "Add an agent", done: hasAgent, core: true, href: "/dashboard/agents/new" },
+    { label: "Run your first task", done: hasRun, core: true, onClick: focusComposer },
+    { label: "Add custom instructions", done: !!prefs?.custom_instructions, core: false, href: "/onboarding" },
+  ];
+
+  // Auto-hide once the core items are all done.
+  if (items.filter((i) => i.core).every((i) => i.done)) return null;
+
+  const dismiss = async () => {
+    setDismissed(true);
+    try {
+      const token = await getToken();
+      if (token) await api.preferences.update({ getting_started_dismissed: true }, token);
+    } catch {
+      // best-effort — the card is already hidden for this session
+    }
+  };
+
+  const doneCount = items.filter((i) => i.done).length;
+
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm" data-testid="getting-started">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Getting started</h2>
+          <p className="text-sm text-muted-foreground">
+            {doneCount}/{items.length} done — finish setting up Forge.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="Dismiss getting started"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <ul className="mt-3 space-y-1.5">
+        {items.map((item) => {
+          const icon = item.done ? (
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+          ) : (
+            <Circle className="h-4 w-4 text-muted-foreground" />
+          );
+          const label = (
+            <span className={`text-sm ${item.done ? "text-muted-foreground line-through" : ""}`}>{item.label}</span>
+          );
+          return (
+            <li key={item.label} className="flex items-center gap-2">
+              {icon}
+              {item.done ? (
+                label
+              ) : item.href ? (
+                <Link href={item.href} className="text-sm hover:underline">
+                  {item.label}
+                </Link>
+              ) : (
+                <button type="button" onClick={item.onClick} className="text-sm hover:underline">
+                  {item.label}
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -67,6 +67,7 @@ export interface Preferences {
   onboarded_at: string | null;
   use_case: string | null;
   custom_instructions: string | null;
+  getting_started_dismissed?: boolean | number | null;
 }
 
 export interface PreferencesUpdate {
@@ -75,6 +76,7 @@ export interface PreferencesUpdate {
   use_case?: string;
   custom_instructions?: string;
   onboarded_at?: string;
+  getting_started_dismissed?: boolean;
 }
 
 export type ProviderKind = "cloud" | "ollama" | "generic";

--- a/frontend/tests/dashboard-composer.test.tsx
+++ b/frontend/tests/dashboard-composer.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+vi.mock("@/lib/auth-client", () => ({ getToken: vi.fn(async () => "test-token") }));
+vi.mock("@/lib/demo-data", () => ({ isDemoMode: () => false }));
+
+const targets = vi.fn();
+const providersList = vi.fn();
+vi.mock("@/lib/api", () => ({
+  api: {
+    dispatch: { targets: (...a: unknown[]) => targets(...a), send: vi.fn() },
+    providers: { list: (...a: unknown[]) => providersList(...a) },
+    uploads: { files: vi.fn() },
+    transcribe: { send: vi.fn() },
+  },
+}));
+
+describe("DashboardComposer — disabled state without a provider", () => {
+  beforeEach(() => {
+    targets.mockReset().mockResolvedValue([]);
+    providersList.mockReset();
+  });
+
+  it("shows a Connect-a-model CTA and disables the composer when no provider", async () => {
+    providersList.mockResolvedValue({ providers: [] });
+    const { DashboardComposer } = await import("@/components/dashboard/DashboardComposer");
+    render(<DashboardComposer />);
+
+    await waitFor(() => expect(screen.getByTestId("composer-no-provider")).toBeInTheDocument());
+    expect(screen.getByText("Connect a model →").closest("a")).toHaveAttribute("href", "/dashboard/connections");
+    expect(screen.getByLabelText("Command composer", { selector: "textarea" })).toBeDisabled();
+  });
+
+  it("enables the composer when a provider is connected", async () => {
+    providersList.mockResolvedValue({ providers: ["ollama"] });
+    const { DashboardComposer } = await import("@/components/dashboard/DashboardComposer");
+    render(<DashboardComposer />);
+
+    await waitFor(() => expect(providersList).toHaveBeenCalled());
+    expect(screen.queryByTestId("composer-no-provider")).toBeNull();
+    expect(screen.getByLabelText("Command composer", { selector: "textarea" })).not.toBeDisabled();
+  });
+});

--- a/frontend/tests/getting-started.test.tsx
+++ b/frontend/tests/getting-started.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/lib/auth-client", () => ({ getToken: vi.fn(async () => "test-token") }));
+vi.mock("@/lib/backend-context", () => ({ useBackendMode: () => ({ mode: "live", backendUrl: "" }) }));
+
+const prefsGet = vi.fn();
+const prefsUpdate = vi.fn();
+const providersList = vi.fn();
+const agentsList = vi.fn();
+const runsList = vi.fn();
+vi.mock("@/lib/api", () => ({
+  api: {
+    preferences: { get: (...a: unknown[]) => prefsGet(...a), update: (...a: unknown[]) => prefsUpdate(...a) },
+    providers: { list: (...a: unknown[]) => providersList(...a) },
+    agents: { list: (...a: unknown[]) => agentsList(...a) },
+    runs: { list: (...a: unknown[]) => runsList(...a) },
+  },
+}));
+
+const basePrefs = {
+  user_id: "u1", default_model: null, default_provider: null,
+  onboarded_at: null, use_case: null, custom_instructions: null, getting_started_dismissed: false,
+};
+
+describe("GettingStarted", () => {
+  beforeEach(() => {
+    prefsGet.mockReset();
+    prefsUpdate.mockReset().mockResolvedValue({});
+    providersList.mockReset().mockResolvedValue({ providers: [] });
+    agentsList.mockReset().mockResolvedValue([]);
+    runsList.mockReset().mockResolvedValue([]);
+  });
+
+  it("shows the checklist with incomplete items for a fresh account", async () => {
+    prefsGet.mockResolvedValue(basePrefs);
+    const { GettingStarted } = await import("@/components/dashboard/GettingStarted");
+    render(<GettingStarted />);
+
+    await waitFor(() => expect(screen.getByTestId("getting-started")).toBeInTheDocument());
+    expect(screen.getByText("Connect a model")).toBeInTheDocument();
+    expect(screen.getByText("Add an agent")).toBeInTheDocument();
+    expect(screen.getByText("0/5 done — finish setting up Forge.")).toBeInTheDocument();
+  });
+
+  it("auto-hides when the core items are all done", async () => {
+    prefsGet.mockResolvedValue(basePrefs);
+    providersList.mockResolvedValue({ providers: ["ollama"] });
+    agentsList.mockResolvedValue([{ id: "a1" }]);
+    runsList.mockResolvedValue([{ id: "r1" }]);
+    const { GettingStarted } = await import("@/components/dashboard/GettingStarted");
+    const { container } = render(<GettingStarted />);
+
+    await waitFor(() => expect(prefsGet).toHaveBeenCalled());
+    await waitFor(() => expect(container.querySelector('[data-testid="getting-started"]')).toBeNull());
+  });
+
+  it("dismiss persists the flag and hides the card", async () => {
+    prefsGet.mockResolvedValue(basePrefs);
+    const { GettingStarted } = await import("@/components/dashboard/GettingStarted");
+    render(<GettingStarted />);
+
+    await waitFor(() => expect(screen.getByTestId("getting-started")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText("Dismiss getting started"));
+
+    await waitFor(() => expect(screen.queryByTestId("getting-started")).toBeNull());
+    expect(prefsUpdate).toHaveBeenCalledWith({ getting_started_dismissed: true }, "test-token");
+  });
+
+  it("stays hidden when already dismissed in preferences", async () => {
+    prefsGet.mockResolvedValue({ ...basePrefs, getting_started_dismissed: true });
+    const { GettingStarted } = await import("@/components/dashboard/GettingStarted");
+    const { container } = render(<GettingStarted />);
+    await waitFor(() => expect(prefsGet).toHaveBeenCalled());
+    expect(container.querySelector('[data-testid="getting-started"]')).toBeNull();
+  });
+});

--- a/supabase/migrations/20260602_getting_started.sql
+++ b/supabase/migrations/20260602_getting_started.sql
@@ -1,0 +1,3 @@
+-- forge-onboarding-spec (PR-6) — dashboard getting-started checklist dismissal.
+
+ALTER TABLE user_preferences ADD COLUMN IF NOT EXISTS getting_started_dismissed BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
## Summary

**PR-6** — the safety net for anyone who skipped onboarding, plus a graceful no-provider state. Completes the series.

- **`GettingStarted`** card: live-computed checklist — Connect a model ✓/✗ (→ Connections), Choose what you're working on (→ /onboarding), Add an agent (→ new agent), Run your first task (focuses the composer), Add custom instructions (→ /onboarding). **Auto-hides** when the core items (connect / agent / first run) are done **or** when dismissed; dismissal **persists** to `user_preferences.getting_started_dismissed` (new column + idempotent SQLite migration + Supabase migration). Live mode only.
- **Disabled-composer state**: when no provider is connected, the dashboard composer renders **disabled** with a **"Connect a model →"** CTA to Connections — no dead input. Enables once a provider exists.

## Live verification (local stack)

A skipped user (onboarded, **no provider**) on `/dashboard`:
- **Checklist** shows `0/5 done` with all five items.
- **Composer disabled** + **"Connect a model"** CTA present.
- **Dismiss** → card hidden, `getting_started_dismissed` persisted to the backend (confirmed `= 1`), and the card **stays hidden on reload**.

## Tests

`getting-started.test.tsx` (4): shows incomplete checklist; auto-hides when core done; dismiss persists the flag + hides; stays hidden when already dismissed. `dashboard-composer.test.tsx` (2): no-provider → CTA + disabled composer; provider present → enabled.

## Verification

`ruff` ✅ `mypy` ✅ `pytest` ✅ (704 + 5 pre-existing CLI). `tsc` ✅ `lint` ✅ `vitest` ✅ (60). Entropy clean.

> Note: the new column reaches existing DBs via the idempotent `COLUMN_MIGRATIONS` pass on startup (verified on a copy of a real `forge.db`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)