### PR TITLE
fix(timetravel): record + replay attachments (fork divergence)

### DIFF
--- a/backend/app/services/agent_executor.py
+++ b/backend/app/services/agent_executor.py
@@ -136,7 +136,9 @@ class AgentRunner:
 
         # Open the run's event log (no-op when no recorder is attached).
         self._current_step = 0
-        self.recorder.run_start(agent_id=agent_id, user_input=user_input, model=model)
+        self.recorder.run_start(
+            agent_id=agent_id, user_input=user_input, model=model, attachments=attachments
+        )
 
         yield {"type": "step", "content": f"Starting agent: {agent_config.get('name', 'Unnamed')}", "tokens": 0}
         for note in notes:

--- a/backend/app/services/timetravel/fork.py
+++ b/backend/app/services/timetravel/fork.py
@@ -74,6 +74,7 @@ class ForkService:
         recon = reconstruct_agent_config(events)
         agent_config = recon["agent_config"]
         user_input = recon["user_input"]
+        attachments = recon.get("attachments") or None
 
         # Pull the parent agent's real config (system prompt + tools) — the event
         # log records workflow/model but the system prompt lives on the agent.
@@ -158,7 +159,9 @@ class ForkService:
         total_tokens = 0
         recomputed_steps: list[int] = []
         try:
-            async for event in runner.execute(agent_config, user_input, run_id=child_run_id, user_id=user_id):
+            async for event in runner.execute(
+                agent_config, user_input, run_id=child_run_id, user_id=user_id, attachments=attachments
+            ):
                 if event.get("type") == "token":
                     final_output += event.get("content", "")
                 total_tokens += event.get("tokens", 0)

--- a/backend/app/services/timetravel/recorder.py
+++ b/backend/app/services/timetravel/recorder.py
@@ -65,11 +65,22 @@ class RunRecorder:
             logger.warning("Failed to record run event %s for run %s", event_type, self.run_id, exc_info=True)
         return row
 
-    def run_start(self, *, agent_id: str | None, user_input: str, model: str | None) -> None:
+    def run_start(
+        self,
+        *,
+        agent_id: str | None,
+        user_input: str,
+        model: str | None,
+        attachments: list[dict[str, Any]] | None = None,
+    ) -> None:
+        # Record attachment refs (small url/kind/name dicts, not content) so a
+        # fork/replay can reattach them — otherwise recomputed steps diverge from
+        # the original, which had the document/image context.
         self._append(EVENT_RUN_START, 0, {
             "agent_id": agent_id,
             "user_input": user_input,
             "model": model,
+            "attachments": attachments or [],
         })
 
     def step_boundary(self, step: int, description: str) -> None:

--- a/backend/app/services/timetravel/replayer.py
+++ b/backend/app/services/timetravel/replayer.py
@@ -113,6 +113,7 @@ def reconstruct_agent_config(events: list[dict[str, Any]]) -> dict[str, Any]:
     """
     user_input = ""
     model: str | None = None
+    attachments: list[dict[str, Any]] = []
     workflow: list[tuple[int, str]] = []
     for ev in events:
         etype = ev.get("event_type")
@@ -120,6 +121,7 @@ def reconstruct_agent_config(events: list[dict[str, Any]]) -> dict[str, Any]:
         if etype == "run_start":
             user_input = payload.get("user_input", "")
             model = payload.get("model")
+            attachments = payload.get("attachments") or []
         elif etype == EVENT_STEP_BOUNDARY:
             workflow.append((int(ev.get("step", 0) or 0), payload.get("description", "")))
     workflow.sort(key=lambda t: t[0])
@@ -130,6 +132,7 @@ def reconstruct_agent_config(events: list[dict[str, Any]]) -> dict[str, Any]:
             "workflow_steps": [d for _s, d in workflow],
             "model": model,
         },
+        "attachments": attachments,
         "user_input": user_input,
     }
 

--- a/backend/tests/test_time_travel.py
+++ b/backend/tests/test_time_travel.py
@@ -370,3 +370,19 @@ def test_replay_route_no_model_calls(sqlite_backend, auth_client, mock_user):
     assert resp.status_code == 200
     assert replay_mock.await_count == 0
     assert len(resp.json()["steps"]) == 2
+
+
+def test_reconstruct_carries_attachments():
+    """run_start attachments must survive into the reconstructed config so a fork
+    reattaches them (else recomputed steps diverge from the original)."""
+    from app.services.timetravel.replayer import reconstruct_agent_config
+
+    atts = [{"kind": "document", "name": "spec.pdf", "url": "https://x/spec.pdf"}]
+    events = [
+        {"event_type": "run_start", "step": 0,
+         "payload": {"agent_id": "a1", "user_input": "hi", "model": "gpt-4o", "attachments": atts}},
+        {"event_type": "step_boundary", "step": 1, "payload": {"description": "do it"}},
+    ]
+    recon = reconstruct_agent_config(events)
+    assert recon["attachments"] == atts
+    assert recon["user_input"] == "hi"


### PR DESCRIPTION
## Dedicated PR 2 — deferred from the audit remediation (#128)

Closes the high-severity time-travel finding #17.

### Problem
Attachments were never captured in the run event log. `reconstruct_agent_config` and `ForkService.fork` rebuilt the run without them, so **forking or replaying a run that used document/image attachments dropped the context** and recomputed steps diverged from the original.

### Change
- `recorder.run_start` records attachment refs (small `url`/`kind`/`name` dicts — not content).
- `reconstruct_agent_config` extracts them; `ForkService.fork` passes `attachments=` to the executor.
- Round-trip regression test.

### Scope note
Two sibling findings were intentionally left for a separate change because they carry real regression risk on a determinism-sensitive feature:
- **#22** (served-from-cache reporting when a prefix recording is missing) — needs `ResponseCache` internals work.
- **#21** (the executor doesn't record individual tool-call events, so the `tool_result` fork edit has nothing to override) — removing the dead path risks the fork API; wiring up per-tool recording with langgraph is a feature.

### Verification
734 backend tests pass (incl. new test); ruff + mypy clean.

Stacked on `fix/audit-hardening` (#128).