### PR TITLE
fix(timetravel): record individual tool-call events (#21)

### DIFF
--- a/backend/app/services/agent_executor.py
+++ b/backend/app/services/agent_executor.py
@@ -319,6 +319,16 @@ class AgentRunner:
         messages = result.get("messages", []) if isinstance(result, dict) else []
         content = messages[-1].content if messages else ""
 
+        # Record each individual tool invocation so the run event log / timeline
+        # captures the model<->tool loop ``create_agent`` runs internally. This
+        # is purely additive: an AIMessage carries ``.tool_calls`` (name/args/id)
+        # and the matching ToolMessage carries the result via ``.tool_call_id``.
+        # Wrapped so a recording failure never breaks the run.
+        try:
+            self._record_tool_calls(messages)
+        except Exception:
+            logger.warning("Failed to record tool calls", exc_info=True)
+
         out = {
             "content": content,
             "tokens": 0,
@@ -331,6 +341,51 @@ class AgentRunner:
             response=out,
         )
         return out
+
+    @staticmethod
+    def _field(obj: Any, name: str, default: Any = None) -> Any:
+        """Read ``name`` from a langchain message object OR a plain dict."""
+        if isinstance(obj, dict):
+            return obj.get(name, default)
+        return getattr(obj, name, default)
+
+    def _record_tool_calls(self, messages: list) -> None:
+        """Record each tool invocation found in ``create_agent``'s messages.
+
+        Walks the returned messages: an AIMessage's ``.tool_calls`` lists the
+        invocations (each with ``name``/``args``/``id``) and the matching
+        ToolMessage carries the result via ``.tool_call_id``. Messages may be
+        langchain objects or dicts, so every field read goes through
+        :meth:`_field`. Best-effort — skips anything malformed and no-ops when
+        there are no tool calls.
+        """
+        if not messages:
+            return
+
+        # Index tool results by the call id they answer (ToolMessage carries
+        # ``tool_call_id`` + ``content``). Some messages expose this only via
+        # a ``type`` discriminator, so we key off whatever has a tool_call_id.
+        results_by_id: dict[str, Any] = {}
+        for msg in messages:
+            call_id = self._field(msg, "tool_call_id")
+            if call_id is not None:
+                results_by_id[str(call_id)] = self._field(msg, "content")
+
+        for msg in messages:
+            tool_calls = self._field(msg, "tool_calls") or []
+            for call in tool_calls:
+                try:
+                    name = self._field(call, "name")
+                    args = self._field(call, "args", {}) or {}
+                    call_id = self._field(call, "id")
+                    result = results_by_id.get(str(call_id)) if call_id is not None else None
+                    if name is None:
+                        continue
+                    self.recorder.tool_call(
+                        self._current_step, name=name, args=args, result=result
+                    )
+                except Exception:
+                    logger.warning("Failed to record a tool call", exc_info=True)
 
     async def _execute_step(
         self,


### PR DESCRIPTION
## Audit tail

Closes #21 (the recording half). The agent executor recorded each tool-using step as a single `model_call` but never recorded the individual tool invocations, so the run event log / timeline was incomplete and the tool-call cache path was dead.

**Change (additive, low-risk):** `_execute_with_tools` now extracts tool calls from `create_agent`'s returned messages (AIMessage `.tool_calls` matched to ToolMessage results by `tool_call_id`) and records each via `recorder.tool_call`. Works for both langchain message objects and dicts; fully wrapped in try/except so a recording failure never breaks a run; no-op when there are no tool calls. Replay/serve and `model_call` recording paths untouched.

Verified: 22 tests (time_travel/recordings/agent_executor/tools) pass; ruff+mypy clean; `build_timeline` consumes the new events.

> Note: full tool-LEVEL fork-edit replay (serving an edited tool result) remains a larger feature — this PR makes the recording live (timeline complete).