### PR TITLE
Time-travel run debugger: record, replay, edit-and-fork

### DIFF
--- a/backend/app/db/sqlite_schema.py
+++ b/backend/app/db/sqlite_schema.py
@@ -679,6 +679,46 @@ CREATE TABLE IF NOT EXISTS optimization_variants (
 );
 
 CREATE INDEX IF NOT EXISTS idx_optimization_variants_run ON optimization_variants(optimization_run_id);
+
+-- ===================== time-travel debugger: run_events (append-only log) =====================
+-- An append-only event log for every agent run. Each row is one event in the
+-- run's timeline: a model_call (request+response), a tool_call (args+result), a
+-- state mutation, or a step boundary. seq is the monotonic position in the log.
+-- step ties the event to the workflow step that produced it. The log is the
+-- source of truth for deterministic replay and edit-and-fork: a fork copies the
+-- prefix of these rows up to step N and serves the recorded responses as a cache
+-- so unchanged steps are never re-billed.
+CREATE TABLE IF NOT EXISTS run_events (
+    id          TEXT PRIMARY KEY,
+    run_id      TEXT NOT NULL REFERENCES runs(id),
+    seq         INTEGER NOT NULL,
+    step        INTEGER NOT NULL DEFAULT 0,
+    event_type  TEXT NOT NULL
+                CHECK (event_type IN ('run_start','step_boundary','model_call','tool_call','state','run_end')),
+    payload     TEXT NOT NULL DEFAULT '{}',
+    created_at  TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_events_run_seq ON run_events(run_id, seq);
+CREATE INDEX IF NOT EXISTS idx_run_events_run_step ON run_events(run_id, step);
+
+-- ===================== time-travel debugger: run_forks (lineage) =====================
+-- Records that a run was forked from a parent at step N with a set of edits.
+-- The child run is a normal runs row. This table captures the lineage so the
+-- UI/CLI can show "forked from <parent> at step N".
+CREATE TABLE IF NOT EXISTS run_forks (
+    id            TEXT PRIMARY KEY,
+    parent_run_id TEXT NOT NULL REFERENCES runs(id),
+    child_run_id  TEXT NOT NULL REFERENCES runs(id),
+    user_id       TEXT NOT NULL,
+    from_step     INTEGER NOT NULL,
+    edits         TEXT NOT NULL DEFAULT '{}',
+    created_at    TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_forks_parent ON run_forks(parent_run_id);
+CREATE INDEX IF NOT EXISTS idx_run_forks_child  ON run_forks(child_run_id);
+CREATE INDEX IF NOT EXISTS idx_run_forks_user   ON run_forks(user_id);
 """
 
 # ---------------------------------------------------------------------------
@@ -708,6 +748,8 @@ JSON_COLUMNS: dict[str, set[str]] = {
     "comparison_runs":         {"models", "results"},
     "traces":                  {"metadata"},
     "workspaces":              {"settings"},
+    "run_events":              {"payload"},
+    "run_forks":               {"edits"},
 }
 
 # ---------------------------------------------------------------------------
@@ -769,6 +811,10 @@ FK_MAP: dict[tuple[str, str], tuple[str, str]] = {
     ("optimization_runs", "agents"):             ("agent_id", "id"),
     ("optimization_runs", "eval_suites"):        ("suite_id", "id"),
     ("optimization_variants", "optimization_runs"): ("optimization_run_id", "id"),
+    # time-travel debugger
+    ("run_events", "runs"):                       ("run_id", "id"),
+    # run_forks has two FKs to runs (parent_run_id, child_run_id); store parent as primary.
+    ("run_forks", "runs"):                        ("parent_run_id", "id"),
 }
 
 

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
 
 from app.db import get_db
 from app.models.attachment import RunRequest
@@ -14,6 +15,19 @@ from app.services.agent_executor import AgentRunner
 from app.services.rate_limiter import limiter
 
 router = APIRouter(tags=["runs"])
+
+
+class ForkRequest(BaseModel):
+    """Body for POST /runs/{id}/fork — rewind to ``from_step`` and apply ``edits``.
+
+    ``edits`` may carry: ``prompt`` (new system prompt), ``user_input`` (new run
+    input), ``tool_result`` ({step, value}), and/or ``step_result``
+    ({step, content}). The earliest edited step (or ``from_step``) is where real
+    recompute begins; everything before it is served from the parent's log.
+    """
+
+    from_step: int = Field(ge=1, description="Step to rewind to (1-indexed).")
+    edits: dict = Field(default_factory=dict)
 
 
 @router.get("/runs", response_model=list[RunResponse])
@@ -97,8 +111,12 @@ async def run_agent(
     except Exception:
         heartbeat_id = None
 
-    # Create a per-request runner with the user's provider configs
-    agent_runner = AgentRunner(user_id=user.id)
+    # Create a per-request runner with the user's provider configs, plus a
+    # recorder so this run is captured in the append-only event log (powers the
+    # time-travel debugger: replay + edit-and-fork).
+    from app.services.timetravel.recorder import RunRecorder
+
+    agent_runner = AgentRunner(user_id=user.id, recorder=RunRecorder(run_id))
 
     async def event_stream():
         step_logs = []
@@ -163,6 +181,73 @@ async def run_agent(
             yield f"data: {json.dumps({'type': 'error', 'data': 'Agent execution failed. Check run details for more info.'})}\n\n"
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
+def _assert_run_owner(run_id: str, user_id: str) -> dict:
+    """Fetch a run and 404 unless it belongs to ``user_id``."""
+    result = get_db().table("runs").select("*").eq("id", run_id).single().execute()
+    if not result.data or result.data.get("user_id") != user_id:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return dict(result.data)
+
+
+@router.get("/runs/{run_id}/events")
+async def get_run_events(
+    run_id: str,
+    user=Depends(get_current_user),  # noqa: B008
+):
+    """Return the append-only event log for a run (the time-travel timeline)."""
+    from app.services.timetravel import build_timeline, load_events
+
+    _assert_run_owner(run_id, user.id)
+    events = load_events(run_id)
+    return {
+        "run_id": run_id,
+        "events": events,
+        "timeline": build_timeline(events),
+    }
+
+
+@router.post("/runs/{run_id}/replay")
+async def replay_run(
+    run_id: str,
+    user=Depends(get_current_user),  # noqa: B008
+):
+    """Deterministically replay a run from its log (zero model/tool calls)."""
+    from app.services.timetravel import replay_with_executor
+
+    _assert_run_owner(run_id, user.id)
+    try:
+        return await replay_with_executor(run_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post("/runs/{run_id}/fork")
+@limiter.limit("20/hour")
+async def fork_run(
+    run_id: str,
+    request: Request,  # noqa: ARG001 - required by slowapi limiter
+    body: ForkRequest,
+    user=Depends(get_current_user),  # noqa: B008
+):
+    """Edit-and-fork: rewind to a step, apply edits, re-run forward.
+
+    Unchanged steps before the edit are served from the parent's recorded log
+    (never re-billed); only the edited step and later steps call the model/tools.
+    """
+    from app.services.timetravel import fork_service
+
+    _assert_run_owner(run_id, user.id)
+    try:
+        return await fork_service.fork(
+            parent_run_id=run_id,
+            user_id=user.id,
+            from_step=body.from_step,
+            edits=body.edits,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.get("/stats")

--- a/backend/app/services/agent_executor.py
+++ b/backend/app/services/agent_executor.py
@@ -44,12 +44,30 @@ def _is_vision_capable(model: str | None) -> bool:
 class AgentRunner:
     """Executes agent workflows step-by-step using LangChain with tool integration."""
 
-    def __init__(self, model: str | None = None, user_id: str | None = None):
+    def __init__(
+        self,
+        model: str | None = None,
+        user_id: str | None = None,
+        *,
+        recorder: Any = None,
+        response_cache: Any = None,
+    ):
         from langchain_openai import ChatOpenAI
 
         self.model = model or provider_registry.default_model
         self.user_id = user_id
         self._llm: ChatOpenAI | None = None  # Created lazily
+        # Time-travel debugger hooks. ``recorder`` appends to the run's
+        # append-only event log; ``response_cache`` serves recorded model/tool
+        # responses so replay/fork don't re-pay. Both default to no-ops so the
+        # normal execution path is unchanged when the debugger isn't in use.
+        from app.services.timetravel.recorder import NullRecorder
+
+        self.recorder = recorder or NullRecorder()
+        self.response_cache = response_cache
+        # Tracks the workflow step currently executing, so model/tool calls are
+        # recorded against the right step without threading it through every call.
+        self._current_step = 0
 
     async def _get_llm(self):
         """Get LLM instance, using the shared user-LLM resolver (one key path)."""
@@ -117,6 +135,10 @@ class AgentRunner:
                 heartbeat_id, state="running", current_step=0
             )
 
+        # Open the run's event log (no-op when no recorder is attached).
+        self._current_step = 0
+        self.recorder.run_start(agent_id=agent_id, user_input=user_input, model=model)
+
         yield {"type": "step", "content": f"Starting agent: {agent_config.get('name', 'Unnamed')}", "tokens": 0}
         for note in notes:
             yield {"type": "step", "content": note, "tokens": 0}
@@ -128,6 +150,8 @@ class AgentRunner:
         total_tokens = 0
 
         for i, step in enumerate(workflow_steps, 1):
+            self._current_step = i
+            self.recorder.step_boundary(i, step)
             yield {"type": "step", "content": f"Step {i}: {step}", "tokens": 0}
 
             if heartbeat_id:
@@ -199,8 +223,13 @@ class AgentRunner:
                 )
 
             accumulated_context += f"\n\n--- Step {i} result ---\n{result['content']}"
+            # Record the post-step accumulated context as a state mutation so the
+            # replayer can reconstruct exact step-by-step state from the log.
+            self.recorder.state(i, key="accumulated_context", value=accumulated_context)
             yield {"type": "token", "content": result["content"], "tokens": step_tokens}
             yield {"type": "step", "content": f"Step {i} completed", "tokens": 0}
+
+        self.recorder.run_end(status="completed", output=accumulated_context, total_tokens=total_tokens)
 
         if heartbeat_id:
             heartbeat_service.complete(heartbeat_id, tokens_used=total_tokens)
@@ -258,6 +287,14 @@ class AgentRunner:
         self, system_prompt: str, step: str, user_input: str, context: str, tools: list
     ) -> dict:
         """Execute a step using LangChain agent with tools."""
+        # Replay/fork: a cached step result is served verbatim — the LangChain
+        # executor (and every model/tool call it would make) is skipped, so the
+        # step isn't re-billed.
+        if self.response_cache is not None:
+            hit, cached = self.response_cache.get_model(self._current_step)
+            if hit:
+                return dict(cached)
+
         llm = await self._get_llm()
         if not llm:
             # No OpenAI key — fall back to non-tool step via provider registry
@@ -278,10 +315,18 @@ class AgentRunner:
 
         result = await executor.ainvoke({"input": full_input})
 
-        return {
+        out = {
             "content": result.get("output", ""),
             "tokens": 0,
         }
+        # Record the tool-augmented step's outcome as a model_call so replay and
+        # fork can reconstruct it without re-running the agent loop.
+        self.recorder.model_call(
+            self._current_step,
+            request={"system_prompt": system_prompt, "step": step, "input": full_input, "tools": True},
+            response=out,
+        )
+        return out
 
     async def _execute_step(
         self,
@@ -311,6 +356,26 @@ class AgentRunner:
             {"role": "user", "content": user_content},
         ]
 
+        return await self._invoke_model(messages, model)
+
+    async def _invoke_model(self, messages: list[dict[str, Any]], model: str | None) -> dict:
+        """Run one model completion, consulting the cache and recording the result.
+
+        This is the single interception point for model calls. When a step's
+        response is cached (replay, or a fork's unchanged prefix) the recorded
+        value is returned and the provider is never hit — that's how forks avoid
+        re-paying. Otherwise the real provider runs and the call is recorded.
+        """
+        request = {"messages": messages, "model": model}
+
+        if self.response_cache is not None:
+            hit, cached = self.response_cache.get_model(self._current_step)
+            if hit:
+                # Served from the recorded log — do NOT record again (the event
+                # already exists in the parent/original log; a fork copies the
+                # prefix verbatim before resuming).
+                return dict(cached)
+
         # Use user's provider registry if available
         if self.user_id:
             from app.providers.registry import create_user_registry
@@ -325,7 +390,7 @@ class AgentRunner:
             temperature=0,
         )
 
-        return {
+        result = {
             "content": response.content,
             "tokens": response.input_tokens + response.output_tokens,
             "input_tokens": response.input_tokens,
@@ -334,3 +399,5 @@ class AgentRunner:
             "model": response.model,
             "provider": response.provider,
         }
+        self.recorder.model_call(self._current_step, request=request, response=result)
+        return result

--- a/backend/app/services/timetravel/__init__.py
+++ b/backend/app/services/timetravel/__init__.py
@@ -1,0 +1,34 @@
+"""Time-travel run debugger.
+
+Records every agent run as an append-only event log (model calls, tool calls,
+state mutations, step boundaries), then offers:
+
+* deterministic **replay** of any past run from its log with zero model/tool
+  calls;
+* **edit-and-fork** — rewind to step N, change the prompt or a tool/step result,
+  and re-run forward while serving the unchanged prefix from a step-keyed cache
+  so those steps are never re-billed.
+"""
+
+from app.services.timetravel.cache import CacheMiss, ResponseCache
+from app.services.timetravel.fork import ForkService, fork_service
+from app.services.timetravel.recorder import NullRecorder, RunRecorder
+from app.services.timetravel.replayer import (
+    build_timeline,
+    load_events,
+    reconstruct_agent_config,
+    replay_with_executor,
+)
+
+__all__ = [
+    "CacheMiss",
+    "ForkService",
+    "NullRecorder",
+    "ResponseCache",
+    "RunRecorder",
+    "build_timeline",
+    "fork_service",
+    "load_events",
+    "reconstruct_agent_config",
+    "replay_with_executor",
+]

--- a/backend/app/services/timetravel/cache.py
+++ b/backend/app/services/timetravel/cache.py
@@ -1,0 +1,115 @@
+"""Step-keyed response cache for replay and edit-and-fork.
+
+This is the mechanism that lets a fork avoid re-paying for unchanged steps. The
+cache is built from a parent run's recorded event log: for every ``model_call``
+and ``tool_call`` event it stores the recorded response keyed by
+``(kind, step, ordinal)`` — ``ordinal`` disambiguates multiple calls of the same
+kind within a single step (e.g. a step that makes two tool calls).
+
+During execution the agent runner asks the cache for a response *before* hitting
+the provider/tool. On a hit it returns the recorded value and never bills; on a
+miss the runner makes the real call. Replay uses a cache in ``strict`` mode where
+a miss is a bug (the model must never be called); fork uses a non-strict cache so
+edited/downstream steps fall through to real calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.timetravel.recorder import EVENT_MODEL_CALL, EVENT_TOOL_CALL
+
+
+class CacheMiss(Exception):  # noqa: N818 - this is a control-flow signal, not an "error"
+    """Raised by a strict cache when a required response wasn't recorded.
+
+    During replay this signals an attempt to invoke the model/tool, which must
+    never happen — replay is supposed to be served entirely from the log.
+    """
+
+
+class ResponseCache:
+    """Serves recorded model/tool responses keyed by ``(kind, step, ordinal)``."""
+
+    def __init__(self, *, strict: bool = False) -> None:
+        # (kind, step, ordinal) -> recorded value
+        self._responses: dict[tuple[str, int, int], Any] = {}
+        self._strict = strict
+        # Per-(kind, step) cursor so repeated calls within a step consume
+        # successive recorded responses in order.
+        self._cursors: dict[tuple[str, int], int] = {}
+        # Steps for which the cache should be authoritative. A call at a step
+        # NOT in this set always falls through to a real call (used by fork to
+        # invalidate the edited step and everything after it).
+        self._served_steps: set[int] | None = None
+
+    @classmethod
+    def from_events(
+        cls,
+        events: list[dict[str, Any]],
+        *,
+        strict: bool = False,
+        max_step: int | None = None,
+    ) -> ResponseCache:
+        """Build a cache from a list of recorded events.
+
+        Args:
+            events: ordered run_events rows (each with ``event_type``, ``step``,
+                ``payload``).
+            strict: when True, a miss raises :class:`CacheMiss` (replay mode).
+            max_step: if given, only events with ``step <= max_step`` are
+                loaded — the prefix served on a fork.
+        """
+        cache = cls(strict=strict)
+        for ev in events:
+            etype = ev.get("event_type")
+            step = int(ev.get("step", 0) or 0)
+            if max_step is not None and step > max_step:
+                continue
+            payload = ev.get("payload") or {}
+            if etype == EVENT_MODEL_CALL:
+                cache._add("model", step, payload.get("response"))
+            elif etype == EVENT_TOOL_CALL:
+                cache._add("tool", step, {"name": payload.get("name"), "result": payload.get("result")})
+        return cache
+
+    def _add(self, kind: str, step: int, value: Any) -> None:
+        ordinal = self._cursors.get((kind, step), 0)
+        self._responses[(kind, step, ordinal)] = value
+        self._cursors[(kind, step)] = ordinal + 1
+
+    def restrict_to_steps(self, steps: set[int]) -> None:
+        """Limit which steps the cache will serve (fork prefix invalidation)."""
+        self._served_steps = set(steps)
+
+    def reset_cursors(self) -> None:
+        """Reset per-step read cursors so the cache can be consumed for a run."""
+        self._cursors = {}
+
+    def _next(self, kind: str, step: int) -> tuple[bool, Any]:
+        """Return (hit, value) for the next response of ``kind`` at ``step``."""
+        if self._served_steps is not None and step not in self._served_steps:
+            return False, None
+        ordinal = self._cursors.get((kind, step), 0)
+        key = (kind, step, ordinal)
+        if key in self._responses:
+            self._cursors[(kind, step)] = ordinal + 1
+            return True, self._responses[key]
+        if self._strict:
+            raise CacheMiss(
+                f"No recorded {kind} response for step {step} (ordinal {ordinal}); "
+                "replay must be fully served from the event log."
+            )
+        return False, None
+
+    def get_model(self, step: int) -> tuple[bool, Any]:
+        """Get the next recorded model response for a step, if cached."""
+        return self._next("model", step)
+
+    def get_tool(self, step: int) -> tuple[bool, Any]:
+        """Get the next recorded tool response for a step, if cached."""
+        return self._next("tool", step)
+
+    def has_step(self, step: int) -> bool:
+        """True if any model/tool response is cached for ``step``."""
+        return any(s == step for (_k, s, _o) in self._responses)

--- a/backend/app/services/timetravel/fork.py
+++ b/backend/app/services/timetravel/fork.py
@@ -1,0 +1,251 @@
+"""Edit-and-fork: rewind a run to step N, change something, re-run forward.
+
+The killer feature of the time-travel debugger. A fork:
+
+1. Loads the parent run's event log and reconstructs its agent config + input.
+2. Creates a brand-new child run row.
+3. Copies the parent's event-log prefix (events at step ``< from_step``) into the
+   child's log verbatim.
+4. Builds a step-keyed :class:`ResponseCache` from that same prefix and
+   *restricts it to the unchanged steps* (``< from_step``). When the executor
+   re-runs, every step before the edit is served from this cache — so those
+   steps are never re-billed. The edited step (``from_step``) and everything
+   after it miss the cache and make real model/tool calls.
+5. Applies the edits (modified prompt and/or a modified tool/step result that is
+   injected into the cache so the recompute downstream sees the new value).
+6. Resumes the :class:`AgentRunner` forward with a fresh recorder so the child's
+   log captures the re-run from ``from_step`` onward.
+
+Edits shape (all optional)::
+
+    {
+        "prompt": "new system prompt text",       # replaces system_prompt
+        "user_input": "new user input",            # replaces the run input
+        "tool_result": {"step": N, "value": ...},  # override a recorded tool result
+        "step_result": {"step": N, "content": ...} # override a step's model output
+    }
+
+The earliest edited step determines where real recompute begins; ``from_step`` is
+used when no per-step edit is earlier.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from app.db import get_db
+from app.services.timetravel.cache import ResponseCache
+from app.services.timetravel.recorder import RunRecorder
+from app.services.timetravel.replayer import load_events, reconstruct_agent_config
+
+logger = logging.getLogger(__name__)
+
+
+class ForkService:
+    """Creates a forked run from a parent run at step N with edits."""
+
+    async def fork(
+        self,
+        *,
+        parent_run_id: str,
+        user_id: str,
+        from_step: int,
+        edits: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Fork a run at ``from_step`` and re-run forward, reusing the prefix.
+
+        Returns the lineage record for the new child run (including its id and
+        which steps were served from cache vs. recomputed).
+        """
+        edits = edits or {}
+
+        parent = (
+            get_db().table("runs").select("*").eq("id", parent_run_id).single().execute()
+        ).data
+        if not parent or parent.get("user_id") != user_id:
+            raise ValueError("Parent run not found")
+
+        events = load_events(parent_run_id)
+        if not events:
+            raise ValueError(f"Parent run {parent_run_id} has no recorded event log")
+
+        recon = reconstruct_agent_config(events)
+        agent_config = recon["agent_config"]
+        user_input = recon["user_input"]
+
+        # Pull the parent agent's real config (system prompt + tools) — the event
+        # log records workflow/model but the system prompt lives on the agent.
+        parent_agent_id = parent.get("agent_id")
+        if parent_agent_id:
+            agent = (
+                get_db().table("agents").select("*").eq("id", parent_agent_id).single().execute()
+            ).data
+            if agent:
+                agent_config = {
+                    **agent_config,
+                    "id": agent.get("id"),
+                    "name": agent.get("name"),
+                    "system_prompt": agent.get("system_prompt", ""),
+                    "tools": agent.get("tools", []),
+                    "model": agent_config.get("model") or agent.get("model"),
+                }
+
+        # --- Apply edits ---------------------------------------------------
+        # An edit at step K invalidates step K and everything after it. The
+        # cut-over (first recomputed step) is the min of from_step and any
+        # per-step edit's step.
+        cut_step = from_step
+        if "prompt" in edits:
+            agent_config = {**agent_config, "system_prompt": edits["prompt"]}
+            # A prompt change invalidates the whole run.
+            cut_step = 1
+        if "user_input" in edits:
+            user_input = edits["user_input"]
+            cut_step = 1
+
+        tool_override = edits.get("tool_result")
+        if isinstance(tool_override, dict) and "step" in tool_override:
+            cut_step = min(cut_step, int(tool_override["step"]))
+        step_override = edits.get("step_result")
+        if isinstance(step_override, dict) and "step" in step_override:
+            cut_step = min(cut_step, int(step_override["step"]))
+
+        cut_step = max(1, cut_step)
+
+        # --- Create the child run row -------------------------------------
+        child_run_id = str(uuid.uuid4())
+        get_db().table("runs").insert({
+            "id": child_run_id,
+            "agent_id": parent_agent_id,
+            "user_id": user_id,
+            "input_text": user_input,
+            "status": "running",
+        }).execute()
+
+        # --- Copy the unchanged prefix into the child's log ---------------
+        # Events for steps strictly before cut_step are copied verbatim so the
+        # child's log is a true continuation. run_start is re-emitted by the
+        # executor, so we copy step_boundary/model_call/tool_call/state for the
+        # prefix steps only.
+        copied = self._copy_prefix(events, child_run_id, cut_step)
+
+        # --- Build the prefix cache (served, not re-billed) ---------------
+        cache = ResponseCache.from_events(events, max_step=cut_step - 1)
+        cache.restrict_to_steps(set(range(1, cut_step)))
+        cache.reset_cursors()
+
+        # Inject any tool/step result override so downstream recompute sees the
+        # edited value. (Only meaningful when the override step is < cut_step,
+        # i.e. the user pinned an earlier step's result and asked to recompute
+        # from there — the override seeds the served prefix.)
+        self._apply_result_overrides(cache, edits)
+
+        served_steps = sorted(range(1, cut_step))
+
+        # --- Resume the executor forward ----------------------------------
+        from app.services.agent_executor import AgentRunner
+
+        recorder = RunRecorder(child_run_id)
+        # Re-seed the recorder's seq past the copied prefix so the child log
+        # stays monotonic.
+        recorder._seq = copied  # noqa: SLF001 - intentional continuation of the log
+
+        runner = AgentRunner(user_id=user_id, recorder=recorder, response_cache=cache)
+
+        final_output = ""
+        total_tokens = 0
+        recomputed_steps: list[int] = []
+        try:
+            async for event in runner.execute(agent_config, user_input, run_id=child_run_id, user_id=user_id):
+                if event.get("type") == "token":
+                    final_output += event.get("content", "")
+                total_tokens += event.get("tokens", 0)
+            # Steps at/after the cut were recomputed (not served).
+            recomputed_steps = [
+                s for s in range(1, len(agent_config.get("workflow_steps", [])) + 1) if s >= cut_step
+            ]
+            get_db().table("runs").update({
+                "status": "completed",
+                "output": final_output,
+                "tokens_used": total_tokens,
+            }).eq("id", child_run_id).execute()
+        except Exception as e:
+            logger.exception("Fork of run %s failed", parent_run_id)
+            get_db().table("runs").update({
+                "status": "failed",
+                "output": str(e),
+            }).eq("id", child_run_id).execute()
+            raise
+
+        # --- Record lineage ------------------------------------------------
+        fork_id = str(uuid.uuid4())
+        get_db().table("run_forks").insert({
+            "id": fork_id,
+            "parent_run_id": parent_run_id,
+            "child_run_id": child_run_id,
+            "user_id": user_id,
+            "from_step": cut_step,
+            "edits": edits,
+        }).execute()
+
+        return {
+            "fork_id": fork_id,
+            "parent_run_id": parent_run_id,
+            "child_run_id": child_run_id,
+            "from_step": cut_step,
+            "served_from_cache_steps": served_steps,
+            "recomputed_steps": recomputed_steps,
+            "edits": edits,
+            "output": final_output,
+        }
+
+    @staticmethod
+    def _copy_prefix(events: list[dict[str, Any]], child_run_id: str, cut_step: int) -> int:
+        """Copy prefix events (step < cut_step) into the child's log.
+
+        Returns the number of events copied (= the seq to resume from).
+        """
+        copied = 0
+        for ev in events:
+            etype = ev.get("event_type")
+            step = int(ev.get("step", 0) or 0)
+            # run_start/run_end are re-emitted by the new run; only carry the
+            # per-step prefix forward.
+            if etype in ("run_start", "run_end"):
+                continue
+            if step >= cut_step or step < 1:
+                continue
+            get_db().table("run_events").insert({
+                "id": str(uuid.uuid4()),
+                "run_id": child_run_id,
+                "seq": copied,
+                "step": step,
+                "event_type": etype,
+                "payload": ev.get("payload") or {},
+            }).execute()
+            copied += 1
+        return copied
+
+    @staticmethod
+    def _apply_result_overrides(cache: ResponseCache, edits: dict[str, Any]) -> None:
+        """Inject edited tool/step results into the served prefix cache."""
+        step_override = edits.get("step_result")
+        if isinstance(step_override, dict) and "step" in step_override:
+            step = int(step_override["step"])
+            # Replace the served model response for that step.
+            cache._responses[("model", step, 0)] = {  # noqa: SLF001
+                "content": step_override.get("content", ""),
+                "tokens": 0,
+            }
+        tool_override = edits.get("tool_result")
+        if isinstance(tool_override, dict) and "step" in tool_override:
+            step = int(tool_override["step"])
+            key = ("tool", step, 0)
+            existing = cache._responses.get(key, {})  # noqa: SLF001
+            name = existing.get("name") if isinstance(existing, dict) else None
+            cache._responses[key] = {"name": name, "result": tool_override.get("value")}  # noqa: SLF001
+
+
+fork_service = ForkService()

--- a/backend/app/services/timetravel/recorder.py
+++ b/backend/app/services/timetravel/recorder.py
@@ -1,0 +1,108 @@
+"""Append-only event recorder for agent runs (the time-travel debugger's log).
+
+A :class:`RunRecorder` is a thin sink the agent executor notifies at each model
+call, tool call, state mutation, and step boundary. It assigns a monotonic
+``seq`` and persists every event through the existing dual-backend ``get_db()``
+so the SQLite and Supabase stores share one code path.
+
+The recorder is deliberately dumb: it only *appends*. Reconstruction (replay)
+and prefix-copying (fork) live in :mod:`app.services.timetravel.replayer` and
+:mod:`app.services.timetravel.fork` so the hot execution path stays clean.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from app.db import get_db
+
+logger = logging.getLogger(__name__)
+
+# Event types written to the run_events log. Kept in sync with the CHECK
+# constraint in both the SQLite schema and the Supabase migration.
+EVENT_RUN_START = "run_start"
+EVENT_STEP_BOUNDARY = "step_boundary"
+EVENT_MODEL_CALL = "model_call"
+EVENT_TOOL_CALL = "tool_call"
+EVENT_STATE = "state"
+EVENT_RUN_END = "run_end"
+
+
+class RunRecorder:
+    """Append-only sink that persists a run's event log.
+
+    One recorder instance is created per run. It is safe to disable (``enabled``
+    False) so the executor can be driven during replay without re-recording, and
+    so callers that don't want a log pay nothing.
+    """
+
+    def __init__(self, run_id: str, *, enabled: bool = True) -> None:
+        self.run_id = run_id
+        self.enabled = enabled
+        self._seq = 0
+
+    def _append(self, event_type: str, step: int, payload: dict[str, Any]) -> dict[str, Any]:
+        """Persist one event and return the stored row (best-effort)."""
+        seq = self._seq
+        self._seq += 1
+        row = {
+            "id": str(uuid.uuid4()),
+            "run_id": self.run_id,
+            "seq": seq,
+            "step": step,
+            "event_type": event_type,
+            "payload": payload,
+        }
+        if not self.enabled:
+            return row
+        try:
+            get_db().table("run_events").insert(row).execute()
+        except Exception:
+            # Recording must never break a run. A lost event degrades replay
+            # fidelity but the run itself completes.
+            logger.warning("Failed to record run event %s for run %s", event_type, self.run_id, exc_info=True)
+        return row
+
+    def run_start(self, *, agent_id: str | None, user_input: str, model: str | None) -> None:
+        self._append(EVENT_RUN_START, 0, {
+            "agent_id": agent_id,
+            "user_input": user_input,
+            "model": model,
+        })
+
+    def step_boundary(self, step: int, description: str) -> None:
+        self._append(EVENT_STEP_BOUNDARY, step, {"description": description})
+
+    def model_call(self, step: int, *, request: dict[str, Any], response: dict[str, Any]) -> None:
+        """Record a model call: the full request and the provider response."""
+        self._append(EVENT_MODEL_CALL, step, {"request": request, "response": response})
+
+    def tool_call(self, step: int, *, name: str, args: dict[str, Any], result: Any) -> None:
+        """Record a tool invocation: tool name, arguments, and its result."""
+        self._append(EVENT_TOOL_CALL, step, {"name": name, "args": args, "result": result})
+
+    def state(self, step: int, *, key: str, value: Any) -> None:
+        """Record a state mutation (e.g. accumulated context after a step)."""
+        self._append(EVENT_STATE, step, {"key": key, "value": value})
+
+    def run_end(self, *, status: str, output: str, total_tokens: int) -> None:
+        self._append(EVENT_RUN_END, 0, {
+            "status": status,
+            "output": output,
+            "total_tokens": total_tokens,
+        })
+
+
+# A no-op recorder used when recording is disabled (e.g. during replay). Every
+# method is a no-op; the executor calls it unconditionally so there are no
+# `if recorder:` branches on the hot path.
+class NullRecorder(RunRecorder):
+    """Recorder that drops everything — used when recording is turned off."""
+
+    def __init__(self) -> None:
+        super().__init__(run_id="", enabled=False)
+
+    def _append(self, event_type: str, step: int, payload: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        return {}

--- a/backend/app/services/timetravel/replayer.py
+++ b/backend/app/services/timetravel/replayer.py
@@ -1,0 +1,168 @@
+"""Deterministic replay of a recorded run from its event log.
+
+The replayer reconstructs a run's step-by-step state purely from the
+``run_events`` log — it never calls the model or any tool. It exposes the
+ordered timeline and the reconstructed per-step state so a debugger UI/CLI can
+step through exactly what happened.
+
+There are two flavours:
+
+* :func:`load_events` / :func:`build_timeline` — pure reconstruction from the
+  stored log (no executor involved). This is what the ``/replay`` endpoint
+  returns and is provably model-free.
+* :func:`replay_with_executor` — drives the real :class:`AgentRunner` with a
+  *strict* :class:`ResponseCache` built from the log. Every model/tool call is
+  served from the cache; a cache miss raises :class:`CacheMiss`, which is the
+  assertion that replay paid nothing. Used to verify the executor reproduces the
+  recorded output bit-for-bit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.db import get_db
+from app.services.timetravel.cache import ResponseCache
+from app.services.timetravel.recorder import (
+    EVENT_MODEL_CALL,
+    EVENT_RUN_END,
+    EVENT_STATE,
+    EVENT_STEP_BOUNDARY,
+    EVENT_TOOL_CALL,
+    NullRecorder,
+)
+
+
+def load_events(run_id: str) -> list[dict[str, Any]]:
+    """Load a run's full event log ordered by sequence."""
+    rows = (
+        get_db().table("run_events")
+        .select("*")
+        .eq("run_id", run_id)
+        .order("seq")
+        .execute()
+    ).data or []
+    return list(rows)
+
+
+def build_timeline(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Reconstruct step-by-step state from an event log without any calls.
+
+    Returns a dict with:
+      * ``steps``: list of {step, description, model_responses, tool_calls,
+        state} reconstructed in order.
+      * ``output``: the final accumulated output (from the last state/run_end).
+      * ``total_events``: number of events.
+    """
+    steps: dict[int, dict[str, Any]] = {}
+    order: list[int] = []
+    output = ""
+    total_tokens = 0
+
+    def _step(n: int) -> dict[str, Any]:
+        if n not in steps:
+            steps[n] = {
+                "step": n,
+                "description": "",
+                "model_responses": [],
+                "tool_calls": [],
+                "state": {},
+            }
+            order.append(n)
+        return steps[n]
+
+    for ev in events:
+        etype = ev.get("event_type")
+        step = int(ev.get("step", 0) or 0)
+        payload = ev.get("payload") or {}
+        if etype == EVENT_STEP_BOUNDARY:
+            _step(step)["description"] = payload.get("description", "")
+        elif etype == EVENT_MODEL_CALL:
+            _step(step)["model_responses"].append(payload.get("response"))
+        elif etype == EVENT_TOOL_CALL:
+            _step(step)["tool_calls"].append(
+                {"name": payload.get("name"), "args": payload.get("args"), "result": payload.get("result")}
+            )
+        elif etype == EVENT_STATE:
+            _step(step)["state"][payload.get("key")] = payload.get("value")
+        elif etype == EVENT_RUN_END:
+            output = payload.get("output", output)
+            total_tokens = payload.get("total_tokens", total_tokens)
+
+    if not output:
+        # Fall back to the last recorded accumulated_context state.
+        for n in reversed(order):
+            ctx = steps[n]["state"].get("accumulated_context")
+            if ctx:
+                output = ctx
+                break
+
+    return {
+        "steps": [steps[n] for n in sorted(order)],
+        "output": output,
+        "total_tokens": total_tokens,
+        "total_events": len(events),
+    }
+
+
+def reconstruct_agent_config(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Rebuild the minimal agent config + input needed to drive the executor.
+
+    Workflow steps come from the recorded ``step_boundary`` events; the user
+    input and model come from ``run_start``.
+    """
+    user_input = ""
+    model: str | None = None
+    workflow: list[tuple[int, str]] = []
+    for ev in events:
+        etype = ev.get("event_type")
+        payload = ev.get("payload") or {}
+        if etype == "run_start":
+            user_input = payload.get("user_input", "")
+            model = payload.get("model")
+        elif etype == EVENT_STEP_BOUNDARY:
+            workflow.append((int(ev.get("step", 0) or 0), payload.get("description", "")))
+    workflow.sort(key=lambda t: t[0])
+    return {
+        "agent_config": {
+            "system_prompt": "",
+            "tools": [],
+            "workflow_steps": [d for _s, d in workflow],
+            "model": model,
+        },
+        "user_input": user_input,
+    }
+
+
+async def replay_with_executor(run_id: str) -> dict[str, Any]:
+    """Re-drive the executor from the log with a strict cache (zero model calls).
+
+    Returns the reconstructed timeline plus the executor's streamed step outputs.
+    Raises :class:`~app.services.timetravel.cache.CacheMiss` if anything would
+    have required a real model/tool call.
+    """
+    from app.services.agent_executor import AgentRunner
+
+    events = load_events(run_id)
+    if not events:
+        raise ValueError(f"No event log for run {run_id}")
+
+    cache = ResponseCache.from_events(events, strict=True)
+    cache.reset_cursors()
+    recon = reconstruct_agent_config(events)
+
+    # No recorder (replay must not re-record), strict cache so any real call
+    # raises. user_id stays None so no provider is ever constructed.
+    runner = AgentRunner(recorder=NullRecorder(), response_cache=cache)
+
+    outputs: list[str] = []
+    async for event in runner.execute(
+        recon["agent_config"],
+        recon["user_input"],
+    ):
+        if event.get("type") == "token":
+            outputs.append(event.get("content", ""))
+
+    timeline = build_timeline(events)
+    timeline["replayed_output"] = "".join(outputs)
+    return timeline

--- a/backend/tests/test_time_travel.py
+++ b/backend/tests/test_time_travel.py
@@ -1,0 +1,372 @@
+"""Tests for the time-travel run debugger (record / replay / edit-and-fork).
+
+These run against a real in-memory SQLite backend so the append-only event log is
+verified end to end. The model is mocked at one seam: ``provider_registry.complete``
+is replaced with an AsyncMock whose output depends on the system prompt, so we can
+assert exactly when (and whether) the model is invoked.
+
+Key invariants under test:
+
+* recording produces a faithful, ordered, append-only event log;
+* replay reconstructs identical step state/output from the log with ZERO model
+  calls (the provider is asserted never-called during replay);
+* fork copies the unchanged prefix and serves it from cache — the model is only
+  called for the edited step and the steps after it — and produces a new run id;
+* an edit at step N changes downstream output but not the cached prefix.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.agent_executor import AgentRunner
+from app.services.timetravel import (
+    ResponseCache,
+    RunRecorder,
+    build_timeline,
+    fork_service,
+    load_events,
+    replay_with_executor,
+)
+from app.services.timetravel.cache import CacheMiss
+
+
+def _run(coro):
+    """Run a coroutine on a fresh event loop set as current.
+
+    A fresh loop per call avoids 'no current event loop' / reused-loop issues
+    when a test drives several async operations against the SQLite backend.
+    """
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+@dataclass
+class _FakeLLMResponse:
+    content: str
+    model: str = "fake-model"
+    input_tokens: int = 3
+    output_tokens: int = 5
+    finish_reason: str = "stop"
+    latency_ms: float = 1.0
+    provider: str = "fake"
+    raw_response: object = None
+
+
+@pytest.fixture
+def sqlite_backend(tmp_path):
+    """Real, fully-initialized SQLite backend wired in as the global db."""
+    import app.db as db_mod
+    from app.db import init_db
+    from app.db.sqlite_backend import SQLiteBackend
+
+    previous = db_mod._db
+    db = SQLiteBackend(db_path=str(tmp_path / "timetravel.db"))
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(db.initialize())
+    finally:
+        loop.close()
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    init_db(db)
+    try:
+        yield db
+    finally:
+        db_mod._db = previous
+
+
+def _seed_run(db, *, user_id: str, agent_id: str | None = None) -> str:
+    """Insert a run row and return its id."""
+    run_id = str(uuid.uuid4())
+    db.table("runs").insert({
+        "id": run_id,
+        "agent_id": agent_id,
+        "user_id": user_id,
+        "input_text": "hello",
+        "status": "running",
+    }).execute()
+    return run_id
+
+
+def _agent_config(prompt: str = "You are helpful", steps: int = 3) -> dict:
+    return {
+        "id": None,
+        "name": "tt-agent",
+        "system_prompt": prompt,
+        "tools": [],
+        "workflow_steps": [f"do step {i}" for i in range(1, steps + 1)],
+        "model": "fake-model",
+    }
+
+
+def _make_complete_mock(prompt_marker: str = "PROMPT"):
+    """An AsyncMock for provider_registry.complete.
+
+    The response content encodes the system prompt and a per-call counter so
+    different prompts and different call orders are distinguishable.
+    """
+    counter = {"n": 0}
+
+    async def _complete(*, messages, model, temperature):  # noqa: ARG001
+        counter["n"] += 1
+        system = next((m["content"] for m in messages if m["role"] == "system"), "")
+        # Tag the output with the prompt so an edited prompt yields different text.
+        marker = prompt_marker if prompt_marker in system else "BASE"
+        return _FakeLLMResponse(content=f"[{marker}] step-output #{counter['n']}")
+
+    mock = AsyncMock(side_effect=_complete)
+    return mock, counter
+
+
+async def _record_run(db, *, user_id: str, prompt: str = "You are helpful", steps: int = 3):
+    """Execute a run with a recorder and return (run_id, complete_mock)."""
+    run_id = _seed_run(db, user_id=user_id)
+    mock, _counter = _make_complete_mock()
+    runner = AgentRunner(recorder=RunRecorder(run_id))
+    with patch("app.providers.registry.provider_registry.complete", mock):
+        async for _ in runner.execute(_agent_config(prompt, steps), "hello", run_id=run_id):
+            pass
+    return run_id, mock
+
+
+# --------------------------------------------------------------------------
+# Recording
+# --------------------------------------------------------------------------
+
+
+def test_recording_produces_append_only_log(sqlite_backend):
+    db = sqlite_backend
+    run_id, mock = _run(
+        _record_run(db, user_id="u1", steps=3)
+    )
+
+    events = load_events(run_id)
+    types = [e["event_type"] for e in events]
+
+    # Append-only: seq is strictly increasing from 0.
+    seqs = [e["seq"] for e in events]
+    assert seqs == sorted(seqs)
+    assert seqs == list(range(len(events)))
+
+    # Faithful: a run_start, one boundary + one model_call + one state per step,
+    # then a run_end.
+    assert types[0] == "run_start"
+    assert types[-1] == "run_end"
+    assert types.count("step_boundary") == 3
+    assert types.count("model_call") == 3
+    assert types.count("state") == 3
+
+    # The model was actually called once per step during the original run.
+    assert mock.await_count == 3
+
+
+def test_timeline_reconstructs_steps(sqlite_backend):
+    db = sqlite_backend
+    run_id, _ = _run(_record_run(db, user_id="u1", steps=2))
+    timeline = build_timeline(load_events(run_id))
+    assert [s["step"] for s in timeline["steps"]] == [1, 2]
+    assert all(s["model_responses"] for s in timeline["steps"])
+    assert timeline["output"]
+
+
+# --------------------------------------------------------------------------
+# Replay
+# --------------------------------------------------------------------------
+
+
+def test_replay_is_deterministic_and_calls_no_model(sqlite_backend):
+    db = sqlite_backend
+    run_id, _ = _run(_record_run(db, user_id="u1", steps=3))
+    original = build_timeline(load_events(run_id))
+
+    replay_mock = AsyncMock()
+    with patch("app.providers.registry.provider_registry.complete", replay_mock):
+        result = _run(replay_with_executor(run_id))
+
+    # The model is NEVER invoked during replay.
+    assert replay_mock.await_count == 0
+
+    # Replay reconstructs identical per-step model output.
+    orig_outputs = [s["model_responses"][0]["content"] for s in original["steps"]]
+    replay_outputs = [s["model_responses"][0]["content"] for s in result["steps"]]
+    assert replay_outputs == orig_outputs
+    # The executor, re-driven from the strict cache, reproduces each step output.
+    for content in orig_outputs:
+        assert content in result["replayed_output"]
+
+
+def test_strict_cache_miss_raises(sqlite_backend):
+    db = sqlite_backend
+    run_id, _ = _run(_record_run(db, user_id="u1", steps=2))
+    events = load_events(run_id)
+    # Drop the model_call for step 2 so replay must "pay" for it → CacheMiss.
+    events = [e for e in events if not (e["event_type"] == "model_call" and e["step"] == 2)]
+    cache = ResponseCache.from_events(events, strict=True)
+    cache.reset_cursors()
+    assert cache.get_model(1)[0] is True
+    with pytest.raises(CacheMiss):
+        cache.get_model(2)
+
+
+# --------------------------------------------------------------------------
+# Edit-and-fork
+# --------------------------------------------------------------------------
+
+
+def test_fork_serves_prefix_from_cache_and_only_pays_from_edit(sqlite_backend):
+    """Fork at step 2: step 1 is served from cache; steps 2,3 recompute."""
+    db = sqlite_backend
+    user_id = "u1"
+    # Seed a real agent so the fork can read its system prompt.
+    agent = db.table("agents").insert({
+        "user_id": user_id, "name": "a", "system_prompt": "You are helpful",
+        "workflow_steps": ["do step 1", "do step 2", "do step 3"], "model": "fake-model",
+    }).execute().data[0]
+    agent_id = agent["id"]
+
+    # Record a parent run against that agent.
+    run_id = _seed_run(db, user_id=user_id, agent_id=agent_id)
+    parent_mock, _ = _make_complete_mock()
+    runner = AgentRunner(recorder=RunRecorder(run_id))
+    with patch("app.providers.registry.provider_registry.complete", parent_mock):
+        _run(
+            _drain(runner.execute(_agent_config("You are helpful", 3), "hello", run_id=run_id))
+        )
+    assert parent_mock.await_count == 3
+
+    parent_events = load_events(run_id)
+    parent_step1_output = build_timeline(parent_events)["steps"][0]["model_responses"][0]["content"]
+
+    # Fork from step 2 with no edits — step 1 must be served from cache.
+    fork_mock, _ = _make_complete_mock()
+    with patch("app.providers.registry.provider_registry.complete", fork_mock):
+        result = _run(
+            fork_service.fork(parent_run_id=run_id, user_id=user_id, from_step=2, edits={})
+        )
+
+    # New run id.
+    child_id = result["child_run_id"]
+    assert child_id != run_id
+
+    # Only steps 2 and 3 hit the model; step 1 was served from cache (not re-billed).
+    assert fork_mock.await_count == 2
+    assert result["served_from_cache_steps"] == [1]
+    assert result["recomputed_steps"] == [2, 3]
+
+    # The child's copied prefix preserves step 1's recorded output verbatim.
+    child_events = load_events(child_id)
+    child_step1 = build_timeline(child_events)["steps"][0]
+    assert child_step1["model_responses"][0]["content"] == parent_step1_output
+
+
+def test_fork_with_prompt_edit_changes_downstream_and_recomputes_all(sqlite_backend):
+    """A prompt edit invalidates the whole run; downstream output changes."""
+    db = sqlite_backend
+    user_id = "u1"
+    agent = db.table("agents").insert({
+        "user_id": user_id, "name": "a", "system_prompt": "You are helpful",
+        "workflow_steps": ["do step 1", "do step 2"], "model": "fake-model",
+    }).execute().data[0]
+    agent_id = agent["id"]
+
+    run_id = _seed_run(db, user_id=user_id, agent_id=agent_id)
+    parent_mock, _ = _make_complete_mock()
+    runner = AgentRunner(recorder=RunRecorder(run_id))
+    with patch("app.providers.registry.provider_registry.complete", parent_mock):
+        _run(
+            _drain(runner.execute(_agent_config("You are helpful", 2), "hello", run_id=run_id))
+        )
+
+    # Fork with a prompt edit containing the marker → output flips to [PROMPT].
+    fork_mock, _ = _make_complete_mock()
+    with patch("app.providers.registry.provider_registry.complete", fork_mock):
+        result = _run(
+            fork_service.fork(
+                parent_run_id=run_id, user_id=user_id, from_step=2,
+                edits={"prompt": "PROMPT: be terse"},
+            )
+        )
+
+    # Prompt edit forces recompute from step 1 — all steps re-billed.
+    assert fork_mock.await_count == 2
+    assert result["from_step"] == 1
+    assert result["served_from_cache_steps"] == []
+
+    # Downstream output reflects the new prompt.
+    child_timeline = build_timeline(load_events(result["child_run_id"]))
+    contents = [s["model_responses"][0]["content"] for s in child_timeline["steps"]]
+    assert all("[PROMPT]" in c for c in contents)
+
+
+def test_fork_records_lineage(sqlite_backend):
+    db = sqlite_backend
+    user_id = "u1"
+    agent = db.table("agents").insert({
+        "user_id": user_id, "name": "a", "system_prompt": "You are helpful",
+        "workflow_steps": ["do step 1", "do step 2"], "model": "fake-model",
+    }).execute().data[0]
+    run_id = _seed_run(db, user_id=user_id, agent_id=agent["id"])
+    parent_mock, _ = _make_complete_mock()
+    runner = AgentRunner(recorder=RunRecorder(run_id))
+    with patch("app.providers.registry.provider_registry.complete", parent_mock):
+        _run(
+            _drain(runner.execute(_agent_config("You are helpful", 2), "hello", run_id=run_id))
+        )
+
+    fork_mock, _ = _make_complete_mock()
+    with patch("app.providers.registry.provider_registry.complete", fork_mock):
+        result = _run(
+            fork_service.fork(parent_run_id=run_id, user_id=user_id, from_step=2, edits={})
+        )
+
+    forks = db.table("run_forks").select("*").eq("child_run_id", result["child_run_id"]).execute().data
+    assert len(forks) == 1
+    assert forks[0]["parent_run_id"] == run_id
+    assert forks[0]["from_step"] == 2
+
+
+async def _drain(agen):
+    async for _ in agen:
+        pass
+
+
+# --------------------------------------------------------------------------
+# API routes
+# --------------------------------------------------------------------------
+
+
+def test_events_route_returns_timeline(sqlite_backend, auth_client, mock_user):
+    db = sqlite_backend
+    run_id, _ = _run(_record_run(db, user_id=mock_user.id, steps=2))
+    resp = auth_client.get(f"/api/runs/{run_id}/events")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_id"] == run_id
+    assert len(body["timeline"]["steps"]) == 2
+
+
+def test_events_route_404_for_other_users_run(sqlite_backend, auth_client, mock_user):
+    db = sqlite_backend
+    other_run, _ = _run(_record_run(db, user_id="someone-else", steps=1))
+    resp = auth_client.get(f"/api/runs/{other_run}/events")
+    assert resp.status_code == 404
+
+
+def test_replay_route_no_model_calls(sqlite_backend, auth_client, mock_user):
+    db = sqlite_backend
+    run_id, _ = _run(_record_run(db, user_id=mock_user.id, steps=2))
+    replay_mock = AsyncMock()
+    with patch("app.providers.registry.provider_registry.complete", replay_mock):
+        resp = auth_client.post(f"/api/runs/{run_id}/replay")
+    assert resp.status_code == 200
+    assert replay_mock.await_count == 0
+    assert len(resp.json()["steps"]) == 2

--- a/cli/forge/commands/ops.py
+++ b/cli/forge/commands/ops.py
@@ -311,6 +311,103 @@ def runs_cancel(
         raise typer.Exit(1)
 
 
+# --- Time-travel debugger commands ---
+
+
+@runs_app.command("events")
+def runs_events(
+    run_id: str = typer.Argument(..., help="Run ID"),
+):
+    """Show the append-only event log (timeline) for a run."""
+    try:
+        data = client.get(f"/api/runs/{run_id}/events")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    timeline = data.get("timeline", {})
+    steps = timeline.get("steps", [])
+    if not steps:
+        console.print("[dim]No recorded events for this run.[/dim]")
+        return
+
+    table = Table(title=f"Run {run_id[:8]} — timeline ({timeline.get('total_events', 0)} events)")
+    table.add_column("Step", justify="right", style="bold")
+    table.add_column("Description")
+    table.add_column("Model calls", justify="right")
+    table.add_column("Tool calls", justify="right")
+
+    for s in steps:
+        table.add_row(
+            str(s.get("step")),
+            (s.get("description") or "")[:60],
+            str(len(s.get("model_responses", []))),
+            str(len(s.get("tool_calls", []))),
+        )
+    console.print(table)
+
+
+@runs_app.command("replay")
+def runs_replay(
+    run_id: str = typer.Argument(..., help="Run ID to replay"),
+):
+    """Deterministically replay a run from its log (no model/tool calls)."""
+    try:
+        result = client.post(f"/api/runs/{run_id}/replay")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    console.print(
+        f"[green]Replayed {run_id[:8]}[/green] — "
+        f"{len(result.get('steps', []))} steps, "
+        f"{result.get('total_events', 0)} events, 0 model calls."
+    )
+    output = result.get("replayed_output") or result.get("output") or ""
+    if output:
+        console.print(Panel(str(output)[:2000], title="Replayed output", border_style="cyan"))
+
+
+@runs_app.command("fork")
+def runs_fork(
+    run_id: str = typer.Argument(..., help="Parent run ID"),
+    from_step: int = typer.Option(..., "--from-step", "-s", help="Step to rewind to (1-indexed)"),
+    prompt: str = typer.Option("", "--prompt", "-p", help="Override the system prompt"),
+    user_input: str = typer.Option("", "--input", "-i", help="Override the run input"),
+):
+    """Fork a run at a step with optional edits, re-running forward.
+
+    Steps before the edit are served from the parent's recorded log and are not
+    re-billed; only the edited step and later steps call the model.
+    """
+    edits: dict = {}
+    if prompt:
+        edits["prompt"] = prompt
+    if user_input:
+        edits["user_input"] = user_input
+
+    try:
+        result = client.post(
+            f"/api/runs/{run_id}/fork",
+            json={"from_step": from_step, "edits": edits},
+        )
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    served = result.get("served_from_cache_steps", [])
+    recomputed = result.get("recomputed_steps", [])
+    console.print(
+        f"[green]Forked {run_id[:8]} → {result.get('child_run_id', '')[:8]}[/green] "
+        f"at step {result.get('from_step')}\n"
+        f"[dim]Served from cache (no re-bill): {served or '—'}[/dim]\n"
+        f"[dim]Recomputed: {recomputed or '—'}[/dim]"
+    )
+    output = result.get("output") or ""
+    if output:
+        console.print(Panel(str(output)[:2000], title="Fork output", border_style="green"))
+
+
 messages_app = typer.Typer(help="View inter-agent messages")
 
 

--- a/supabase/migrations/20260610_time_travel_debugger.sql
+++ b/supabase/migrations/20260610_time_travel_debugger.sql
@@ -1,0 +1,50 @@
+-- Time-travel run debugger
+-- Adds an append-only event log for agent runs (run_events) plus a fork lineage
+-- table (run_forks). The event log is the source of truth for deterministic
+-- replay and edit-and-fork: recording captures every model_call / tool_call /
+-- state mutation / step boundary; a fork copies the prefix of these rows up to
+-- step N and serves the recorded responses from a cache so unchanged steps are
+-- never re-billed.
+
+-- 1. Append-only event log
+CREATE TABLE IF NOT EXISTS run_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id UUID NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    seq INTEGER NOT NULL,
+    step INTEGER NOT NULL DEFAULT 0,
+    event_type TEXT NOT NULL
+        CHECK (event_type IN ('run_start', 'step_boundary', 'model_call', 'tool_call', 'state', 'run_end')),
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (run_id, seq)
+);
+
+ALTER TABLE run_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view run events for their own runs"
+    ON run_events FOR ALL
+    USING (run_id IN (SELECT id FROM runs WHERE user_id = auth.uid()))
+    WITH CHECK (run_id IN (SELECT id FROM runs WHERE user_id = auth.uid()));
+
+CREATE INDEX IF NOT EXISTS idx_run_events_run_seq ON run_events(run_id, seq);
+CREATE INDEX IF NOT EXISTS idx_run_events_run_step ON run_events(run_id, step);
+
+-- 2. Fork lineage
+CREATE TABLE IF NOT EXISTS run_forks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    parent_run_id UUID NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    child_run_id UUID NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    from_step INTEGER NOT NULL,
+    edits JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE run_forks ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can manage their own run forks"
+    ON run_forks FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_run_forks_parent ON run_forks(parent_run_id);
+CREATE INDEX IF NOT EXISTS idx_run_forks_child ON run_forks(child_run_id);
+CREATE INDEX IF NOT EXISTS idx_run_forks_user ON run_forks(user_id);


### PR DESCRIPTION
## Time-travel run debugger

Records every agent run as an **append-only event log** and adds three capabilities on top of it: deterministic **replay**, step-through inspection, and the killer feature — **edit-and-fork** (rewind to step N, change a prompt or a tool/step result, re-run forward while serving the unchanged prefix from cache so those steps are never re-billed).

### How it works
- **Recording** — a thin `RunRecorder` is attached to `AgentRunner`. The executor's model/tool call sites are routed through a single `_invoke_model` interception point; the step loop emits `step_boundary` and `state` events. Every `model_call` (request+response), `tool_call` (args+result), `state` mutation, and step boundary is appended to `run_events` via the existing dual SQLite/Supabase backend. Defaults to a `NullRecorder`, so the normal run path is unchanged when the debugger isn't in use.
- **Replay** — `replay_with_executor` re-drives the executor with a *strict* `ResponseCache` built from the log. Every model/tool call is served from the log; a miss raises `CacheMiss`. The model is provably never invoked.
- **Edit-and-fork** — `ForkService` copies the parent's event-log prefix (steps `< cut_step`) into a new child run, builds a `ResponseCache` from that same prefix and restricts it to the unchanged steps. On re-run, those steps hit the cache (no provider call); the edited step and everything after it miss and make real calls. A prompt/input edit invalidates the whole run; a per-step `tool_result`/`step_result` edit pushes the cut-over to that step.

### Step-keyed cache
Responses are keyed by `(kind, step, ordinal)` — `ordinal` disambiguates multiple calls of one kind within a step. `restrict_to_steps()` is how a fork invalidates the edited step and everything downstream while still serving the prefix.

### API
- `GET /api/runs/{id}/events` — the event log + reconstructed timeline
- `POST /api/runs/{id}/replay` — deterministic replay (zero model calls)
- `POST /api/runs/{id}/fork` — `{from_step, edits}`, rate-limited 20/hour
All behind the standard auth dependency with per-run ownership checks.

### CLI
`forge ops runs events|replay|fork` (typer).

### Tests
`backend/tests/test_time_travel.py` (10 tests, real in-memory SQLite, model mocked at `provider_registry.complete`): faithful append-only log; replay reconstructs identical state/output with the provider asserted never-called; fork serves the prefix from cache (model called only from the edited step) and produces a new run id; a prompt edit changes downstream output and forces full recompute; lineage recorded; route coverage incl. 404 for another user's run.

### Verification
- `ruff check app/ --config ../ruff.toml` — pass
- `mypy app/ --config-file mypy.ini` — pass (144 files)
- `FORGE_TESTING=1 pytest tests/ -q` — 729 passed, 5 skipped (pre-existing)