### PR TITLE
chore(deps): upgrade backend Python deps group (supersedes #139)

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-pytest==9.0.3
-pytest-asyncio==1.3.0
-pytest-cov==7.0.0
-ruff==0.8.6
+pytest==9.1.1
+pytest-asyncio==1.4.0
+pytest-cov==7.1.0
+ruff==0.15.20
 mypy==1.14.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,19 +1,19 @@
-fastapi==0.115.6
-uvicorn[standard]==0.34.0
-langchain==1.3.9
-langchain-openai==1.3.2
+fastapi==0.138.2
+uvicorn[standard]==0.49.0
+langchain==1.3.11
+langchain-openai==1.3.3
 # Split out of the langchain meta-package in 1.x; must be declared explicitly.
 langchain-text-splitters==1.1.2
-openai==2.26.0
+openai==2.44.0
 python-dotenv==1.2.2
-python-multipart==0.0.31
-pydantic==2.10.4
+python-multipart==0.0.32
+pydantic==2.13.4
 httpx==0.28.1
-pypdf==6.13.3
-python-docx==1.1.2
-slowapi==0.1.9
-anthropic==0.52.0
-tiktoken==0.9.0
+pypdf==6.14.2
+python-docx==1.2.0
+slowapi==0.1.10
+anthropic==0.115.0
+tiktoken==0.13.0
 croniter==5.0.1
 # Database backends (SQLite is default, Supabase is optional)
 aiosqlite>=0.20.0
@@ -24,4 +24,4 @@ cryptography>=42.0.0
 # Workspace file watching
 watchdog>=6.0.0
 # Optional: Supabase backend (install with: pip install supabase)
-supabase==2.11.0
+supabase==2.31.0

--- a/backend/tests/route_utils.py
+++ b/backend/tests/route_utils.py
@@ -1,0 +1,41 @@
+"""Helpers for enumerating an app's routes across FastAPI versions.
+
+FastAPI 0.138 changed ``include_router`` to register lazy ``_IncludedRouter``
+wrapper objects on ``app.routes`` instead of eagerly flattening every included
+route into the top-level list. Those wrappers do not expose ``.path``; the real
+sub-routes live under ``original_router.routes`` with the include ``prefix``
+applied separately. These helpers walk that structure so tests can keep
+asserting on the full set of registered paths regardless of FastAPI version.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+
+def iter_app_routes(app: Any) -> Iterator[tuple[str, Any]]:
+    """Yield ``(full_path, route)`` for every leaf route registered on ``app``.
+
+    Traverses FastAPI 0.138+ ``_IncludedRouter`` wrappers recursively, prepending
+    each include prefix so the yielded path matches the externally served URL.
+    """
+
+    def _walk(routes: list[Any], prefix: str) -> Iterator[tuple[str, Any]]:
+        for route in routes:
+            original = getattr(route, "original_router", None)
+            if original is not None:
+                sub_prefix = (
+                    getattr(getattr(route, "include_context", None), "prefix", "")
+                    or ""
+                )
+                yield from _walk(original.routes, prefix + sub_prefix)
+            elif hasattr(route, "path"):
+                yield prefix + route.path, route
+
+    yield from _walk(app.routes, "")
+
+
+def app_route_paths(app: Any) -> list[str]:
+    """Return the full path of every leaf route registered on ``app``."""
+    return [path for path, _ in iter_app_routes(app)]

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -442,7 +442,9 @@ def test_cross_feature_prompt_versioning_structure():
     """18.5 — Prompt versioning + eval integration."""
     from app.main import app
 
-    routes = [r.path for r in app.routes]
+    from tests.route_utils import app_route_paths
+
+    routes = app_route_paths(app)
     # Prompt routes use /agents/{agent_id}/prompts pattern
     prompt_routes = [r for r in routes if "prompts" in r]
     assert len(prompt_routes) >= 1
@@ -453,7 +455,9 @@ def test_cross_feature_marketplace_org_integration(auth_client):
     """18.1 — Marketplace + teams integration."""
     from app.main import app
 
-    routes = [r.path for r in app.routes]
+    from tests.route_utils import app_route_paths
+
+    routes = app_route_paths(app)
     assert "/api/marketplace/listings" in routes
     assert "/api/organizations" in routes
 
@@ -462,7 +466,9 @@ def test_cross_feature_traces_exist_for_runs():
     """18.4 — Traces endpoint exists alongside runs."""
     from app.main import app
 
-    routes = [r.path for r in app.routes]
+    from tests.route_utils import app_route_paths
+
+    routes = app_route_paths(app)
     assert "/api/traces" in routes
     assert "/api/runs" in routes
     assert "/api/traces/stats" in routes

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -131,7 +131,7 @@ class TestPromptInjectionBlueprints:
             execute_template_renderer,
         )
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             execute_template_renderer(
                 {"template": "Hello {{name}}, {{__import__('os').system('ls')}}"},
                 {"name": "World"},
@@ -346,7 +346,7 @@ class TestAuthSecurity:
         from app.routers.auth import get_current_user
 
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 get_current_user("InvalidTokenNoBearer")
             )
         assert exc_info.value.status_code == 401
@@ -363,7 +363,7 @@ class TestAuthSecurity:
         with patch("app.db._db") as mock_sb:
             mock_sb.auth.get_user.side_effect = Exception("Invalid token")
             with pytest.raises(HTTPException) as exc_info:
-                asyncio.get_event_loop().run_until_complete(
+                asyncio.run(
                     get_current_user("Bearer ")
                 )
             assert exc_info.value.status_code == 401
@@ -990,7 +990,7 @@ class TestSecretsExposure:
 
         from app.main import health
 
-        result = asyncio.get_event_loop().run_until_complete(health())
+        result = asyncio.run(health())
         assert "key" not in str(result).lower()
         assert "secret" not in str(result).lower()
         assert "password" not in str(result).lower()
@@ -1001,7 +1001,7 @@ class TestSecretsExposure:
 
         from app.main import root
 
-        result = asyncio.get_event_loop().run_until_complete(root())
+        result = asyncio.run(root())
         assert "key" not in str(result).lower()
         assert "secret" not in str(result).lower()
 
@@ -1206,10 +1206,11 @@ class TestInjectionSurface:
             "/api/marketplace/listings/{listing_id}/forks",
         }
 
-        for route in app.routes:
+        from tests.route_utils import iter_app_routes
+
+        for path, route in iter_app_routes(app):
             if not hasattr(route, "methods"):
                 continue
-            path = getattr(route, "path", "")
             methods = getattr(route, "methods", set())
 
             # Skip public/read routes


### PR DESCRIPTION
Applies all 17 backend bumps from Dependabot PR #139 together, with the code migration required for the new versions.

## Bumps (requirements.txt + requirements-dev.txt)
fastapi 0.115.6->0.138.2, uvicorn 0.34.0->0.49.0, langchain 1.3.9->1.3.11, langchain-openai 1.3.2->1.3.3, openai 2.26.0->2.44.0, python-multipart 0.0.31->0.0.32, pydantic 2.10.4->2.13.4, pypdf 6.13.3->6.14.2, python-docx 1.1.2->1.2.0, slowapi 0.1.9->0.1.10, anthropic 0.52.0->0.115.0, tiktoken 0.9.0->0.13.0, supabase 2.11.0->2.31.0, pytest 9.0.3->9.1.1, pytest-asyncio 1.3.0->1.4.0, pytest-cov 7.0.0->7.1.0, ruff 0.8.6->0.15.20.

## Migration
- **FastAPI 0.138** registers lazy `_IncludedRouter` wrappers on `app.routes` instead of eagerly flattening included sub-routes. Added `backend/tests/route_utils.py` to walk that structure (prefix-aware) and updated the route-enumeration tests so they still assert over every real route path (and the auth-coverage test still traverses every mutation route).
- **pytest-asyncio 1.4** no longer leaves a current event loop set; switched 5 `asyncio.get_event_loop().run_until_complete(...)` call sites to `asyncio.run(...)`.

## Verification (Python 3.12, exact CI commands)
- `ruff check app/ --config ../ruff.toml` — passed
- `mypy app/ --config-file mypy.ini` — Success, 143 files
- `pytest tests/ -v --cov=app` — 732 passed, 23 skipped

Closes #139.