### PR TITLE
fix(timetravel): accurate served-from-cache reporting (#22)

### DIFF
--- a/backend/app/services/timetravel/fork.py
+++ b/backend/app/services/timetravel/fork.py
@@ -142,7 +142,15 @@ class ForkService:
         # from there — the override seeds the served prefix.)
         self._apply_result_overrides(cache, edits)
 
-        served_steps = sorted(range(1, cut_step))
+        # Report the steps ACTUALLY served from cache, not the whole prefix range.
+        # A prefix step whose model_call event was lost (recorder swallows insert
+        # failures) isn't in the cache → it gets recomputed and re-billed, so it
+        # must not be reported as served (the old range(1, cut_step) silently
+        # over-reported cache hits / under-reported re-billing).
+        served_steps = sorted({
+            step for (kind, step, _ordinal) in cache._responses
+            if kind == "model" and step < cut_step
+        })
 
         # --- Resume the executor forward ----------------------------------
         from app.services.agent_executor import AgentRunner

--- a/backend/tests/test_time_travel.py
+++ b/backend/tests/test_time_travel.py
@@ -268,6 +268,27 @@ def test_fork_serves_prefix_from_cache_and_only_pays_from_edit(sqlite_backend):
     assert child_step1["model_responses"][0]["content"] == parent_step1_output
 
 
+def test_fork_excludes_lost_prefix_recording_from_served_steps(sqlite_backend):
+    """A prefix step whose recording was lost is recomputed, not reported as
+    served (the old code reported the whole prefix range unconditionally)."""
+    db = sqlite_backend
+    run_id, _ = _run(_record_run(db, user_id="u1", steps=3))
+    # Simulate a lost recording: drop step 1's model_call event.
+    db.table("run_events").delete().eq("run_id", run_id).eq(
+        "event_type", "model_call"
+    ).eq("step", 1).execute()
+
+    fork_mock, _ = _make_complete_mock()
+    with patch("app.providers.registry.provider_registry.complete", fork_mock):
+        result = _run(
+            fork_service.fork(parent_run_id=run_id, user_id="u1", from_step=3, edits={})
+        )
+
+    # Step 1's recording is gone → not served from cache; step 2 still is.
+    assert 1 not in result["served_from_cache_steps"]
+    assert 2 in result["served_from_cache_steps"]
+
+
 def test_fork_with_prompt_edit_changes_downstream_and_recomputes_all(sqlite_backend):
     """A prompt edit invalidates the whole run; downstream output changes."""
     db = sqlite_backend


### PR DESCRIPTION
## Dedicated PR 5 — remaining tail from the audit

Closes #22.

### Problem
`ForkService` reported `served_from_cache_steps` as the **whole prefix range** (`range(1, cut_step)`) regardless of what was actually cached. A prefix step whose `model_call` event was lost (the recorder swallows insert failures by design) isn't in the cache, so the executor recomputes and **re-bills** it — yet it was still reported as served. The billing/usage report under-counted real spend.

### Change
Compute `served_steps` from the cache's actual contents (steps with a recorded model response) rather than the nominal range. Regression test drops a prefix `model_call` and asserts that step is no longer reported as served.

### Verification
712 backend tests pass (incl. new test); ruff clean.

Targets `main` (touches `fork.py`, which #130 also edits — trivial merge resolution if both land).

---
### Remaining audit tail — intentionally NOT changed (reasons)
- **#21** (executor records no per-tool-call events, so `tool_result` fork edits are inert): removing the dead path risks replay/timeline; wiring per-tool recording into the langgraph agent is a feature, not a fix.
- **`search_multi` re-embed**: defensible — collections can use different embedding models, so one shared embedding would be wrong.
- **`auth-client` null-vs-error**, **CU config "frozen at import"**: near-zero practical value (env is set before import; distinguishing would churn many call sites).
- **blueprint final-result-from-sink / deterministic-node retry**: both change execution/output semantics for existing blueprints (retrying side-effectful nodes risks double-sends).