### PR TITLE
fix(targets): scope execution-target registry by user (cross-tenant leak)

### DIFF
--- a/backend/app/routers/targets.py
+++ b/backend/app/routers/targets.py
@@ -27,14 +27,14 @@ class TargetUpdate(BaseModel):
 
 
 @router.get("")
-async def list_targets(user: dict = Depends(get_current_user)):  # noqa: B008
-    """List all registered execution targets."""
-    return dispatch_service.list_targets()
+async def list_targets(user=Depends(get_current_user)):  # noqa: B008
+    """List the caller's execution targets (plus the shared local target)."""
+    return dispatch_service.list_targets(user.id)
 
 
 @router.post("")
-async def create_target(body: TargetCreate, user: dict = Depends(get_current_user)):  # noqa: B008
-    """Register a new execution target."""
+async def create_target(body: TargetCreate, user=Depends(get_current_user)):  # noqa: B008
+    """Register a new execution target owned by the caller."""
     import uuid
     target_id = str(uuid.uuid4())
     target = dispatch_service.register_target(
@@ -44,23 +44,24 @@ async def create_target(body: TargetCreate, user: dict = Depends(get_current_use
         listen_url=body.listen_url,
         api_key=body.api_key,
         platform=body.platform,
+        user_id=user.id,
     )
     return {"id": target.id, "name": target.name, "status": target.status}
 
 
 @router.delete("/{target_id}")
-async def remove_target(target_id: str, user: dict = Depends(get_current_user)):  # noqa: B008
-    """Remove an execution target."""
-    removed = dispatch_service.remove_target(target_id)
+async def remove_target(target_id: str, user=Depends(get_current_user)):  # noqa: B008
+    """Remove an execution target the caller owns."""
+    removed = dispatch_service.remove_target(target_id, user.id)
     if not removed:
         return {"error": "Target not found or cannot be removed", "removed": False}
     return {"removed": True}
 
 
 @router.post("/{target_id}/health")
-async def health_check_target(target_id: str, user: dict = Depends(get_current_user)):  # noqa: B008
-    """Run a health check on a specific target."""
-    return await dispatch_service.health_check(target_id)
+async def health_check_target(target_id: str, user=Depends(get_current_user)):  # noqa: B008
+    """Run a health check on a target the caller can see."""
+    return await dispatch_service.health_check(target_id, user.id)
 
 
 @router.get("/capabilities")

--- a/backend/app/services/computer_use/dispatch.py
+++ b/backend/app/services/computer_use/dispatch.py
@@ -24,6 +24,11 @@ class ExecutionTarget:
     capabilities: dict[str, Any] = field(default_factory=dict)
     status: str = "unknown"  # "healthy", "unhealthy", "unknown"
     last_health_check: str = ""
+    user_id: str = ""  # owner; "" == shared (the built-in local target)
+
+    def _visible_to(self, user_id: str) -> bool:
+        """A target is visible to its owner, or to anyone if it's shared (local)."""
+        return self.user_id == "" or self.user_id == user_id
 
 
 class DispatchService:
@@ -47,8 +52,9 @@ class DispatchService:
         listen_url: str = "",
         api_key: str = "",
         platform: str = "macos",
+        user_id: str = "",
     ) -> ExecutionTarget:
-        """Register a new execution target."""
+        """Register a new execution target owned by ``user_id``."""
         target = ExecutionTarget(
             id=target_id,
             name=name,
@@ -56,18 +62,22 @@ class DispatchService:
             listen_url=listen_url,
             api_key=api_key,
             platform=platform,
+            user_id=user_id,
         )
         self._targets[target_id] = target
         return target
 
-    def remove_target(self, target_id: str) -> bool:
-        """Remove an execution target."""
+    def remove_target(self, target_id: str, user_id: str = "") -> bool:
+        """Remove an execution target the caller owns."""
         if target_id == "local":
-            return False  # Can't remove local
+            return False  # Can't remove the shared local target
+        target = self._targets.get(target_id)
+        if not target or not target._visible_to(user_id):
+            return False
         return self._targets.pop(target_id, None) is not None
 
-    def list_targets(self) -> list[dict[str, Any]]:
-        """List all targets with current status."""
+    def list_targets(self, user_id: str = "") -> list[dict[str, Any]]:
+        """List the caller's targets (plus the shared local target)."""
         return [
             {
                 "id": t.id,
@@ -80,16 +90,17 @@ class DispatchService:
                 "last_health_check": t.last_health_check,
             }
             for t in self._targets.values()
+            if t._visible_to(user_id)
         ]
 
     def get_target(self, target_id: str) -> ExecutionTarget | None:
         """Get a specific target."""
         return self._targets.get(target_id)
 
-    async def health_check(self, target_id: str) -> dict[str, Any]:
-        """Run a health check on a target."""
+    async def health_check(self, target_id: str, user_id: str = "") -> dict[str, Any]:
+        """Run a health check on a target the caller can see."""
         target = self._targets.get(target_id)
-        if not target:
+        if not target or not target._visible_to(user_id):
             return {"error": f"Unknown target: {target_id}"}
 
         if target.target_type == "local":

--- a/backend/tests/test_computer_use.py
+++ b/backend/tests/test_computer_use.py
@@ -598,6 +598,22 @@ def test_dispatch_register_target():
     assert service.remove_target("local") is False  # Can't remove local
 
 
+def test_dispatch_targets_are_user_scoped():
+    """A user can't see, remove, or health-check another user's target (#19)."""
+    from app.services.computer_use.dispatch import DispatchService
+
+    service = DispatchService()
+    service.register_target(target_id="t-a", name="A's box", user_id="user-a")
+
+    ids_b = {t["id"] for t in service.list_targets("user-b")}
+    assert "t-a" not in ids_b and "local" in ids_b  # only the shared local target
+    ids_a = {t["id"] for t in service.list_targets("user-a")}
+    assert "t-a" in ids_a
+
+    assert service.remove_target("t-a", "user-b") is False  # not yours
+    assert service.remove_target("t-a", "user-a") is True   # owner can
+
+
 def test_dispatch_resolve_fallback():
     """Dispatch resolves to local target by default."""
     from app.services.computer_use.dispatch import DispatchService


### PR DESCRIPTION
## Dedicated PR 3 — deferred from the audit remediation (#128)

Closes the cross-tenant finding #19 (security core).

### Problem
The `/targets` endpoints delegated to a process-wide `DispatchService` with **no user scoping**: `GET /targets` returned *every* user's execution targets (including their `listen_url`), and `DELETE` / health-check could touch anyone's.

### Change
- Tag each `ExecutionTarget` with an owner `user_id`; `list_targets` / `remove_target` / `health_check` filter to the caller via `_visible_to()` (the built-in **local** target stays shared).
- Router passes `user.id` through. Cross-tenant scoping test added.

### Scope note
This closes the **security** half of #19 (cross-tenant visibility/control). The registry is still process-in-memory (targets are lost on restart) — persisting it to the `execution_targets` table is a separate reliability change, not a leak.

### Verification
734 backend tests pass (incl. new test); ruff + mypy clean.

Stacked on `fix/audit-hardening` (#128).