### PR TITLE
Eval-driven self-optimization loop

### DIFF
--- a/backend/app/db/sqlite_schema.py
+++ b/backend/app/db/sqlite_schema.py
@@ -634,6 +634,51 @@ CREATE TABLE IF NOT EXISTS workspace_changes (
 CREATE INDEX IF NOT EXISTS idx_ws_changes_workspace ON workspace_changes(workspace_id);
 CREATE INDEX IF NOT EXISTS idx_ws_changes_file      ON workspace_changes(workspace_id, file_path);
 CREATE INDEX IF NOT EXISTS idx_ws_changes_time      ON workspace_changes(created_at);
+
+-- ===================== optimizer: optimization_runs (lineage) =====================
+-- One self-optimization attempt: baseline eval of an agent against a suite,
+-- N generated prompt variants, the winner, and the score delta. The promotion
+-- of the winner is gated behind an approval (approval_id), never auto-applied.
+CREATE TABLE IF NOT EXISTS optimization_runs (
+    id                  TEXT PRIMARY KEY,
+    user_id             TEXT NOT NULL,
+    agent_id            TEXT NOT NULL REFERENCES agents(id),
+    suite_id            TEXT NOT NULL REFERENCES eval_suites(id),
+    status              TEXT NOT NULL DEFAULT 'running'
+                        CHECK (status IN ('running','no_improvement','no_failures','awaiting_approval','failed')),
+    parent_prompt       TEXT NOT NULL DEFAULT '',
+    baseline_run_id     TEXT REFERENCES eval_runs(id),
+    baseline_score      REAL,
+    winner_variant_id   TEXT,
+    winner_score        REAL,
+    score_delta         REAL,
+    approval_id         TEXT REFERENCES approvals(id),
+    summary             TEXT DEFAULT '',
+    error               TEXT,
+    created_at          TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    completed_at        TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_optimization_runs_user  ON optimization_runs(user_id);
+CREATE INDEX IF NOT EXISTS idx_optimization_runs_agent ON optimization_runs(agent_id);
+
+-- ===================== optimizer: optimization_variants =====================
+-- Each candidate prompt produced for an optimization run, with the eval run it
+-- was scored by and its resulting suite score.
+CREATE TABLE IF NOT EXISTS optimization_variants (
+    id                  TEXT PRIMARY KEY,
+    optimization_run_id TEXT NOT NULL REFERENCES optimization_runs(id),
+    variant_index       INTEGER NOT NULL DEFAULT 0,
+    system_prompt       TEXT NOT NULL,
+    rationale           TEXT DEFAULT '',
+    eval_run_id         TEXT REFERENCES eval_runs(id),
+    score               REAL,
+    pass_rate           REAL,
+    is_winner           INTEGER NOT NULL DEFAULT 0,
+    created_at          TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_optimization_variants_run ON optimization_variants(optimization_run_id);
 """
 
 # ---------------------------------------------------------------------------
@@ -720,6 +765,10 @@ FK_MAP: dict[tuple[str, str], tuple[str, str]] = {
     ("marketplace_forks", "blueprints"):         ("source_blueprint_id", "id"),
     # workspaces
     ("workspace_changes", "workspaces"):         ("workspace_id", "id"),
+    # optimizer
+    ("optimization_runs", "agents"):             ("agent_id", "id"),
+    ("optimization_runs", "eval_suites"):        ("suite_id", "id"),
+    ("optimization_variants", "optimization_runs"): ("optimization_run_id", "id"),
 }
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from app.routers import (
     mcp,
     messages,
     onboarding,
+    optimizer,
     orchestration,
     organizations,
     preferences,
@@ -138,6 +139,7 @@ app.include_router(evals.router, prefix="/api")
 app.include_router(approvals.router, prefix="/api")
 app.include_router(traces.router, prefix="/api")
 app.include_router(prompt_versions.router, prefix="/api")
+app.include_router(optimizer.router, prefix="/api")
 app.include_router(knowledge.router, prefix="/api")
 app.include_router(marketplace.router, prefix="/api")
 app.include_router(organizations.router, prefix="/api")

--- a/backend/app/routers/optimizer.py
+++ b/backend/app/routers/optimizer.py
@@ -1,0 +1,83 @@
+"""Eval-driven self-optimization API routes.
+
+Kick off an optimization run (baseline eval → variants → score → gate winner
+behind an approval) and read back the lineage.
+"""
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from app.routers.auth import get_current_user
+from app.services.optimizer import optimizer_service
+from app.services.rate_limiter import limiter
+
+router = APIRouter(tags=["optimizer"])
+
+
+class OptimizationRunRequest(BaseModel):
+    agent_id: str
+    suite_id: str
+    n_variants: int = Field(default=3, ge=1, le=8)
+    model: str | None = None
+
+
+@router.post("/optimizer/runs")
+@limiter.limit("5/hour")
+async def create_optimization_run(
+    request: Request,  # noqa: ARG001 - required by slowapi limiter
+    body: OptimizationRunRequest,
+    user: Any = Depends(get_current_user),  # noqa: B008
+) -> dict[str, Any]:
+    """Run one self-optimization attempt and return its lineage record."""
+    try:
+        return await optimizer_service.optimize(
+            user_id=user.id,
+            agent_id=body.agent_id,
+            suite_id=body.suite_id,
+            n_variants=body.n_variants,
+            model=body.model,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.get("/optimizer/runs")
+async def list_optimization_runs(
+    agent_id: str | None = Query(default=None),
+    user: Any = Depends(get_current_user),  # noqa: B008
+) -> list[dict[str, Any]]:
+    """List a user's optimization runs, newest first."""
+    return await optimizer_service.list_lineage(user.id, agent_id=agent_id)
+
+
+@router.get("/optimizer/runs/{run_id}")
+async def get_optimization_run(
+    run_id: str,
+    user: Any = Depends(get_current_user),  # noqa: B008
+) -> dict[str, Any]:
+    """Get an optimization run with its variant lineage."""
+    lineage = await optimizer_service.get_lineage(run_id, user.id)
+    if not lineage:
+        raise HTTPException(status_code=404, detail="Optimization run not found")
+    return lineage
+
+
+@router.post("/optimizer/approvals/{approval_id}/apply")
+async def apply_optimization(
+    approval_id: str,
+    user: Any = Depends(get_current_user),  # noqa: B008
+) -> dict[str, Any]:
+    """Promote an approved optimization winner to the agent's active prompt.
+
+    The approval must already be approved (via the approvals API). This records a
+    new prompt version and updates the live agent.
+    """
+    result = await optimizer_service.apply_approved(approval_id=approval_id, user_id=user.id)
+    if not result:
+        raise HTTPException(
+            status_code=400,
+            detail="Approval not found, not approved, or not a prompt optimization",
+        )
+    return result

--- a/backend/app/services/evals/executor.py
+++ b/backend/app/services/evals/executor.py
@@ -28,8 +28,14 @@ class EvalExecutor:
         user_id: str,
         model: str | None = None,
         triggered_by: str = "manual",
+        prompt_override: str | None = None,
     ) -> dict[str, Any]:
-        """Execute an eval suite and return the run summary."""
+        """Execute an eval suite and return the run summary.
+
+        ``prompt_override`` lets a caller (e.g. the self-optimization loop) run an
+        agent-targeted suite with a candidate system prompt without mutating the
+        stored agent. It is ignored for non-agent targets.
+        """
         # Get suite
         suite = (
             get_db().table("eval_suites")
@@ -77,6 +83,7 @@ class EvalExecutor:
                     suite=suite,
                     run_id=run_id,
                     model=model,
+                    prompt_override=prompt_override,
                 )
                 results.append(result)
                 if result.get("passed"):
@@ -127,6 +134,7 @@ class EvalExecutor:
         suite: dict[str, Any],
         run_id: str,
         model: str | None = None,
+        prompt_override: str | None = None,
     ) -> dict[str, Any]:
         """Execute a single eval case."""
         input_data = case.get("input", {})
@@ -141,6 +149,7 @@ class EvalExecutor:
             target_id=suite["target_id"],
             input_data=input_data,
             model=model,
+            prompt_override=prompt_override,
         )
         latency_ms = int((time.time() - start) * 1000)
 
@@ -185,6 +194,7 @@ class EvalExecutor:
         target_id: str,
         input_data: dict[str, Any],
         model: str | None = None,
+        prompt_override: str | None = None,
     ) -> dict[str, Any]:
         """Run an agent or blueprint and capture output."""
         input_text = input_data.get("text", input_data.get("input_text", json.dumps(input_data)))
@@ -202,10 +212,11 @@ class EvalExecutor:
             if not agent:
                 raise ValueError(f"Agent {target_id} not found")
 
+            system_prompt = prompt_override if prompt_override is not None else agent.get("system_prompt", "")
             resolved_model = model or agent.get("model") or None
             response = await provider_registry.complete(
                 messages=[
-                    {"role": "system", "content": agent.get("system_prompt", "")},
+                    {"role": "system", "content": system_prompt},
                     {"role": "user", "content": input_text},
                 ],
                 model=resolved_model,

--- a/backend/app/services/optimizer/__init__.py
+++ b/backend/app/services/optimizer/__init__.py
@@ -1,0 +1,24 @@
+"""Eval-driven self-optimization loop.
+
+Closes the loop between the eval framework and agent configs: an eval run
+completes, an optimizer reads the failures, proposes N prompt variants, runs the
+eval suite against each, promotes the winner behind an approval gate, and logs
+the lineage.
+"""
+
+from app.services.optimizer.service import OptimizerService, optimizer_service
+from app.services.optimizer.variant_generator import (
+    LLMVariantGenerator,
+    PromptVariant,
+    VariantGenerator,
+    default_variant_generator,
+)
+
+__all__ = [
+    "LLMVariantGenerator",
+    "OptimizerService",
+    "PromptVariant",
+    "VariantGenerator",
+    "default_variant_generator",
+    "optimizer_service",
+]

--- a/backend/app/services/optimizer/service.py
+++ b/backend/app/services/optimizer/service.py
@@ -1,0 +1,405 @@
+"""Self-optimization service — closes the loop between evals and agent configs.
+
+Pipeline for a single optimization run:
+
+1. Run a baseline eval of the agent against the suite.
+2. Collect the failing cases. If there are none, short-circuit (nothing to
+   optimize) — the agent already passes.
+3. Generate N candidate system prompts from the failures (one model call via the
+   injectable :class:`VariantGenerator`).
+4. Run the eval suite against each candidate (concurrently), using the executor's
+   ``prompt_override`` so the stored agent is never mutated.
+5. Select the winner by suite-score delta over the baseline. If no candidate
+   beats the baseline, record ``no_improvement`` and stop.
+6. Create an approval request to promote the winner. The new prompt is NOT
+   applied to the agent until that approval is approved — promotion happens in
+   :meth:`apply_approved`.
+7. Persist the lineage: parent prompt, every variant + its score, the winner and
+   the delta.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from app.db import get_db
+from app.services.evals.approvals import approval_service
+from app.services.evals.executor import EvalExecutor, eval_executor
+from app.services.observability.prompt_versions import (
+    PromptVersionService,
+    prompt_version_service,
+)
+from app.services.optimizer.variant_generator import (
+    PromptVariant,
+    VariantGenerator,
+    VariantRequest,
+    default_variant_generator,
+)
+
+logger = logging.getLogger(__name__)
+
+# How much a variant must beat the baseline by to be considered a winner.
+MIN_IMPROVEMENT = 0.001
+
+
+class OptimizerService:
+    """Orchestrates eval-driven prompt optimization with an approval gate."""
+
+    def __init__(
+        self,
+        *,
+        executor: EvalExecutor | None = None,
+        variant_generator: VariantGenerator | None = None,
+        approvals: Any = None,
+        prompt_versions: PromptVersionService | None = None,
+    ) -> None:
+        self._executor = executor or eval_executor
+        self._variant_generator = variant_generator or default_variant_generator
+        self._approvals = approvals or approval_service
+        self._prompt_versions = prompt_versions or prompt_version_service
+
+    async def optimize(
+        self,
+        *,
+        user_id: str,
+        agent_id: str,
+        suite_id: str,
+        n_variants: int = 3,
+        model: str | None = None,
+    ) -> dict[str, Any]:
+        """Run one optimization attempt and return the lineage record."""
+        agent = (
+            get_db().table("agents")
+            .select("*")
+            .eq("id", agent_id)
+            .eq("user_id", user_id)
+            .single()
+            .execute()
+        ).data
+        if not agent:
+            raise ValueError(f"Agent {agent_id} not found")
+
+        suite = (
+            get_db().table("eval_suites")
+            .select("*")
+            .eq("id", suite_id)
+            .eq("user_id", user_id)
+            .single()
+            .execute()
+        ).data
+        if not suite:
+            raise ValueError(f"Eval suite {suite_id} not found")
+        if suite.get("target_type") != "agent" or suite.get("target_id") != agent_id:
+            raise ValueError("Eval suite must target the agent being optimized")
+
+        parent_prompt = agent.get("system_prompt", "")
+        opt_run_id = str(uuid.uuid4())
+        get_db().table("optimization_runs").insert({
+            "id": opt_run_id,
+            "user_id": user_id,
+            "agent_id": agent_id,
+            "suite_id": suite_id,
+            "status": "running",
+            "parent_prompt": parent_prompt,
+        }).execute()
+
+        try:
+            return await self._run(
+                opt_run_id=opt_run_id,
+                user_id=user_id,
+                agent_id=agent_id,
+                suite_id=suite_id,
+                parent_prompt=parent_prompt,
+                n_variants=n_variants,
+                model=model,
+            )
+        except Exception as e:  # noqa: BLE001 - record failure, re-raise to caller
+            logger.exception("Optimization run %s failed", opt_run_id)
+            self._finalize(opt_run_id, {"status": "failed", "error": str(e)})
+            raise
+
+    async def _run(
+        self,
+        *,
+        opt_run_id: str,
+        user_id: str,
+        agent_id: str,
+        suite_id: str,
+        parent_prompt: str,
+        n_variants: int,
+        model: str | None,
+    ) -> dict[str, Any]:
+        # 1. Baseline eval.
+        baseline = await self._executor.run_suite(
+            suite_id=suite_id,
+            user_id=user_id,
+            model=model,
+            triggered_by="optimizer",
+        )
+        baseline_score = float(baseline.get("avg_score", 0.0) or 0.0)
+        baseline_run_id = baseline.get("run_id")
+
+        # 2. Collect failures. No failures → nothing to optimize.
+        failures = self._collect_failures(baseline_run_id)
+        if not failures:
+            return self._finalize(opt_run_id, {
+                "status": "no_failures",
+                "baseline_run_id": baseline_run_id,
+                "baseline_score": baseline_score,
+                "summary": "Baseline eval has no failing cases; nothing to optimize.",
+            })
+
+        # 3. Generate candidate prompts (one model call).
+        variants = await self._variant_generator(
+            VariantRequest(
+                current_prompt=parent_prompt,
+                failures=failures,
+                n=n_variants,
+                model=model,
+            )
+        )
+        variants = [v for v in variants if v.system_prompt.strip() and v.system_prompt != parent_prompt]
+        if not variants:
+            return self._finalize(opt_run_id, {
+                "status": "no_improvement",
+                "baseline_run_id": baseline_run_id,
+                "baseline_score": baseline_score,
+                "summary": "Variant generator produced no usable candidates.",
+            })
+
+        # 4. Score each candidate against the suite (concurrently).
+        scored = await self._score_variants(
+            opt_run_id=opt_run_id,
+            variants=variants,
+            suite_id=suite_id,
+            user_id=user_id,
+            model=model,
+        )
+
+        # 5. Select the winner by score delta.
+        winner = max(scored, key=lambda v: v["score"])
+        delta = winner["score"] - baseline_score
+        if delta < MIN_IMPROVEMENT:
+            return self._finalize(opt_run_id, {
+                "status": "no_improvement",
+                "baseline_run_id": baseline_run_id,
+                "baseline_score": baseline_score,
+                "winner_variant_id": winner["id"],
+                "winner_score": winner["score"],
+                "score_delta": delta,
+                "summary": (
+                    f"Best candidate scored {winner['score']:.3f} vs baseline "
+                    f"{baseline_score:.3f} (+{delta:.3f}); below improvement threshold."
+                ),
+            })
+
+        # Mark the winning variant row.
+        get_db().table("optimization_variants").update(
+            {"is_winner": True}
+        ).eq("id", winner["id"]).execute()
+
+        # 6. Gate the winner behind an approval — DO NOT auto-apply.
+        suite_name = (
+            get_db().table("eval_suites").select("name").eq("id", suite_id).single().execute()
+        ).data
+        suite_label = suite_name.get("name", suite_id) if suite_name else suite_id
+        pct = delta * 100
+        summary = (
+            f"Optimized prompt beat baseline by +{pct:.1f}% on suite '{suite_label}' "
+            f"({baseline_score:.3f} → {winner['score']:.3f})"
+        )
+        approval = await self._approvals.create_approval(
+            user_id=user_id,
+            blueprint_run_id=opt_run_id,
+            node_id=f"optimizer:{agent_id}",
+            context={
+                "kind": "prompt_optimization",
+                "optimization_run_id": opt_run_id,
+                "agent_id": agent_id,
+                "suite_id": suite_id,
+                "variant_id": winner["id"],
+                "baseline_score": baseline_score,
+                "winner_score": winner["score"],
+                "score_delta": delta,
+                "system_prompt": winner["system_prompt"],
+                "summary": summary,
+            },
+        )
+
+        return self._finalize(opt_run_id, {
+            "status": "awaiting_approval",
+            "baseline_run_id": baseline_run_id,
+            "baseline_score": baseline_score,
+            "winner_variant_id": winner["id"],
+            "winner_score": winner["score"],
+            "score_delta": delta,
+            "approval_id": approval.get("id"),
+            "summary": summary,
+        })
+
+    async def _score_variants(
+        self,
+        *,
+        opt_run_id: str,
+        variants: list[PromptVariant],
+        suite_id: str,
+        user_id: str,
+        model: str | None,
+    ) -> list[dict[str, Any]]:
+        """Run the suite against each variant concurrently; persist + return rows."""
+
+        async def _score_one(index: int, variant: PromptVariant) -> dict[str, Any]:
+            run = await self._executor.run_suite(
+                suite_id=suite_id,
+                user_id=user_id,
+                model=model,
+                triggered_by="optimizer",
+                prompt_override=variant.system_prompt,
+            )
+            return {
+                "index": index,
+                "variant": variant,
+                "eval_run_id": run.get("run_id"),
+                "score": float(run.get("avg_score", 0.0) or 0.0),
+                "pass_rate": float(run.get("pass_rate", 0.0) or 0.0),
+            }
+
+        results = await asyncio.gather(
+            *(_score_one(i, v) for i, v in enumerate(variants))
+        )
+
+        rows: list[dict[str, Any]] = []
+        for r in results:
+            variant_id = str(uuid.uuid4())
+            row = {
+                "id": variant_id,
+                "optimization_run_id": opt_run_id,
+                "variant_index": r["index"],
+                "system_prompt": r["variant"].system_prompt,
+                "rationale": r["variant"].rationale,
+                "eval_run_id": r["eval_run_id"],
+                "score": r["score"],
+                "pass_rate": r["pass_rate"],
+                "is_winner": False,
+            }
+            get_db().table("optimization_variants").insert(row).execute()
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    def _collect_failures(eval_run_id: str | None) -> list[dict[str, Any]]:
+        """Pull failing cases for an eval run into a transcript-friendly shape."""
+        if not eval_run_id:
+            return []
+        results = (
+            get_db().table("eval_results")
+            .select("*")
+            .eq("run_id", eval_run_id)
+            .execute()
+        ).data or []
+
+        failures: list[dict[str, Any]] = []
+        for r in results:
+            if r.get("passed"):
+                continue
+            case = (
+                get_db().table("eval_cases").select("*").eq("id", r["case_id"]).single().execute()
+            ).data or {}
+            actual = r.get("actual_output") or {}
+            details = r.get("grading_details") or {}
+            failures.append({
+                "case_id": r["case_id"],
+                "input": case.get("input"),
+                "expected": case.get("expected_output"),
+                "actual": actual.get("text", actual) if isinstance(actual, dict) else actual,
+                "reason": details.get("error") or details.get("reasoning") or details.get("method", ""),
+            })
+        return failures
+
+    @staticmethod
+    def _finalize(opt_run_id: str, fields: dict[str, Any]) -> dict[str, Any]:
+        """Write terminal fields onto the optimization run and return it."""
+        update = dict(fields)
+        update["completed_at"] = datetime.now(UTC).isoformat()
+        get_db().table("optimization_runs").update(update).eq("id", opt_run_id).execute()
+        get_run = (
+            get_db().table("optimization_runs").select("*").eq("id", opt_run_id).single().execute()
+        ).data
+        return dict(get_run) if get_run else {"id": opt_run_id, **update}
+
+    async def get_lineage(self, opt_run_id: str, user_id: str) -> dict[str, Any] | None:
+        """Fetch an optimization run with its variants (the lineage record)."""
+        run = (
+            get_db().table("optimization_runs")
+            .select("*")
+            .eq("id", opt_run_id)
+            .eq("user_id", user_id)
+            .single()
+            .execute()
+        ).data
+        if not run:
+            return None
+        variants = (
+            get_db().table("optimization_variants")
+            .select("*")
+            .eq("optimization_run_id", opt_run_id)
+            .order("variant_index")
+            .execute()
+        ).data or []
+        result = dict(run)
+        result["variants"] = variants
+        return result
+
+    async def list_lineage(
+        self, user_id: str, *, agent_id: str | None = None, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        """List optimization runs for a user, newest first."""
+        query = (
+            get_db().table("optimization_runs")
+            .select("*")
+            .eq("user_id", user_id)
+        )
+        if agent_id:
+            query = query.eq("agent_id", agent_id)
+        result = query.order("created_at", desc=True).limit(limit).execute()
+        return result.data or []
+
+    async def apply_approved(
+        self, *, approval_id: str, user_id: str
+    ) -> dict[str, Any] | None:
+        """Promote a winner whose approval has been approved.
+
+        Records a new prompt version (which also updates the agent's stored
+        ``system_prompt``). Safe to call only after the approval is approved;
+        returns ``None`` otherwise.
+        """
+        approval = await self._approvals.get_approval(approval_id)
+        if not approval or approval.get("user_id") != user_id:
+            return None
+        if approval.get("status") != "approved":
+            return None
+        ctx = approval.get("context") or {}
+        if ctx.get("kind") != "prompt_optimization":
+            return None
+
+        agent_id = ctx["agent_id"]
+        new_prompt = ctx["system_prompt"]
+        version = await self._prompt_versions.create_version(
+            user_id=user_id,
+            agent_id=agent_id,
+            system_prompt=new_prompt,
+            change_summary=ctx.get("summary", "Promoted by optimizer"),
+        )
+        # create_version deactivates prior versions but doesn't touch the agent
+        # row; mirror prompt_version_service.rollback and update the live agent.
+        get_db().table("agents").update(
+            {"system_prompt": new_prompt}
+        ).eq("id", agent_id).eq("user_id", user_id).execute()
+        return version
+
+
+optimizer_service = OptimizerService()

--- a/backend/app/services/optimizer/variant_generator.py
+++ b/backend/app/services/optimizer/variant_generator.py
@@ -1,0 +1,133 @@
+"""Prompt-variant generation for the self-optimization loop.
+
+Variant generation is a single model call: given the current system prompt and a
+transcript of the failing eval cases, ask the model for N improved prompts. The
+generator is an injectable interface so tests can supply a deterministic fake;
+the default implementation calls the real backend LLM path
+(``provider_registry.complete``), the same convention the eval runner uses.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from app.providers.registry import provider_registry
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PromptVariant:
+    """A single candidate system prompt produced by a generator."""
+
+    system_prompt: str
+    rationale: str = ""
+
+
+@dataclass
+class VariantRequest:
+    """Inputs handed to a variant generator."""
+
+    current_prompt: str
+    failures: list[dict[str, Any]] = field(default_factory=list)
+    n: int = 3
+    model: str | None = None
+
+
+@runtime_checkable
+class VariantGenerator(Protocol):
+    """Callable interface that proposes improved prompt variants.
+
+    Implementations must be async and return between 1 and ``request.n``
+    variants. Tests can supply a deterministic fake satisfying this protocol.
+    """
+
+    async def __call__(self, request: VariantRequest) -> list[PromptVariant]: ...
+
+
+def _format_failures(failures: list[dict[str, Any]], *, limit: int = 10) -> str:
+    """Render failing eval cases into a compact transcript for the model."""
+    lines: list[str] = []
+    for i, f in enumerate(failures[:limit], start=1):
+        inp = f.get("input")
+        expected = f.get("expected")
+        actual = f.get("actual")
+        reason = f.get("reason", "")
+        lines.append(
+            f"Case {i}:\n"
+            f"  Input: {json.dumps(inp, default=str)[:500]}\n"
+            f"  Expected: {json.dumps(expected, default=str)[:500]}\n"
+            f"  Actual: {json.dumps(actual, default=str)[:500]}\n"
+            f"  Grader: {reason}"
+        )
+    remaining = len(failures) - limit
+    if remaining > 0:
+        lines.append(f"... and {remaining} more failing case(s).")
+    return "\n\n".join(lines) if lines else "(no failure detail available)"
+
+
+class LLMVariantGenerator:
+    """Default generator — one model call returns N improved prompts."""
+
+    async def __call__(self, request: VariantRequest) -> list[PromptVariant]:
+        system_prompt = (
+            "You are a prompt engineer improving an AI agent's system prompt. "
+            "You are given the agent's current system prompt and a transcript of "
+            "eval cases it FAILED. Propose improved system prompts that would make "
+            "the agent pass these cases while preserving its original intent. "
+            f"Return strictly a JSON object: {{\"variants\": [{{\"system_prompt\": "
+            "\"...\", \"rationale\": \"...\"}}]}} with exactly "
+            f"{request.n} variant(s). Do not include any prose outside the JSON."
+        )
+        user_prompt = (
+            f"Current system prompt:\n---\n{request.current_prompt}\n---\n\n"
+            f"Failing eval cases:\n{_format_failures(request.failures)}\n\n"
+            f"Propose {request.n} improved system prompt variant(s) as JSON."
+        )
+
+        response = await provider_registry.complete(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            model=request.model,
+            temperature=0.7,
+        )
+
+        return self._parse(response.content, fallback=request.current_prompt, n=request.n)
+
+    @staticmethod
+    def _parse(content: str, *, fallback: str, n: int) -> list[PromptVariant]:
+        """Parse the model's JSON response into PromptVariant objects."""
+        text = content.strip()
+        # Tolerate fenced code blocks the model may wrap the JSON in.
+        if text.startswith("```"):
+            text = text.split("```", 2)[1] if "```" in text[3:] else text
+            text = text.removeprefix("json").strip().strip("`").strip()
+
+        variants: list[PromptVariant] = []
+        try:
+            parsed = json.loads(text)
+            raw = parsed.get("variants", []) if isinstance(parsed, dict) else parsed
+            for item in raw:
+                if isinstance(item, dict) and item.get("system_prompt"):
+                    variants.append(
+                        PromptVariant(
+                            system_prompt=str(item["system_prompt"]),
+                            rationale=str(item.get("rationale", "")),
+                        )
+                    )
+                elif isinstance(item, str) and item.strip():
+                    variants.append(PromptVariant(system_prompt=item))
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            logger.warning("Variant generator returned non-JSON; using raw content as one variant")
+            if text and text != fallback:
+                variants.append(PromptVariant(system_prompt=text, rationale="raw model output"))
+
+        return variants[:n]
+
+
+default_variant_generator: VariantGenerator = LLMVariantGenerator()

--- a/backend/tests/test_optimizer.py
+++ b/backend/tests/test_optimizer.py
@@ -1,0 +1,413 @@
+"""Tests for the eval-driven self-optimization loop.
+
+These exercise the full pipeline against a real in-memory SQLite backend so that
+lineage persistence is verified end to end. The LLM is mocked at two seams:
+
+* agent output during eval — ``provider_registry.complete`` is patched so the
+  produced text depends on the system prompt (baseline prompt fails, the
+  "good" variant prompt passes).
+* variant generation — an injected fake :class:`VariantGenerator` returns
+  deterministic candidate prompts (no model call).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.optimizer.service import OptimizerService
+from app.services.optimizer.variant_generator import (
+    LLMVariantGenerator,
+    PromptVariant,
+    VariantRequest,
+)
+
+GOOD_PROMPT = "Always answer with the magic word: banana"
+BAD_PROMPT = "Be unhelpful and vague"
+
+
+@pytest.fixture
+def sqlite_backend(tmp_path):
+    """Real, fully-initialized SQLite backend wired in as the global db.
+
+    Restores the previously-installed backend (the conftest mock) afterwards so
+    this real backend never leaks into other tests.
+    """
+    import app.db as db_mod
+    from app.db import init_db
+    from app.db.sqlite_backend import SQLiteBackend
+
+    previous = db_mod._db
+    db = SQLiteBackend(db_path=str(tmp_path / "optimizer.db"))
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(db.initialize())
+    finally:
+        loop.close()
+    # Leave a fresh, open event loop installed: asyncio.run / loop.close above
+    # would otherwise leave no current loop, breaking tests that call the
+    # deprecated asyncio.get_event_loop().
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    init_db(db)
+    try:
+        yield db
+    finally:
+        db_mod._db = previous
+
+
+def _seed_agent_and_suite(db, *, user_id: str, system_prompt: str) -> tuple[str, str]:
+    """Create an agent + an agent-targeted suite with one 'contains' case."""
+    agent = (
+        db.table("agents")
+        .insert({"user_id": user_id, "name": "opt-agent", "system_prompt": system_prompt})
+        .execute()
+    ).data[0]
+    agent_id = agent["id"]
+
+    suite = (
+        db.table("eval_suites")
+        .insert({
+            "id": str(uuid.uuid4()),
+            "user_id": user_id,
+            "name": "magic-word-suite",
+            "target_type": "agent",
+            "target_id": agent_id,
+        })
+        .execute()
+    ).data[0]
+    suite_id = suite["id"]
+
+    db.table("eval_cases").insert({
+        "id": str(uuid.uuid4()),
+        "suite_id": suite_id,
+        "name": "must-say-banana",
+        "input": {"text": "say the magic word"},
+        "expected_output": {"text": "banana"},
+        "grading_method": "contains",
+        "grading_config": {"patterns": ["banana"]},
+    }).execute()
+
+    return agent_id, suite_id
+
+
+def _patch_agent_output():
+    """Patch the eval executor's LLM call so output depends on the system prompt."""
+
+    async def fake_complete(*, messages, model=None, temperature=0, **kwargs):
+        system = next((m["content"] for m in messages if m["role"] == "system"), "")
+        text = "banana" if "banana" in system else "i don't know"
+        resp = MagicMock()
+        resp.content = text
+        resp.input_tokens = 1
+        resp.output_tokens = 1
+        resp.model = model or "test-model"
+        return resp
+
+    return patch(
+        "app.services.evals.executor.provider_registry.complete",
+        side_effect=fake_complete,
+    )
+
+
+class _FakeGenerator:
+    """Deterministic variant generator — records the request, returns fixed variants."""
+
+    def __init__(self, variants: list[PromptVariant]) -> None:
+        self.variants = variants
+        self.last_request: VariantRequest | None = None
+        self.calls = 0
+
+    async def __call__(self, request: VariantRequest) -> list[PromptVariant]:
+        self.calls += 1
+        self.last_request = request
+        return list(self.variants)
+
+
+@pytest.mark.asyncio
+async def test_winner_is_highest_scoring_variant(sqlite_backend):
+    """The variant whose prompt passes the suite must be selected as winner."""
+    user_id = "user-1"
+    agent_id, suite_id = _seed_agent_and_suite(
+        sqlite_backend, user_id=user_id, system_prompt=BAD_PROMPT
+    )
+
+    gen = _FakeGenerator([
+        PromptVariant(system_prompt="still vague and unhelpful", rationale="bad"),
+        PromptVariant(system_prompt=GOOD_PROMPT, rationale="good"),
+    ])
+    svc = OptimizerService(variant_generator=gen)
+
+    with _patch_agent_output():
+        result = await svc.optimize(user_id=user_id, agent_id=agent_id, suite_id=suite_id)
+
+    assert gen.calls == 1
+    assert result["status"] == "awaiting_approval"
+    # Winner score should be the perfect (1.0) GOOD_PROMPT variant.
+    assert result["winner_score"] == pytest.approx(1.0)
+    assert result["score_delta"] > 0
+
+    lineage = await svc.get_lineage(result["id"], user_id)
+    winners = [v for v in lineage["variants"] if v["is_winner"]]
+    assert len(winners) == 1
+    assert winners[0]["system_prompt"] == GOOD_PROMPT
+
+
+@pytest.mark.asyncio
+async def test_no_failures_short_circuits(sqlite_backend):
+    """If the baseline eval has no failures, the loop does nothing further."""
+    user_id = "user-2"
+    agent_id, suite_id = _seed_agent_and_suite(
+        sqlite_backend, user_id=user_id, system_prompt=GOOD_PROMPT
+    )
+
+    gen = _FakeGenerator([PromptVariant(system_prompt=GOOD_PROMPT)])
+    svc = OptimizerService(variant_generator=gen)
+
+    with _patch_agent_output():
+        result = await svc.optimize(user_id=user_id, agent_id=agent_id, suite_id=suite_id)
+
+    assert result["status"] == "no_failures"
+    # Variant generator must not be invoked — nothing to optimize.
+    assert gen.calls == 0
+    lineage = await svc.get_lineage(result["id"], user_id)
+    assert lineage["variants"] == []
+
+
+@pytest.mark.asyncio
+async def test_no_improvement_when_no_variant_beats_baseline(sqlite_backend):
+    """If no candidate beats the baseline, status is no_improvement and no gate opens."""
+    user_id = "user-3"
+    agent_id, suite_id = _seed_agent_and_suite(
+        sqlite_backend, user_id=user_id, system_prompt=BAD_PROMPT
+    )
+
+    gen = _FakeGenerator([
+        PromptVariant(system_prompt="also unhelpful"),
+        PromptVariant(system_prompt="equally vague"),
+    ])
+    approvals = MagicMock()
+    approvals.create_approval = AsyncMock()
+    svc = OptimizerService(variant_generator=gen, approvals=approvals)
+
+    with _patch_agent_output():
+        result = await svc.optimize(user_id=user_id, agent_id=agent_id, suite_id=suite_id)
+
+    assert result["status"] == "no_improvement"
+    approvals.create_approval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_winner_is_gated_not_auto_applied(sqlite_backend):
+    """The winning prompt must NOT be written to the agent until approved."""
+    user_id = "user-4"
+    agent_id, suite_id = _seed_agent_and_suite(
+        sqlite_backend, user_id=user_id, system_prompt=BAD_PROMPT
+    )
+
+    gen = _FakeGenerator([PromptVariant(system_prompt=GOOD_PROMPT, rationale="good")])
+    svc = OptimizerService(variant_generator=gen)
+
+    with _patch_agent_output():
+        result = await svc.optimize(user_id=user_id, agent_id=agent_id, suite_id=suite_id)
+
+    assert result["status"] == "awaiting_approval"
+    assert result["approval_id"]
+
+    # Agent's stored prompt is unchanged — promotion is gated.
+    agent = (
+        sqlite_backend.table("agents").select("*").eq("id", agent_id).single().execute()
+    ).data
+    assert agent["system_prompt"] == BAD_PROMPT
+
+    # A pending approval exists carrying the candidate prompt.
+    approval = (
+        sqlite_backend.table("approvals").select("*").eq("id", result["approval_id"]).single().execute()
+    ).data
+    assert approval["status"] == "pending"
+    assert approval["context"]["system_prompt"] == GOOD_PROMPT
+    assert approval["context"]["kind"] == "prompt_optimization"
+
+
+@pytest.mark.asyncio
+async def test_apply_approved_promotes_winner(sqlite_backend):
+    """After the approval is approved, apply_approved updates the live agent."""
+    user_id = "user-5"
+    agent_id, suite_id = _seed_agent_and_suite(
+        sqlite_backend, user_id=user_id, system_prompt=BAD_PROMPT
+    )
+
+    gen = _FakeGenerator([PromptVariant(system_prompt=GOOD_PROMPT)])
+    svc = OptimizerService(variant_generator=gen)
+
+    with _patch_agent_output():
+        result = await svc.optimize(user_id=user_id, agent_id=agent_id, suite_id=suite_id)
+
+    approval_id = result["approval_id"]
+
+    # Not yet approved → apply must refuse.
+    assert await svc.apply_approved(approval_id=approval_id, user_id=user_id) is None
+
+    # Approve it, then apply.
+    from app.services.evals.approvals import approval_service
+
+    await approval_service.approve(approval_id, user_id, "ship it")
+    version = await svc.apply_approved(approval_id=approval_id, user_id=user_id)
+
+    assert version is not None
+    agent = (
+        sqlite_backend.table("agents").select("*").eq("id", agent_id).single().execute()
+    ).data
+    assert agent["system_prompt"] == GOOD_PROMPT
+
+
+@pytest.mark.asyncio
+async def test_lineage_persisted_and_listable(sqlite_backend):
+    """Lineage (run + per-variant scores) is persisted and retrievable."""
+    user_id = "user-6"
+    agent_id, suite_id = _seed_agent_and_suite(
+        sqlite_backend, user_id=user_id, system_prompt=BAD_PROMPT
+    )
+
+    gen = _FakeGenerator([
+        PromptVariant(system_prompt="vague one"),
+        PromptVariant(system_prompt=GOOD_PROMPT),
+    ])
+    svc = OptimizerService(variant_generator=gen)
+
+    with _patch_agent_output():
+        result = await svc.optimize(user_id=user_id, agent_id=agent_id, suite_id=suite_id)
+
+    lineage = await svc.get_lineage(result["id"], user_id)
+    assert lineage["parent_prompt"] == BAD_PROMPT
+    assert len(lineage["variants"]) == 2
+    # Each variant carries its own eval run id and score.
+    assert all(v["eval_run_id"] for v in lineage["variants"])
+    assert any(v["score"] == pytest.approx(1.0) for v in lineage["variants"])
+
+    runs = await svc.list_lineage(user_id, agent_id=agent_id)
+    assert len(runs) == 1
+    assert runs[0]["id"] == result["id"]
+
+
+@pytest.mark.asyncio
+async def test_suite_must_target_agent(sqlite_backend):
+    """Optimizing against a suite that targets a different agent is rejected."""
+    user_id = "user-7"
+    agent_id, suite_id = _seed_agent_and_suite(
+        sqlite_backend, user_id=user_id, system_prompt=BAD_PROMPT
+    )
+    other = (
+        sqlite_backend.table("agents")
+        .insert({"user_id": user_id, "name": "other", "system_prompt": "x"})
+        .execute()
+    ).data[0]
+
+    svc = OptimizerService(variant_generator=_FakeGenerator([]))
+    with pytest.raises(ValueError, match="must target the agent"):
+        await svc.optimize(user_id=user_id, agent_id=other["id"], suite_id=suite_id)
+
+
+# === Variant generator (LLM) parsing — model call mocked ===
+
+
+@pytest.mark.asyncio
+async def test_llm_variant_generator_parses_json():
+    gen = LLMVariantGenerator()
+    resp = MagicMock()
+    resp.content = (
+        '{"variants": [{"system_prompt": "p1", "rationale": "r1"}, '
+        '{"system_prompt": "p2", "rationale": "r2"}]}'
+    )
+    resp.input_tokens = 1
+    resp.output_tokens = 1
+
+    with patch(
+        "app.services.optimizer.variant_generator.provider_registry.complete",
+        new=AsyncMock(return_value=resp),
+    ):
+        variants = await gen(VariantRequest(current_prompt="orig", failures=[], n=3))
+
+    assert [v.system_prompt for v in variants] == ["p1", "p2"]
+    assert variants[0].rationale == "r1"
+
+
+@pytest.mark.asyncio
+async def test_llm_variant_generator_handles_fenced_json():
+    gen = LLMVariantGenerator()
+    resp = MagicMock()
+    resp.content = '```json\n{"variants": [{"system_prompt": "fenced"}]}\n```'
+    resp.input_tokens = 1
+    resp.output_tokens = 1
+
+    with patch(
+        "app.services.optimizer.variant_generator.provider_registry.complete",
+        new=AsyncMock(return_value=resp),
+    ):
+        variants = await gen(VariantRequest(current_prompt="orig", failures=[], n=2))
+
+    assert len(variants) == 1
+    assert variants[0].system_prompt == "fenced"
+
+
+# === API route ===
+
+
+def test_optimizer_run_route_validates_target():
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.routers.auth import get_current_user
+
+    mock_user = MagicMock(id="user1")
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    try:
+        with patch("app.routers.optimizer.optimizer_service") as mock_svc:
+            mock_svc.optimize = AsyncMock(side_effect=ValueError("Eval suite must target the agent"))
+            resp = TestClient(app).post(
+                "/api/optimizer/runs",
+                json={"agent_id": "a1", "suite_id": "s1", "n_variants": 2},
+            )
+        assert resp.status_code == 400
+        assert "must target" in resp.json()["detail"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_optimizer_get_run_route():
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.routers.auth import get_current_user
+
+    mock_user = MagicMock(id="user1")
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    try:
+        with patch("app.routers.optimizer.optimizer_service") as mock_svc:
+            mock_svc.get_lineage = AsyncMock(return_value={
+                "id": "opt1", "status": "awaiting_approval", "variants": [],
+            })
+            resp = TestClient(app).get("/api/optimizer/runs/opt1")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "awaiting_approval"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_optimizer_get_run_404():
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.routers.auth import get_current_user
+
+    mock_user = MagicMock(id="user1")
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    try:
+        with patch("app.routers.optimizer.optimizer_service") as mock_svc:
+            mock_svc.get_lineage = AsyncMock(return_value=None)
+            resp = TestClient(app).get("/api/optimizer/runs/missing")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()

--- a/cli/forge/commands/evals.py
+++ b/cli/forge/commands/evals.py
@@ -21,6 +21,8 @@ _app = typer.Typer()
 
 evals_app = typer.Typer(help="Manage eval suites and runs")
 
+optimize_app = typer.Typer(help="Eval-driven self-optimization of agent prompts")
+
 
 
 @evals_app.command("list")
@@ -229,6 +231,125 @@ def evals_results(
             )
         console.print(table)
     console.print()
+
+
+@optimize_app.command("run")
+def optimize_run(
+    agent_id: str = typer.Argument(..., help="Agent ID to optimize"),
+    suite_id: str = typer.Option(..., "--suite", "-s", help="Eval suite ID (must target the agent)"),
+    n_variants: int = typer.Option(3, "--variants", "-n", help="Number of prompt variants to try"),
+    model: str = typer.Option("", "--model", "-m", help="Override model for evals/generation"),
+):
+    """Run a self-optimization attempt: baseline eval, generate + score variants, gate the winner."""
+    console.print(f"[bold]Optimizing agent {agent_id[:8]} against suite {suite_id[:8]}...[/bold]")
+    try:
+        body: dict = {"agent_id": agent_id, "suite_id": suite_id, "n_variants": n_variants}
+        if model:
+            body["model"] = model
+        result = client.post("/api/optimizer/runs", json=body)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    status = result.get("status", "?")
+    console.print(f"  Status: [bold]{status}[/bold]")
+    console.print(f"  Baseline score: {result.get('baseline_score') or 0:.3f}")
+    if result.get("winner_score") is not None:
+        console.print(f"  Winner score: {result.get('winner_score') or 0:.3f}")
+        console.print(f"  Delta: [green]{result.get('score_delta') or 0:+.3f}[/green]")
+    if result.get("summary"):
+        console.print(f"  {result['summary']}")
+    if status == "awaiting_approval":
+        console.print(
+            f"\n[yellow]Winner is gated behind approval {str(result.get('approval_id', ''))[:8]}.[/yellow]"
+        )
+        console.print("  Approve it (forge ops approvals) then: "
+                      f"forge evals optimize apply {result.get('approval_id', '')[:8]}...")
+    console.print(f"  Run ID: {result.get('id', '')[:8]}")
+
+
+@optimize_app.command("list")
+def optimize_list(
+    agent_id: str = typer.Option("", "--agent", "-a", help="Filter by agent ID"),
+):
+    """List optimization runs (lineage)."""
+    try:
+        params = {"agent_id": agent_id} if agent_id else None
+        runs = client.get("/api/optimizer/runs", params=params)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    if not runs:
+        console.print("[dim]No optimization runs.[/dim]")
+        return
+
+    table = Table(title="Optimization Runs")
+    table.add_column("ID", style="dim", max_width=8)
+    table.add_column("Agent", style="dim", max_width=8)
+    table.add_column("Status")
+    table.add_column("Baseline", justify="right")
+    table.add_column("Winner", justify="right")
+    table.add_column("Delta", justify="right")
+    for r in runs:
+        base = f"{r['baseline_score']:.3f}" if r.get("baseline_score") is not None else "—"
+        win = f"{r['winner_score']:.3f}" if r.get("winner_score") is not None else "—"
+        delta = f"{r['score_delta']:+.3f}" if r.get("score_delta") is not None else "—"
+        table.add_row(r["id"][:8], (r.get("agent_id") or "")[:8], r.get("status", "?"), base, win, delta)
+    console.print(table)
+
+
+@optimize_app.command("show")
+def optimize_show(
+    run_id: str = typer.Argument(..., help="Optimization run ID"),
+):
+    """Show an optimization run with its variant lineage."""
+    try:
+        run = client.get(f"/api/optimizer/runs/{run_id}")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    console.print(f"\n[bold]Optimization Run {run['id'][:8]}[/bold]")
+    console.print(f"  Status: {run.get('status', '?')}")
+    console.print(f"  Baseline score: {run.get('baseline_score') or 0:.3f}")
+    if run.get("summary"):
+        console.print(f"  {run['summary']}")
+
+    variants = run.get("variants", [])
+    if variants:
+        table = Table(title="Variants")
+        table.add_column("Idx", justify="right")
+        table.add_column("Score", justify="right")
+        table.add_column("Pass rate", justify="right")
+        table.add_column("Winner")
+        for v in variants:
+            table.add_row(
+                str(v.get("variant_index", "?")),
+                f"{v.get('score') or 0:.3f}",
+                f"{(v.get('pass_rate') or 0) * 100:.0f}%",
+                "[green]★[/green]" if v.get("is_winner") else "",
+            )
+        console.print(table)
+    console.print()
+
+
+@optimize_app.command("apply")
+def optimize_apply(
+    approval_id: str = typer.Argument(..., help="Approved optimization approval ID"),
+):
+    """Promote an approved optimization winner to the agent's active prompt."""
+    try:
+        result = client.post(f"/api/optimizer/approvals/{approval_id}/apply")
+        console.print(f"[green]Promoted to prompt version {result.get('version_number', '?')}.[/green]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+
+# Attach the optimize sub-app at module import — main.py mounts evals_app directly
+# (it does not call register()), so sub-apps must be wired here.
+evals_app.add_typer(optimize_app, name="optimize")
 
 
 def register(parent: typer.Typer) -> None:

--- a/supabase/migrations/20260610_optimizer.sql
+++ b/supabase/migrations/20260610_optimizer.sql
@@ -1,0 +1,58 @@
+-- Eval-driven self-optimization loop (optimizer)
+-- Adds optimization_runs (lineage) and optimization_variants tables.
+-- An optimization run takes an agent + eval suite, runs a baseline eval, and if
+-- there are failures generates N prompt variants, scores each against the suite,
+-- selects the winner, and opens an approval to promote it. Nothing is auto-applied.
+
+-- 1. Optimization runs (lineage record)
+CREATE TABLE IF NOT EXISTS optimization_runs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    suite_id UUID NOT NULL REFERENCES eval_suites(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'running'
+        CHECK (status IN ('running', 'no_improvement', 'no_failures', 'awaiting_approval', 'failed')),
+    parent_prompt TEXT NOT NULL DEFAULT '',
+    baseline_run_id UUID REFERENCES eval_runs(id) ON DELETE SET NULL,
+    baseline_score REAL,
+    winner_variant_id UUID,
+    winner_score REAL,
+    score_delta REAL,
+    approval_id UUID REFERENCES approvals(id) ON DELETE SET NULL,
+    summary TEXT DEFAULT '',
+    error TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    completed_at TIMESTAMPTZ
+);
+
+ALTER TABLE optimization_runs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage their own optimization runs"
+    ON optimization_runs FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- 2. Optimization variants (candidate prompts + per-variant scores)
+CREATE TABLE IF NOT EXISTS optimization_variants (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    optimization_run_id UUID NOT NULL REFERENCES optimization_runs(id) ON DELETE CASCADE,
+    variant_index INTEGER NOT NULL DEFAULT 0,
+    system_prompt TEXT NOT NULL,
+    rationale TEXT DEFAULT '',
+    eval_run_id UUID REFERENCES eval_runs(id) ON DELETE SET NULL,
+    score REAL,
+    pass_rate REAL,
+    is_winner BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE optimization_variants ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view optimization variants via run"
+    ON optimization_variants FOR ALL
+    USING (
+        optimization_run_id IN (SELECT id FROM optimization_runs WHERE user_id = auth.uid())
+    );
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_optimization_runs_user ON optimization_runs(user_id);
+CREATE INDEX IF NOT EXISTS idx_optimization_runs_agent ON optimization_runs(agent_id);
+CREATE INDEX IF NOT EXISTS idx_optimization_variants_run ON optimization_variants(optimization_run_id);


### PR DESCRIPTION
## What this does

Closes the loop between the eval framework and agent configs. Until now evals *reported*; now they *improve*. An optimization run takes an agent + an eval suite and:

1. **Baseline eval** — runs the suite against the agent's current prompt.
2. **Collect failures** — if there are none, short-circuits (`no_failures`); nothing to optimize.
3. **Generate variants** — one model call (via the existing `provider_registry.complete` path) produces N candidate system prompts from the current prompt + a transcript of the failing cases.
4. **Score variants** — runs the suite against each candidate concurrently using a new `prompt_override` on the eval executor, so the stored agent is never mutated.
5. **Select winner** — by suite-score delta over baseline. If nothing beats baseline → `no_improvement`.
6. **Gate the winner** — opens an approval request (`awaiting_approval`). The new prompt is **not** applied to the agent until approved.
7. **Persist lineage** — parent prompt, every variant + its eval run id and score, the winner, and the delta (e.g. "Optimized prompt beat baseline by +12.0% on suite 'X'").

## Approval gating

Promotion is never automatic. The winner is recorded in an `approvals` row (`context.kind = "prompt_optimization"`) reusing Forge's existing approval service. Once approved via the normal approvals API, `POST /api/optimizer/approvals/{id}/apply` records a new prompt version and updates the live agent. Calling apply before approval is a no-op.

## API surface

- `POST /api/optimizer/runs` — kick off (rate-limited `5/hour`, same `get_current_user` auth as every route).
- `GET /api/optimizer/runs` — list lineage (optional `agent_id` filter).
- `GET /api/optimizer/runs/{id}` — lineage with per-variant scores.
- `POST /api/optimizer/approvals/{id}/apply` — promote an approved winner.

## CLI

`forge evals optimize run|list|show|apply`, following the existing evals typer registration.

## Lineage model (dual-backend)

Two tables, mirroring the existing run/eval persistence: `optimization_runs` (parent prompt, baseline run/score, winner, delta, approval id, status) and `optimization_variants` (system prompt, rationale, eval run id, score, pass rate, winner flag). Added to the SQLite schema (DDL + FK map) and as a Supabase migration with RLS.

## Variant generation is injectable

`VariantGenerator` is a `Protocol`; the default `LLMVariantGenerator` calls the real backend LLM path, and `OptimizerService` accepts an injected generator so tests supply a deterministic fake.

## Tests

`backend/tests/test_optimizer.py` — winner selection, no-failure short-circuit, approval-gated (not auto-applied), apply-after-approval promotion, lineage persistence/retrieval, and variant-generator JSON parsing. The pipeline runs against a real in-memory SQLite backend; LLM calls are mocked.

ruff / mypy clean; full backend suite green.