### PR TITLE
Weekly security fixes (20260620)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ python-dotenv==1.2.2
 python-multipart==0.0.31
 pydantic==2.10.4
 httpx==0.28.1
-pypdf==6.13.0
+pypdf==6.13.3
 python-docx==1.1.2
 slowapi==0.1.9
 anthropic==0.52.0


### PR DESCRIPTION
## Summary

Resolves the open security alert tracked for this week.

### Fixed

- **Dependabot (medium): `pypdf` — missing stream length values ignore defined limits.** Bumped `pypdf` from `6.13.0` to `6.13.3` (first patched version) in `backend/requirements.txt`. This is a patch-level bump with no breaking API changes; the only usage in the codebase is `PdfReader(io.BytesIO(...))` in `backend/app/services/extract.py`, which is unchanged across these versions.

### Verification

- The repo has no lockfile for the backend (pip + pinned `requirements.txt`), so only `requirements.txt` required updating.
- No backend virtualenv is provisioned in this environment, so the full `pytest` suite could not be run. Instead, `pypdf==6.13.3` was installed into a clean venv and the exact `PdfReader` API used by `extract.py` was exercised against a sample PDF — import and page parsing succeed.

### Skipped

- Nothing skipped.

### Needs manual rotation

- No secrets involved.

### Code scanning / Secret scanning

- No open alerts.