### PR TITLE
fix(web): RunHistory 'Trace' link 404'd — point it at the traces page

### DIFF
--- a/frontend/components/dashboard/RunHistory.tsx
+++ b/frontend/components/dashboard/RunHistory.tsx
@@ -78,10 +78,10 @@ export function RunHistory({ limit }: { limit?: number } = {}) {
               {run.status}
             </Badge>
             <Link
-              href={`/dashboard/traces/${run.id}`}
+              href="/dashboard/traces"
               className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
             >
-              Trace →
+              Traces →
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary

RunHistory linked each run to `/dashboard/traces/${run.id}`, but there's **no per-id traces route** — the traces page shows the list with inline detail on click. So every "Trace →" was a dead **404**. Point it at `/dashboard/traces` and relabel **"Traces →"**.

(Same class of dead-link bug as the composer's run link, fixed earlier.)

## Verification

`tsc --noEmit` ✅  `lint` ✅  `vitest` ✅ (60). No tests referenced the old href.

> Also refreshes `main` with a run under the **now-synced LastGate gate** (v0.3.0) — the previous red `commit_message` check on main was the stale gate ignoring `severity: warn` (fixed by the LastGate redeploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)