### PR TITLE
fix(deps): resolve remaining Dependabot alerts (langchain 1.x migration)

### DIFF
--- a/backend/app/services/agent_executor.py
+++ b/backend/app/services/agent_executor.py
@@ -4,8 +4,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from dotenv import load_dotenv
-from langchain.agents import AgentExecutor, create_openai_tools_agent
-from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.agents import create_agent
 
 from app.mcp.tool_registry import tool_registry
 from app.providers.registry import provider_registry
@@ -300,23 +299,28 @@ class AgentRunner:
             # No OpenAI key — fall back to non-tool step via provider registry
             return await self._execute_step(system_prompt, step, user_input, context, model=self.model)
 
-        prompt = ChatPromptTemplate.from_messages([
-            ("system", f"{system_prompt}\n\nCurrent task: {step}"),
-            ("human", "{input}"),
-            MessagesPlaceholder("agent_scratchpad"),
-        ])
-
-        agent = create_openai_tools_agent(llm, tools, prompt)
-        executor = AgentExecutor(agent=agent, tools=tools, verbose=False, max_iterations=5)
+        # langchain>=1.0: the legacy AgentExecutor/create_openai_tools_agent
+        # combo was removed in favour of the prebuilt ``create_agent`` graph,
+        # which runs the model<->tool loop internally. It takes a messages-style
+        # input and returns ``{"messages": [...]}`` with the final answer in the
+        # last AIMessage's ``content`` (vs. the old ``{"output": ...}``).
+        agent = create_agent(
+            model=llm,
+            tools=tools,
+            system_prompt=f"{system_prompt}\n\nCurrent task: {step}",
+        )
 
         full_input = user_input
         if context:
             full_input = f"{user_input}\n\nPrevious step results:\n{context}"
 
-        result = await executor.ainvoke({"input": full_input})
+        result = await agent.ainvoke({"messages": [{"role": "user", "content": full_input}]})
+
+        messages = result.get("messages", []) if isinstance(result, dict) else []
+        content = messages[-1].content if messages else ""
 
         out = {
-            "content": result.get("output", ""),
+            "content": content,
             "tokens": 0,
         }
         # Record the tool-augmented step's outcome as a model_call so replay and

--- a/backend/app/services/knowledge/chunker.py
+++ b/backend/app/services/knowledge/chunker.py
@@ -18,4 +18,5 @@ def chunk_text(
         length_function=len,
         separators=["\n\n", "\n", ". ", " ", ""],
     )
-    return splitter.split_text(text)
+    chunks: list[str] = splitter.split_text(text)
+    return chunks

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,13 +1,15 @@
 fastapi==0.115.6
 uvicorn[standard]==0.34.0
-langchain==0.3.30
-langchain-openai==0.3.0
-openai==1.58.1
+langchain==1.3.9
+langchain-openai==1.3.2
+# Split out of the langchain meta-package in 1.x; must be declared explicitly.
+langchain-text-splitters==1.1.2
+openai==2.26.0
 python-dotenv==1.2.2
-python-multipart==0.0.27
+python-multipart==0.0.31
 pydantic==2.10.4
 httpx==0.28.1
-pypdf==6.12.0
+pypdf==6.13.0
 python-docx==1.1.2
 slowapi==0.1.9
 anthropic==0.52.0


### PR DESCRIPTION
## Summary

Resolves the second wave of Dependabot security alerts (#53–#62) that were published against the very versions patched in #116 — newly disclosed CVEs requiring higher patch versions, plus the langchain 1.x major bump.

## Alerts resolved (10)

| Package | From | To | Alerts | Severity |
|---|---|---|---|---|
| `langchain` | 0.3.30 | 1.3.9 | #62 | high |
| `pypdf` | 6.12.0 | 6.13.0 | #57, #58, #59, #60, #61 | medium |
| `python-multipart` | 0.0.27 | 0.0.31 | #53, #54, #55, #56 | high |

## Major migration: langchain 0.3 -> 1.x

langchain 1.0 removed the legacy agents framework. Changes made:

- **`langchain.agents`**: `AgentExecutor` + `create_openai_tools_agent` removed -> rewrote `AgentRunner._execute_with_tools` to use the prebuilt **`create_agent`** graph. New I/O contract: `ainvoke({"messages": [...]})` -> `{"messages": [...]}`, final answer in the last `AIMessage.content` (was `{"output": ...}`).
- **`langchain.prompts`** removed -> the `ChatPromptTemplate`/`MessagesPlaceholder` scaffolding is no longer needed (system prompt passed straight to `create_agent`).
- **Dependency cascade**: `langchain-openai` 0.3.0 -> 1.3.2 (requires `openai>=2.26`), so `openai` 1.58.1 -> 2.26.0. Direct `openai` usage is via `AsyncOpenAI` chat completions, unaffected by the 2.x bump.
- **`langchain-text-splitters`** is no longer a transitive dep of the langchain meta-package in 1.x -> declared explicitly (==1.1.2) to keep `knowledge/chunker.py` importable.
- `langchain.tools.tool` decorator (5 tool files) is unchanged in 1.x.

## Verification (local, matching .github/workflows/ci.yml backend job)

- `ruff check app/` — clean
- `mypy app/` — clean (144 files)
- `pytest tests/` — **711 passed, 23 skipped, 0 failed**
- Runtime import sanity check of agent_executor / chunker / all tools / llm — OK

Closes Dependabot alerts #53, #54, #55, #56, #57, #58, #59, #60, #61, #62.