### PR TITLE
Security audit: Forge — 9 fixes

### DIFF
--- a/backend/app/db/sqlite_backend.py
+++ b/backend/app/db/sqlite_backend.py
@@ -7,6 +7,7 @@ allowing all existing call sites to work without changes.
 from __future__ import annotations
 
 import json
+import os
 import re
 import uuid
 from datetime import UTC, datetime
@@ -554,7 +555,16 @@ class SQLiteAuthBackend(AuthBackend):
 
     def __init__(self, db_path: str, jwt_secret: str = "") -> None:
         self._db_path = db_path
-        self._jwt_secret = jwt_secret or "forge-local-dev-secret"
+        secret = jwt_secret or os.environ.get("FORGE_JWT_SECRET", "")
+        if not secret:
+            if os.environ.get("FORGE_TESTING", "").lower() in ("1", "true"):
+                secret = "forge-local-dev-secret"
+            else:
+                raise RuntimeError(
+                    "FORGE_JWT_SECRET must be set to use SQLite local auth — "
+                    "refusing to sign tokens with a known development secret."
+                )
+        self._jwt_secret = secret
 
     def get_user(self, token: str) -> Any:
         """Verify a local JWT and return a user-like object."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,6 +55,11 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    # Warn when provider API keys can't be encrypted at rest
+    from app.services.security.secrets import warn_if_unconfigured
+
+    warn_if_unconfigured()
+
     # Initialize pluggable database backend
     db = create_db_from_env()
     init_db(db)

--- a/backend/app/providers/registry.py
+++ b/backend/app/providers/registry.py
@@ -233,9 +233,11 @@ async def create_user_registry(user_id: str) -> ProviderRegistry:
 
     registry = ProviderRegistry()
 
+    from app.services.security.secrets import decrypt_secret
+
     for config in configs:
         provider_name = config["provider"]
-        api_key = config.get("api_key_encrypted", "")
+        api_key = decrypt_secret(config.get("api_key_encrypted", ""))
         base_url = config.get("base_url", "") or None
         is_default = config.get("is_default", False)
 

--- a/backend/app/routers/auth_api.py
+++ b/backend/app/routers/auth_api.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from app.db import get_db
 from app.routers.auth import get_current_user
+from app.services.rate_limiter import limiter
 
 router = APIRouter(tags=["auth"])
 
@@ -49,7 +50,8 @@ class UserInfo(BaseModel):
 
 
 @router.post("/auth/signup", response_model=AuthResponse)
-async def signup(req: AuthRequest):
+@limiter.limit("3/minute")
+async def signup(req: AuthRequest, request: Request):
     """Create a local account."""
     db = get_db()
 
@@ -61,7 +63,8 @@ async def signup(req: AuthRequest):
     # Check if email already exists
     existing = db.table("local_users").select("id").eq("email", req.email).execute()
     if existing.data:
-        raise HTTPException(status_code=409, detail="Email already registered")
+        # Generic message — don't confirm whether an email is registered.
+        raise HTTPException(status_code=400, detail="Unable to create account with the provided credentials")
 
     # Hash password
     import bcrypt
@@ -89,7 +92,8 @@ async def signup(req: AuthRequest):
 
 
 @router.post("/auth/login", response_model=AuthResponse)
-async def login(req: AuthRequest):
+@limiter.limit("5/minute")
+async def login(req: AuthRequest, request: Request):
     """Login with email/password and get a JWT."""
     db = get_db()
 

--- a/backend/app/routers/computer_use.py
+++ b/backend/app/routers/computer_use.py
@@ -52,14 +52,15 @@ async def test_remote(_user=Depends(get_current_user)):  # noqa: B008
 
 
 @router.get("/computer-use/audit-log")
-async def audit_log(limit: int = 50, _user=Depends(get_current_user)):  # noqa: B008
-    """Return recent computer use audit log entries."""
+async def audit_log(limit: int = 50, user=Depends(get_current_user)):  # noqa: B008
+    """Return the current user's recent computer use audit log entries."""
     from app.db import get_db
 
     try:
         result = (
             get_db().table("computer_use_audit_log")
             .select("*")
+            .eq("user_id", user.id)
             .order("created_at", desc=True)
             .limit(limit)
             .execute()

--- a/backend/app/routers/mcp.py
+++ b/backend/app/routers/mcp.py
@@ -13,6 +13,7 @@ from app.db import get_db
 from app.mcp.client import mcp_client
 from app.mcp.tool_registry import tool_registry
 from app.routers.auth import get_current_user
+from app.services.security.url_validator import SSRFError, validate_url
 
 router = APIRouter(tags=["mcp"])
 
@@ -40,6 +41,11 @@ async def connect_mcp_server(
     req: MCPConnectRequest, user: Any = Depends(get_current_user)  # noqa: B008
 ) -> dict[str, Any]:
     """Add and test an MCP server connection."""
+    try:
+        validate_url(req.server_url)
+    except SSRFError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     # Test connection first
     status = await mcp_client.connect(req.server_url)
 
@@ -114,6 +120,11 @@ async def list_connection_tools(
         raise HTTPException(status_code=404, detail="Connection not found")
 
     conn = result.data
+    try:
+        validate_url(conn["server_url"])
+    except SSRFError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     # Re-discover tools from the server
     tools = await mcp_client.discover_tools(
         conn["server_url"], server_id=conn["id"], server_name=conn["name"]

--- a/backend/app/routers/providers.py
+++ b/backend/app/routers/providers.py
@@ -11,6 +11,7 @@ from app.db import get_db
 from app.providers.registry import create_user_registry
 from app.routers.auth import get_current_user
 from app.services.security.secrets import decrypt_secret, encrypt_secret
+from app.services.security.url_validator import SSRFError, validate_url
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["providers"])
@@ -41,8 +42,20 @@ class ProviderConnectRequest(BaseModel):
     model: str | None = None
 
 
+def _validate_base_url(base_url: str | None, *, allow_localhost: bool = False) -> None:
+    """Reject SSRF-prone base URLs with a 400 before any fetch."""
+    if not base_url:
+        return
+    try:
+        validate_url(base_url, allow_localhost=allow_localhost)
+    except SSRFError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 def _build_provider(req: ProviderVerifyRequest | ProviderConnectRequest):
     """Instantiate the right provider class for a verify/connect request."""
+    # Ollama is expected to be a local/LAN daemon; generic endpoints must be public.
+    _validate_base_url(req.base_url, allow_localhost=req.kind == "ollama")
     if req.kind == "cloud":
         if req.provider == "openai":
             from app.providers.openai_provider import OpenAIProvider
@@ -150,6 +163,7 @@ class ModelResponse(BaseModel):
 @router.post("/providers/configs")
 async def save_provider_config(config: ProviderConfigCreate, user=Depends(get_current_user)):  # noqa: B008
     """Save or update a user's provider configuration."""
+    _validate_base_url(config.base_url, allow_localhost=config.provider == "ollama")
     data = {
         "user_id": user.id,
         "provider": config.provider,

--- a/backend/app/routers/providers.py
+++ b/backend/app/routers/providers.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from app.db import get_db
 from app.providers.registry import create_user_registry
 from app.routers.auth import get_current_user
+from app.services.security.secrets import decrypt_secret, encrypt_secret
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["providers"])
@@ -101,7 +102,7 @@ async def connect_provider(req: ProviderConnectRequest, user=Depends(get_current
         {
             "user_id": user.id,
             "provider": name,
-            "api_key_encrypted": req.api_key or "",  # plaintext; access control via RLS
+            "api_key_encrypted": encrypt_secret(req.api_key or ""),
             "base_url": req.base_url or "",
             "is_default": True,
             "is_enabled": True,
@@ -152,7 +153,7 @@ async def save_provider_config(config: ProviderConfigCreate, user=Depends(get_cu
     data = {
         "user_id": user.id,
         "provider": config.provider,
-        "api_key_encrypted": config.api_key or "",  # WARNING: stored as plaintext. Access control relies on Supabase RLS policies.
+        "api_key_encrypted": encrypt_secret(config.api_key or ""),
         "base_url": config.base_url or "",
         "is_default": config.is_default,
         "is_enabled": True,
@@ -177,7 +178,7 @@ async def list_provider_configs(user=Depends(get_current_user)):  # noqa: B008
 
     # Mask API keys
     for c in configs:
-        key = c.get("api_key_encrypted", "")
+        key = decrypt_secret(c.get("api_key_encrypted", ""))
         c["api_key_masked"] = f"{key[:8]}...{key[-4:]}" if len(key) > 12 else "***"
         del c["api_key_encrypted"]
 

--- a/backend/app/routers/ws_terminal.py
+++ b/backend/app/routers/ws_terminal.py
@@ -22,18 +22,27 @@ router = APIRouter()
 @router.websocket("/ws/terminal/{workspace_id}")
 async def terminal_websocket(websocket: WebSocket, workspace_id: str, token: str = ""):
     """WebSocket terminal: spawns a pty shell with CWD set to workspace directory."""
-    # Auth check
-    if token:
-        try:
-            get_db().auth.get_user(token)
-        except Exception:
-            await websocket.close(code=4001, reason="Invalid token")
-            return
+    # Auth check — a valid token is required
+    if not token:
+        await websocket.close(code=4401, reason="Authentication required")
+        return
+    try:
+        user_response = get_db().auth.get_user(token)
+        # Supabase returns response.user, local auth returns user directly
+        user = user_response.user if hasattr(user_response, "user") else user_response
+        if not user or not getattr(user, "id", None):
+            raise ValueError("Invalid token")
+    except Exception:
+        await websocket.close(code=4401, reason="Invalid token")
+        return
 
-    # Get workspace path
-    result = get_db().table("workspaces").select("path").eq("id", workspace_id).single().execute()
+    # Get workspace path and verify ownership
+    result = get_db().table("workspaces").select("path, user_id").eq("id", workspace_id).single().execute()
     if not result.data:
         await websocket.close(code=4004, reason="Workspace not found")
+        return
+    if result.data["user_id"] != user.id:
+        await websocket.close(code=4403, reason="Not authorized")
         return
 
     workspace_path = str(result.data["path"])

--- a/backend/app/routers/ws_workspace.py
+++ b/backend/app/routers/ws_workspace.py
@@ -28,18 +28,27 @@ async def workspace_websocket(websocket: WebSocket, workspace_id: str, token: st
     Clients can send:
     - file_save: {type: "file_save", path, content} — saves file to disk
     """
-    # Auth check
-    if token:
-        try:
-            get_db().auth.get_user(token)
-        except Exception:
-            await websocket.close(code=4001, reason="Invalid token")
-            return
+    # Auth check — a valid token is required
+    if not token:
+        await websocket.close(code=4401, reason="Authentication required")
+        return
+    try:
+        user_response = get_db().auth.get_user(token)
+        # Supabase returns response.user, local auth returns user directly
+        user = user_response.user if hasattr(user_response, "user") else user_response
+        if not user or not getattr(user, "id", None):
+            raise ValueError("Invalid token")
+    except Exception:
+        await websocket.close(code=4401, reason="Invalid token")
+        return
 
-    # Verify workspace exists
-    result = get_db().table("workspaces").select("path").eq("id", workspace_id).single().execute()
+    # Verify workspace exists and belongs to this user
+    result = get_db().table("workspaces").select("path, user_id").eq("id", workspace_id).single().execute()
     if not result.data:
         await websocket.close(code=4004, reason="Workspace not found")
+        return
+    if result.data["user_id"] != user.id:
+        await websocket.close(code=4403, reason="Not authorized")
         return
 
     workspace_path = result.data["path"]

--- a/backend/app/services/agent_executor.py
+++ b/backend/app/services/agent_executor.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import AsyncIterator
 from typing import Any
+from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 from langchain.agents import AgentExecutor, create_openai_tools_agent
@@ -8,6 +9,7 @@ from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
 
 from app.mcp.tool_registry import tool_registry
 from app.providers.registry import provider_registry
+from app.services.security.url_validator import SSRFError, validate_url
 from app.services.tools.code_executor import code_executor
 from app.services.tools.data_extractor import data_extractor
 from app.services.tools.document_reader import document_reader
@@ -237,8 +239,15 @@ class AgentRunner:
                     notes.append(f"[image omitted: model not multimodal] {name}")
             elif kind == "document":
                 try:
+                    # Remote URLs must pass the SSRF check; local file:// refs
+                    # are restricted to the upload dir inside extract_text.
+                    if urlparse(url).scheme in ("http", "https"):
+                        validate_url(url)
                     text = await extract_text(url)
                     doc_parts.append(f"--- file: {name} ---\n{text}")
+                except SSRFError:
+                    logger.warning("Blocked attachment URL %s", name)
+                    notes.append(f"[document omitted: URL not allowed for {name}]")
                 except Exception:
                     logger.warning("Failed to extract attachment %s", name, exc_info=True)
                     notes.append(f"[document omitted: could not read {name}]")

--- a/backend/app/services/evals/grading.py
+++ b/backend/app/services/evals/grading.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from typing import Any
 
@@ -153,6 +154,14 @@ def grade_custom(actual: str, expected: str, config: dict[str, Any]) -> dict[str
     func_str = config.get("function", "")
     if not func_str:
         return {"passed": False, "score": 0.0, "method": "custom", "error": "No function provided"}
+
+    if os.environ.get("FORGE_ALLOW_CUSTOM_GRADERS", "").lower() not in ("1", "true"):
+        return {
+            "passed": False,
+            "score": 0.0,
+            "method": "custom",
+            "error": "Custom graders are disabled. Set FORGE_ALLOW_CUSTOM_GRADERS=1 to enable executing custom grading functions.",
+        }
 
     try:
         # Create a restricted namespace

--- a/backend/app/services/extract.py
+++ b/backend/app/services/extract.py
@@ -17,6 +17,9 @@ import httpx
 from docx import Document
 from pypdf import PdfReader
 
+from app.services import storage
+from app.services.security.url_validator import validate_url
+
 # Cap extracted text so a large upload can't blow up a prompt/context window.
 MAX_CHARS = 10_000
 
@@ -45,14 +48,23 @@ async def _load(file_url: str) -> tuple[bytes, str, str]:
     parsed = urlparse(file_url)
 
     if parsed.scheme in ("http", "https"):
+        validate_url(file_url)  # SSRF guard — blocks internal/private targets
         async with httpx.AsyncClient() as client:
             response = await client.get(file_url, timeout=30.0, follow_redirects=True)
         response.raise_for_status()
         return response.content, response.headers.get("content-type", ""), parsed.path
 
-    # Local file: a ``file://`` URI or a bare filesystem path.
+    if parsed.scheme not in ("", "file"):
+        raise ValueError(f"Unsupported URL scheme: {parsed.scheme}")
+
+    # Local file: a ``file://`` URI or a bare filesystem path. Only files the
+    # uploads storage backend wrote (inside the upload dir) may be read back —
+    # anything else is an arbitrary-local-file-read primitive.
     path = Path(unquote(parsed.path)) if parsed.scheme == "file" else Path(file_url)
-    return path.read_bytes(), "", path.name
+    resolved = path.resolve()
+    if not resolved.is_relative_to(storage.upload_dir().resolve()):
+        raise ValueError("Local file access is restricted to the upload directory")
+    return resolved.read_bytes(), "", resolved.name
 
 
 def _extract_pdf(file_bytes: bytes) -> str:

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -89,7 +89,9 @@ class KnowledgeService:
                 .execute()
             )
             if result.data and result.data.get("api_key_encrypted"):
-                return str(result.data["api_key_encrypted"])
+                from app.services.security.secrets import decrypt_secret
+
+                return decrypt_secret(str(result.data["api_key_encrypted"]))
         except Exception:
             pass
         return None

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -41,7 +41,9 @@ async def get_user_openai_key(user_id: str | None) -> str | None:
                 .execute()
             )
             if result.data and result.data.get("api_key_encrypted"):
-                api_key = result.data["api_key_encrypted"]
+                from app.services.security.secrets import decrypt_secret
+
+                api_key = decrypt_secret(result.data["api_key_encrypted"])
         except Exception:
             logger.debug("No user openai provider config for %s", user_id, exc_info=True)
 

--- a/backend/app/services/security/secrets.py
+++ b/backend/app/services/security/secrets.py
@@ -45,7 +45,8 @@ def encrypt_secret(value: str) -> str:
     fernet = _get_fernet()
     if fernet is None:
         return value
-    return fernet.encrypt(value.encode()).decode()
+    encrypted: str = fernet.encrypt(value.encode()).decode()
+    return encrypted
 
 
 def decrypt_secret(value: str) -> str:
@@ -56,7 +57,8 @@ def decrypt_secret(value: str) -> str:
     if fernet is None:
         return value
     try:
-        return fernet.decrypt(value.encode()).decode()
+        decrypted: str = fernet.decrypt(value.encode()).decode()
+        return decrypted
     except Exception:
         # Legacy plaintext row (or a value encrypted with a different key).
         return value

--- a/backend/app/services/security/secrets.py
+++ b/backend/app/services/security/secrets.py
@@ -1,0 +1,62 @@
+"""Encrypt-at-rest helpers for provider API keys.
+
+Values are encrypted with Fernet using a key derived from
+``FORGE_ENCRYPTION_KEY``. When the env var is unset the helpers pass values
+through unchanged (legacy plaintext behavior) and a startup warning is logged.
+Decryption transparently falls back to treating the stored value as legacy
+plaintext when it is not a valid Fernet token.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def _get_fernet():
+    """Build a Fernet from FORGE_ENCRYPTION_KEY, or None when unset."""
+    secret = os.environ.get("FORGE_ENCRYPTION_KEY", "")
+    if not secret:
+        return None
+    from cryptography.fernet import Fernet
+
+    # Accept any string secret — derive a urlsafe 32-byte Fernet key from it.
+    key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode()).digest())
+    return Fernet(key)
+
+
+def warn_if_unconfigured() -> None:
+    """Log a startup warning when encryption-at-rest is not configured."""
+    if _get_fernet() is None:
+        logger.warning(
+            "FORGE_ENCRYPTION_KEY is not set — provider API keys will be stored "
+            "in plaintext. Set FORGE_ENCRYPTION_KEY to enable encryption at rest."
+        )
+
+
+def encrypt_secret(value: str) -> str:
+    """Encrypt ``value`` for storage; passthrough when no key is configured."""
+    if not value:
+        return value
+    fernet = _get_fernet()
+    if fernet is None:
+        return value
+    return fernet.encrypt(value.encode()).decode()
+
+
+def decrypt_secret(value: str) -> str:
+    """Decrypt a stored secret; legacy plaintext rows are returned unchanged."""
+    if not value:
+        return value
+    fernet = _get_fernet()
+    if fernet is None:
+        return value
+    try:
+        return fernet.decrypt(value.encode()).decode()
+    except Exception:
+        # Legacy plaintext row (or a value encrypted with a different key).
+        return value

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,8 @@ croniter==5.0.1
 aiosqlite>=0.20.0
 PyJWT>=2.8.0
 bcrypt>=4.1.0
+# Provider API key encryption at rest (FORGE_ENCRYPTION_KEY)
+cryptography>=42.0.0
 # Workspace file watching
 watchdog>=4.0.0
 # Optional: Supabase backend (install with: pip install supabase)

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -20,14 +20,16 @@ from app.services.extract import extract_text
 
 
 @pytest.mark.asyncio
-async def test_extract_text_reads_local_txt(tmp_path):
+async def test_extract_text_reads_local_txt(tmp_path, monkeypatch):
+    monkeypatch.setenv("AF_UPLOAD_DIR", str(tmp_path))
     f = tmp_path / "notes.txt"
     f.write_text("hello from a text file")
     assert await extract_text(str(f)) == "hello from a text file"
 
 
 @pytest.mark.asyncio
-async def test_extract_text_reads_local_docx(tmp_path):
+async def test_extract_text_reads_local_docx(tmp_path, monkeypatch):
+    monkeypatch.setenv("AF_UPLOAD_DIR", str(tmp_path))
     f = tmp_path / "report.docx"
     doc = Document()
     doc.add_paragraph("First line of the doc")
@@ -40,17 +42,32 @@ async def test_extract_text_reads_local_docx(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_extract_text_handles_file_uri(tmp_path):
+async def test_extract_text_handles_file_uri(tmp_path, monkeypatch):
+    monkeypatch.setenv("AF_UPLOAD_DIR", str(tmp_path))
     f = tmp_path / "readme.md"
     f.write_text("# Title\n\nbody")
     assert "# Title" in await extract_text(f.as_uri())
 
 
 @pytest.mark.asyncio
-async def test_extract_text_caps_length(tmp_path):
+async def test_extract_text_caps_length(tmp_path, monkeypatch):
+    monkeypatch.setenv("AF_UPLOAD_DIR", str(tmp_path))
     f = tmp_path / "big.txt"
     f.write_text("x" * 50_000)
     assert len(await extract_text(str(f))) == 10_000
+
+
+@pytest.mark.asyncio
+async def test_extract_text_rejects_file_outside_upload_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("AF_UPLOAD_DIR", str(tmp_path))
+    with pytest.raises(ValueError, match="upload directory"):
+        await extract_text("file:///etc/passwd")
+
+
+@pytest.mark.asyncio
+async def test_extract_text_rejects_unsupported_scheme():
+    with pytest.raises(ValueError, match="scheme"):
+        await extract_text("ftp://internal-host/secret.txt")
 
 
 # --- Vision detection ---------------------------------------------------------

--- a/backend/tests/test_evals.py
+++ b/backend/tests/test_evals.py
@@ -114,7 +114,8 @@ def test_json_schema_no_schema():
     assert result["passed"] is True
 
 
-def test_custom_grading():
+def test_custom_grading(monkeypatch):
+    monkeypatch.setenv("FORGE_ALLOW_CUSTOM_GRADERS", "1")
     func = """
 result = {"passed": len(actual) > 5, "score": min(len(actual) / 10, 1.0)}
 """
@@ -123,13 +124,21 @@ result = {"passed": len(actual) > 5, "score": min(len(actual) / 10, 1.0)}
     assert result["score"] > 0
 
 
+def test_custom_grading_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("FORGE_ALLOW_CUSTOM_GRADERS", raising=False)
+    result = grade_custom("test", "", {"function": "result = {'passed': True, 'score': 1.0}"})
+    assert result["passed"] is False
+    assert "disabled" in result.get("error", "")
+
+
 def test_custom_grading_no_function():
     result = grade_custom("test", "", {})
     assert result["passed"] is False
     assert "No function" in result.get("error", "")
 
 
-def test_custom_grading_error():
+def test_custom_grading_error(monkeypatch):
+    monkeypatch.setenv("FORGE_ALLOW_CUSTOM_GRADERS", "1")
     result = grade_custom("test", "", {"function": "raise ValueError('boom')"})
     assert result["passed"] is False
     assert "boom" in result.get("error", "")


### PR DESCRIPTION
Fixes from the June 2026 security audit, ordered by severity.

## Critical
- **Unauthenticated RCE via terminal WebSocket** — `backend/app/routers/ws_terminal.py` now closes with 4401 unless the token resolves to a valid user, and 4403 unless the workspace belongs to that user (previously `token` was optional and any workspace id spawned a shell).
- **IDOR / arbitrary file read-write via workspace sync WebSocket** — `backend/app/routers/ws_workspace.py` same auth + ownership enforcement.
- **Authenticated RCE via custom eval graders** — `backend/app/services/evals/grading.py` no longer `exec()`s user-supplied grader code unless `FORGE_ALLOW_CUSTOM_GRADERS=1` is set; disabled by default with a clear grading error.
- **Arbitrary local file read / SSRF via attachment URLs** — `backend/app/services/extract.py` now validates http(s) URLs with `validate_url`, rejects all other schemes, and restricts `file://`/bare-path reads to the uploads directory; `backend/app/services/agent_executor.py` validates remote attachment URLs before extraction. Covers the agent runner, dispatcher, and document_reader tool.

## High
- **Provider API keys stored in plaintext** — keys in `provider_configs.api_key_encrypted` are now Fernet-encrypted with a key derived from `FORGE_ENCRYPTION_KEY` (`backend/app/services/security/secrets.py`); decryption falls back transparently for legacy plaintext rows. If the env var is unset, a startup warning is logged and behavior is unchanged. Adds `cryptography` to `backend/requirements.txt`.
- **Hardcoded JWT fallback secret** — `backend/app/db/sqlite_backend.py` now requires `FORGE_JWT_SECRET` for SQLite local auth and raises at startup if unset outside test mode (`FORGE_TESTING`), instead of signing with the known `forge-local-dev-secret`.
- **SSRF via user-supplied MCP/provider URLs** — `backend/app/routers/mcp.py` and `backend/app/routers/providers.py` run server/base URLs through `validate_url` before any fetch (Ollama base URLs may stay local/LAN; generic endpoints must be public), returning 400 on blocked targets.
- **No rate limit on signup/login + email enumeration** — `backend/app/routers/auth_api.py` adds `@limiter.limit("3/minute")` on signup and `@limiter.limit("5/minute")` on login via the existing slowapi limiter, and replaces the "Email already registered" response with a generic message.

## Medium
- **Cross-user audit log exposure** — `backend/app/routers/computer_use.py` `/computer-use/audit-log` is now filtered by the requesting user's id.

## Verification
- `ruff check app/ --config ../ruff.toml` (CI invocation): clean.
- Backend tests: 689 passed / 23 skipped / 0 failed (baseline 686/23/0; +3 new tests covering the disabled-grader default and extraction URL restrictions).

## Operator follow-ups
- Set `FORGE_ENCRYPTION_KEY` and `FORGE_JWT_SECRET` in the deployment environment (Render) before merging.
- Rotate provider API keys stored prior to this change — they were persisted in plaintext.