### PR TITLE
chore: add license and repository metadata to package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,11 @@
   "name": "frontend",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AaronCx/Forge.git"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
npm treats a package.json without a `license` field as UNLICENSED metadata even though the repo ships an MIT LICENSE file. This adds `"license": "MIT"` and a `repository` field pointing at the GitHub repo.

Part of the 2026-07-08 public-repo audit (Brief 4). Docs/metadata only — no dependency or code changes.