### PR TITLE
fix(blueprint): result from DAG sink + retry deterministic nodes

### DIFF
--- a/backend/app/services/blueprint_engine.py
+++ b/backend/app/services/blueprint_engine.py
@@ -157,7 +157,24 @@ class BlueprintEngine:
                     if not executor:
                         raise ValueError(f"No executor for deterministic node: {node_type_key}")
 
-                    output = await executor(node_config, upstream)
+                    # Execute with retry (same policy as agent nodes)
+                    last_error = None
+                    for attempt in range(max_retries + 1):
+                        try:
+                            output = await executor(node_config, upstream)
+                            last_error = None
+                            break
+                        except Exception as e:
+                            last_error = e
+                            if attempt < max_retries:
+                                logger.warning(
+                                    "Deterministic node %s attempt %d failed: %s",
+                                    node_id, attempt + 1, e,
+                                )
+                                continue
+
+                    if last_error:
+                        raise last_error
 
                 elif node_type.node_class == "agent":
                     executor = _ALL_AGENT.get(node_type_key)
@@ -255,8 +272,18 @@ class BlueprintEngine:
 
             yield {"type": "layer_done", "data": {"layer": layer_idx}}
 
-        # Get final output from the last node
-        last_node_id = nodes[-1]["id"]
+        # Get final output from the topological sink (last node of the last
+        # non-empty executed layer), not the authored array order.
+        sink_node_idx: int | None = None
+        for layer in reversed(layers):
+            if layer:
+                sink_node_idx = layer[-1]
+                break
+        if sink_node_idx is not None:
+            last_node_id = nodes[sink_node_idx]["id"]
+        else:
+            # Fallback (should not happen given non-empty nodes): array order.
+            last_node_id = nodes[-1]["id"]
         final_output = node_outputs.get(last_node_id, {})
 
         # Format final result

--- a/backend/tests/test_blueprints.py
+++ b/backend/tests/test_blueprints.py
@@ -336,3 +336,35 @@ def test_delete_blueprint_not_owner(auth_client):
 def test_blueprints_require_auth(client):
     response = client.get("/api/blueprints")
     assert response.status_code == 422
+
+
+def test_engine_result_comes_from_topological_sink():
+    """execute() returns the DAG SINK's output, not the authored array order.
+
+    Nodes are authored [b, a] where a -> b, so nodes[-1] is the source `a` while
+    the sink (no dependents) is `b`. The run result must reflect `b`.
+    """
+    import asyncio
+
+    from app.services.blueprint_engine import blueprint_engine
+
+    blueprint = {
+        "nodes": [
+            {"id": "b", "type": "template_renderer", "config": {"template": "SINK"}, "dependencies": ["a"]},
+            {"id": "a", "type": "template_renderer", "config": {"template": "SOURCE"}, "dependencies": []},
+        ],
+    }
+
+    async def run():
+        events = []
+        with patch("app.db._db", MagicMock()):
+            async for ev in blueprint_engine.execute(
+                blueprint=blueprint, input_payload={"text": ""}, user_id="u1", run_id="r1"
+            ):
+                events.append(ev)
+        return events
+
+    events = asyncio.run(run())
+    result = next(e for e in events if e.get("type") == "result")
+    assert "SINK" in result["data"]
+    assert "SOURCE" not in result["data"]


### PR DESCRIPTION
## Audit tail — two blueprint-engine correctness fixes

1. **Final result from the topological sink**, not authored array order — the engine took `nodes[-1]` (the last *authored* node) as the result; now it uses the last node of the last executed layer (a true sink). Added an `execute()`-level test (authored order [sink, source]) that locks this in — there was previously **no coverage** of the final-result path.
2. **Retry for deterministic nodes** — the `retry_policy.max_retries` loop wrapped only agent nodes; deterministic nodes ran once. Now both classes retry consistently.

Verified: 47 tests (blueprints + integration) pass; ruff+mypy clean.

> Semantic note: (1) changes the returned result for DAGs whose authored-last node isn't the sink (intended). (2) retries deterministic nodes on *failure* only — a transient webhook failure could re-POST, which is the receiver's idempotency concern (matches the documented retry_policy).