### PR TITLE
chore(storage): restore natural literals now the LastGate gate is synced

### DIFF
--- a/backend/app/routers/uploads.py
+++ b/backend/app/routers/uploads.py
@@ -40,12 +40,10 @@ async def upload_files(
     for upload in files:
         data = await upload.read()
         if len(data) > MAX_FILE_BYTES:
-            # Built by concatenation rather than an f-string so the secret
-            # scanner's entropy heuristic doesn't flag the interpolated message.
             limit_mb = MAX_FILE_BYTES // (1024 * 1024)
             raise HTTPException(
                 status_code=413,
-                detail=(upload.filename or "file") + " exceeds the " + str(limit_mb) + "MB limit",
+                detail=f"{upload.filename or 'file'} exceeds the {limit_mb}MB limit",
             )
         mime = upload.content_type or "application/octet-stream"
         if storage.kind_for_mime(mime) is None:

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -20,12 +20,6 @@ from pathlib import Path
 
 BUCKET = "forge-uploads"
 
-# Defaults pulled into named constants so no single statement carries a long
-# interpolated/concatenated literal (the secret scanner's entropy heuristic
-# flags those as potential credentials).
-DEFAULT_UPLOAD_DIR = "/tmp/forge-uploads"
-_PUBLIC_OBJECT_PREFIX = "/storage/v1/object/public/"
-
 # Allowlisted MIME types. Anything else is rejected by the uploads endpoint
 # with HTTP 415.
 DOCUMENT_MIMES = {
@@ -57,14 +51,12 @@ def use_supabase() -> bool:
     if backend == "sqlite":
         return False
     # Auto: match create_db_from_env — Supabase if its env is configured.
-    has_url = bool(os.getenv("SUPABASE_URL"))
-    has_key = bool(os.getenv("SUPABASE_SERVICE_KEY"))
-    return has_url and has_key
+    return bool(os.getenv("SUPABASE_URL") and os.getenv("SUPABASE_SERVICE_KEY"))
 
 
 def upload_dir() -> Path:
     """The local upload directory, created on first use."""
-    d = Path(os.getenv("AF_UPLOAD_DIR", DEFAULT_UPLOAD_DIR))
+    d = Path(os.getenv("AF_UPLOAD_DIR", "/tmp/forge-uploads"))
     d.mkdir(parents=True, exist_ok=True)
     return d
 
@@ -99,9 +91,7 @@ def get_url(ref: str) -> str:
     if ref.startswith(("http://", "https://", "data:", "file://")):
         return ref
     if use_supabase():
-        # Concatenation via a named prefix constant keeps the secret scanner's
-        # entropy heuristic from flagging the public-object URL as a credential.
-        return os.environ["SUPABASE_URL"] + _PUBLIC_OBJECT_PREFIX + BUCKET + "/" + ref
+        return f"{os.environ['SUPABASE_URL']}/storage/v1/object/public/{BUCKET}/{ref}"
     return (upload_dir() / ref).as_uri()
 
 
@@ -117,9 +107,7 @@ def _save_local(file_id: str, name: str, data: bytes, mime: str, kind: str) -> s
 def _save_supabase(file_id: str, name: str, data: bytes, mime: str, user_id: str) -> str:
     from supabase import create_client
 
-    url = os.environ["SUPABASE_URL"]
-    service_key = os.environ["SUPABASE_SERVICE_KEY"]
-    client = create_client(url, service_key)
+    client = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_SERVICE_KEY"])
     key = f"{user_id}/{file_id}__{name}"
     bucket = client.storage.from_(BUCKET)
     # The forge-uploads bucket must exist and be public (created via the


### PR DESCRIPTION
## Summary

Reverts the entropy **band-aids** from the uploads PR (#83). The deployed LastGate now runs **engine v0.3.0** — conservative quote-breaking extraction + 4.8 threshold + added-lines scanning — which doesn't flag these f-strings (the stale gate's greedy whole-span extraction was the false-positive cause).

- `storage.py`: drop the `DEFAULT_UPLOAD_DIR` / `_PUBLIC_OBJECT_PREFIX` constants and the `has_url`/`has_key` + `url`/`service_key` splits; restore the inline default, the public-URL **f-string**, and the single `create_client(...)`.
- `uploads.py`: restore the size-limit **f-string**.

## Verification

Ran the **local v0.3.0 engine** (`checkSecrets`, every line treated as added — stricter than a real diff) against both files: **`status=pass, findings=0`**. So the live synced gate won't flag them.

`ruff` ✅  `mypy` ✅  `pytest tests/test_uploads.py` ✅ (13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)