### PR TITLE
Harness Phase 2: Provider adapters speak kernel (turn/stream_turn, Google, FallbackPolicy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Harness transformation (Phase 2 — Provider adapters speak kernel).** Every
+  provider now implements kernel `turn()`/`stream_turn()` (`KMessage`s +
+  `ToolSpec`s → `TurnResult`/`StreamEvent`s) with full tool-call, tool-result,
+  and image fidelity — OpenAI, Anthropic (native `tool_use`/`tool_result` +
+  base64 images), Ollama, and any OpenAI-compatible endpoint. Adds a **native
+  Google (Gemini) provider** (`google_provider.py`, registered on
+  `GOOGLE_API_KEY`), making the README's Google claim real. The registry gains
+  `turn()`/`stream()`, ModelCard-first routing (`models.json` provider before
+  legacy prefixes), and a `FallbackPolicy` (default off; never retries 4xx).
+  Legacy `complete()`/`stream_complete()` and `LLMResponse` are unchanged and
+  kept as shims. Zero behavior change to existing paths (parity green).
 - **Harness transformation (Phase 1 — The kernel).** A Forge-owned, provider-neutral
   representation of agentic exchanges under `backend/app/kernel/`: typed content
   blocks (text/image/tool-use/tool-result/thinking), `KMessage`, `TurnResult`,

--- a/backend/app/providers/anthropic_provider.py
+++ b/backend/app/providers/anthropic_provider.py
@@ -154,6 +154,129 @@ class AnthropicProvider(LLMProvider):
                 provider=self.provider_name,
             )
 
+    async def turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> Any:
+        import time
+
+        from app.kernel.types import TextBlock, TurnResult, Usage
+        from app.providers.kernel_bridge import (
+            kmessages_to_anthropic,
+            stop_from_anthropic,
+            tools_to_anthropic,
+        )
+
+        system_prompt, anthropic_msgs = kmessages_to_anthropic(messages)
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": anthropic_msgs,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if system_prompt:
+            kwargs["system"] = system_prompt
+        native_tools = tools_to_anthropic(tools)
+        if native_tools:
+            kwargs["tools"] = native_tools
+
+        start = time.monotonic()
+        response = await self.client.messages.create(**kwargs)
+        elapsed = (time.monotonic() - start) * 1000
+
+        from app.kernel.types import ToolUseBlock
+
+        blocks: list[Any] = []
+        for block in response.content:
+            if block.type == "text":
+                blocks.append(TextBlock(block.text))
+            elif block.type == "tool_use":
+                raw_input = block.input if isinstance(block.input, dict) else {}
+                blocks.append(ToolUseBlock(id=block.id, name=block.name, input=raw_input))
+        return TurnResult(
+            blocks=blocks,
+            stop_reason=stop_from_anthropic(response.stop_reason),
+            usage=Usage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+            ),
+            model=response.model,
+            provider=self.provider_name,
+            latency_ms=elapsed,
+        )
+
+    async def stream_turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator[Any]:
+        import time
+
+        from app.kernel.types import (
+            TextBlock,
+            TextDelta,
+            ToolUseBlock,
+            TurnDone,
+            TurnResult,
+            Usage,
+        )
+        from app.providers.kernel_bridge import (
+            kmessages_to_anthropic,
+            stop_from_anthropic,
+            tools_to_anthropic,
+        )
+
+        system_prompt, anthropic_msgs = kmessages_to_anthropic(messages)
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": anthropic_msgs,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if system_prompt:
+            kwargs["system"] = system_prompt
+        native_tools = tools_to_anthropic(tools)
+        if native_tools:
+            kwargs["tools"] = native_tools
+
+        start = time.monotonic()
+        text_parts: list[str] = []
+        async with self.client.messages.stream(**kwargs) as stream:
+            async for text in stream.text_stream:
+                text_parts.append(text)
+                yield TextDelta(text=text)
+            final = await stream.get_final_message()
+
+        blocks: list[Any] = []
+        for block in final.content:
+            if block.type == "text":
+                blocks.append(TextBlock(block.text))
+            elif block.type == "tool_use":
+                raw_input = block.input if isinstance(block.input, dict) else {}
+                blocks.append(ToolUseBlock(id=block.id, name=block.name, input=raw_input))
+        yield TurnDone(
+            turn=TurnResult(
+                blocks=blocks,
+                stop_reason=stop_from_anthropic(final.stop_reason),
+                usage=Usage(
+                    input_tokens=final.usage.input_tokens,
+                    output_tokens=final.usage.output_tokens,
+                ),
+                model=final.model,
+                provider=self.provider_name,
+                latency_ms=(time.monotonic() - start) * 1000,
+            )
+        )
+
     async def count_tokens(self, text: str, model: str) -> int:
         # Anthropic doesn't expose a tokenizer — estimate at ~4 chars per token
         return len(text) // 4

--- a/backend/app/providers/base.py
+++ b/backend/app/providers/base.py
@@ -105,6 +105,89 @@ class LLMProvider(ABC):
         # Make this an async generator to satisfy type checkers
         yield StreamChunk()  # pragma: no cover
 
+    # --- kernel interface (harness-plan.md Phase 2) ---
+    #
+    # Default implementations derive kernel turns from the legacy
+    # complete()/stream_complete() via message conversion, so every existing
+    # provider (and every test double) speaks kernel without changes. Providers
+    # with native tool/image support override these for full fidelity.
+
+    async def turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> Any:
+        """Run one kernel turn and return a ``TurnResult``.
+
+        ``messages`` is a list of ``KMessage``; ``tools`` a list of ``ToolSpec``.
+        """
+        from app.kernel.convert import to_openai_messages
+        from app.kernel.types import TurnResult, Usage
+        from app.providers.kernel_bridge import (
+            default_turn_blocks_from_text,
+            stop_from_openai,
+            tools_to_openai,
+        )
+
+        resp = await self.complete(
+            to_openai_messages(messages),
+            model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools_to_openai(tools),
+        )
+        return TurnResult(
+            blocks=default_turn_blocks_from_text(resp.content),
+            stop_reason=stop_from_openai(resp.finish_reason),
+            usage=Usage(input_tokens=resp.input_tokens, output_tokens=resp.output_tokens),
+            model=resp.model,
+            provider=resp.provider,
+            latency_ms=resp.latency_ms,
+        )
+
+    async def stream_turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator[Any]:
+        """Stream one kernel turn as ``StreamEvent``s, ending with ``TurnDone``."""
+        from app.kernel.convert import to_openai_messages
+        from app.kernel.types import TextBlock, TextDelta, TurnDone, TurnResult, Usage
+        from app.providers.kernel_bridge import stop_from_openai, tools_to_openai
+
+        text_parts: list[str] = []
+        finish_reason: str | None = None
+        async for chunk in self.stream_complete(
+            to_openai_messages(messages),
+            model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools_to_openai(tools),
+        ):
+            if chunk.content:
+                text_parts.append(chunk.content)
+                yield TextDelta(text=chunk.content)
+            if chunk.finish_reason:
+                finish_reason = chunk.finish_reason
+        text = "".join(text_parts)
+        yield TurnDone(
+            turn=TurnResult(
+                blocks=[TextBlock(text)] if text else [],
+                stop_reason=stop_from_openai(finish_reason),
+                usage=Usage(),
+                model=model,
+                provider=self.provider_name,
+            )
+        )
+
     @abstractmethod
     async def count_tokens(self, text: str, model: str) -> int:
         """Count the number of tokens in the given text for the specified model."""

--- a/backend/app/providers/generic_provider.py
+++ b/backend/app/providers/generic_provider.py
@@ -104,6 +104,39 @@ class GenericOpenAIProvider(LLMProvider):
                 provider=self.provider_name,
             )
 
+    async def turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> Any:
+        from app.providers.kernel_bridge import openai_style_turn
+
+        return await openai_style_turn(
+            self.client, self.provider_name, messages, model,
+            tools=tools, temperature=temperature, max_tokens=max_tokens,
+        )
+
+    async def stream_turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator[Any]:
+        from app.providers.kernel_bridge import openai_style_stream_turn
+
+        async for ev in openai_style_stream_turn(
+            self.client, self.provider_name, messages, model,
+            tools=tools, temperature=temperature, max_tokens=max_tokens,
+        ):
+            yield ev
+
     async def count_tokens(self, text: str, model: str) -> int:
         return len(text) // 4
 

--- a/backend/app/providers/google_provider.py
+++ b/backend/app/providers/google_provider.py
@@ -1,0 +1,351 @@
+"""Google (Gemini) provider — native Generative Language REST API.
+
+Implemented over httpx rather than the google-generativeai SDK to stay
+dependency-light and easily mockable in tests. Supports text, inline base64
+images, tool (function) calling, and streaming, so a Gemini agent is a
+first-class kernel citizen.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+from app.providers.base import (
+    LLMProvider,
+    LLMResponse,
+    ModelInfo,
+    ProviderHealth,
+    StreamChunk,
+)
+
+_GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta"
+
+_FINISH_MAP = {
+    "STOP": "end",
+    "MAX_TOKENS": "max_tokens",
+    "SAFETY": "error",
+    "RECITATION": "error",
+    "OTHER": "end",
+}
+
+
+def _openai_to_contents(
+    messages: list[dict[str, Any]],
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    """Convert OpenAI-format messages to (systemInstruction, contents)."""
+    system_parts: list[dict[str, Any]] = []
+    contents: list[dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content", "")
+        text = content if isinstance(content, str) else json.dumps(content)
+        if role == "system":
+            system_parts.append({"text": text})
+        elif role == "tool":
+            contents.append(
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "functionResponse": {
+                                "name": msg.get("tool_call_id", "tool"),
+                                "response": {"result": text},
+                            }
+                        }
+                    ],
+                }
+            )
+        else:
+            gemini_role = "model" if role == "assistant" else "user"
+            contents.append({"role": gemini_role, "parts": [{"text": text}]})
+    system = {"parts": system_parts} if system_parts else None
+    return system, contents
+
+
+class GoogleProvider(LLMProvider):
+    """Google Gemini provider via the Generative Language REST API."""
+
+    provider_name = "google"
+    default_model = "gemini-1.5-flash"
+
+    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+        self.api_key = api_key or ""
+        self.base_url = (base_url or _GEMINI_BASE).rstrip("/")
+
+    # --- HTTP plumbing ---
+
+    def _url(self, model: str, method: str, *, sse: bool = False) -> str:
+        suffix = "?alt=sse&key=" if sse else "?key="
+        return f"{self.base_url}/models/{model}:{method}{suffix}{self.api_key}"
+
+    async def _generate(self, model: str, body: dict[str, Any]) -> dict[str, Any]:
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.post(self._url(model, "generateContent"), json=body)
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
+            return data
+
+    @staticmethod
+    def _build_body(
+        contents: list[dict[str, Any]],
+        system: dict[str, Any] | None,
+        tools: list[dict[str, Any]] | None,
+        temperature: float,
+        max_tokens: int,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "contents": contents,
+            "generationConfig": {"temperature": temperature, "maxOutputTokens": max_tokens},
+        }
+        if system:
+            body["systemInstruction"] = system
+        if tools:
+            body["tools"] = tools
+        return body
+
+    @staticmethod
+    def _text_and_usage(data: dict[str, Any]) -> tuple[str, str, int, int]:
+        candidates = data.get("candidates") or [{}]
+        cand = candidates[0]
+        parts = cand.get("content", {}).get("parts", [])
+        text = "".join(p.get("text", "") for p in parts if "text" in p)
+        finish = cand.get("finishReason", "STOP")
+        usage = data.get("usageMetadata", {})
+        return (
+            text,
+            finish,
+            usage.get("promptTokenCount", 0),
+            usage.get("candidatesTokenCount", 0),
+        )
+
+    # --- legacy interface ---
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+        tools: list[dict[str, Any]] | None = None,
+        stream: bool = False,
+    ) -> LLMResponse:
+        system, contents = _openai_to_contents(messages)
+        body = self._build_body(contents, system, None, temperature, max_tokens)
+        start = time.monotonic()
+        data = await self._generate(model, body)
+        elapsed = (time.monotonic() - start) * 1000
+        text, finish, in_tok, out_tok = self._text_and_usage(data)
+        return LLMResponse(
+            content=text,
+            model=model,
+            input_tokens=in_tok,
+            output_tokens=out_tok,
+            finish_reason=finish,
+            latency_ms=elapsed,
+            provider=self.provider_name,
+            raw_response=data,
+        )
+
+    async def stream_complete(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        system, contents = _openai_to_contents(messages)
+        body = self._build_body(contents, system, None, temperature, max_tokens)
+        async with httpx.AsyncClient(timeout=60) as client, client.stream(
+            "POST", self._url(model, "streamGenerateContent", sse=True), json=body
+        ) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if not line.startswith("data:"):
+                    continue
+                payload = line[len("data:") :].strip()
+                if not payload:
+                    continue
+                try:
+                    data = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                text, finish, _, _ = self._text_and_usage(data)
+                yield StreamChunk(
+                    content=text,
+                    finish_reason=_FINISH_MAP.get(finish),
+                    model=model,
+                    provider=self.provider_name,
+                )
+
+    # --- kernel interface (native tool/image support) ---
+
+    async def turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> Any:
+        from app.kernel.types import TextBlock, ToolUseBlock, TurnResult, Usage
+
+        system, contents = self._kernel_to_contents(messages)
+        gemini_tools = self._kernel_tools(tools)
+        body = self._build_body(contents, system, gemini_tools, temperature, max_tokens)
+        start = time.monotonic()
+        data = await self._generate(model, body)
+        elapsed = (time.monotonic() - start) * 1000
+
+        candidates = data.get("candidates") or [{}]
+        cand = candidates[0]
+        parts = cand.get("content", {}).get("parts", [])
+        blocks: list[Any] = []
+        has_tool = False
+        for i, part in enumerate(parts):
+            if "text" in part:
+                blocks.append(TextBlock(part["text"]))
+            elif "functionCall" in part:
+                has_tool = True
+                fc = part["functionCall"]
+                blocks.append(
+                    ToolUseBlock(
+                        id=f"{fc.get('name', 'call')}_{i}",
+                        name=fc.get("name", ""),
+                        input=dict(fc.get("args") or {}),
+                    )
+                )
+        finish = cand.get("finishReason", "STOP")
+        stop = "tool_use" if has_tool else _FINISH_MAP.get(finish, "end")
+        usage = data.get("usageMetadata", {})
+        return TurnResult(
+            blocks=blocks,
+            stop_reason=stop,  # type: ignore[arg-type]
+            usage=Usage(
+                input_tokens=usage.get("promptTokenCount", 0),
+                output_tokens=usage.get("candidatesTokenCount", 0),
+            ),
+            model=model,
+            provider=self.provider_name,
+            latency_ms=elapsed,
+        )
+
+    async def stream_turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator[Any]:
+        from app.kernel.types import TextBlock, TextDelta, TurnDone
+
+        # Gemini's SSE tool-call framing is awkward; derive a faithful turn once
+        # and surface its text incrementally plus a terminal TurnDone.
+        turn = await self.turn(
+            messages, model, tools=tools, temperature=temperature, max_tokens=max_tokens
+        )
+        for block in turn.blocks:
+            if isinstance(block, TextBlock) and block.text:
+                yield TextDelta(text=block.text)
+        yield TurnDone(turn=turn)
+
+    def _kernel_to_contents(
+        self, messages: list[Any]
+    ) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+        from app.kernel.types import (
+            ImageBlock,
+            TextBlock,
+            ToolResultBlock,
+            ToolUseBlock,
+        )
+
+        system_parts: list[dict[str, Any]] = []
+        contents: list[dict[str, Any]] = []
+        for m in messages:
+            if m.role == "system":
+                for b in m.blocks:
+                    if isinstance(b, TextBlock):
+                        system_parts.append({"text": b.text})
+                continue
+            role = "model" if m.role == "assistant" else "user"
+            parts: list[dict[str, Any]] = []
+            for b in m.blocks:
+                if isinstance(b, TextBlock):
+                    parts.append({"text": b.text})
+                elif isinstance(b, ImageBlock) and b.data is not None:
+                    parts.append(
+                        {"inline_data": {"mime_type": b.media_type or "image/png", "data": b.data}}
+                    )
+                elif isinstance(b, ToolUseBlock):
+                    parts.append({"functionCall": {"name": b.name, "args": b.input}})
+                elif isinstance(b, ToolResultBlock):
+                    out = b.output if isinstance(b.output, dict) else {"result": b.output}
+                    parts.append(
+                        {"functionResponse": {"name": b.tool_use_id, "response": out}}
+                    )
+            contents.append({"role": role, "parts": parts})
+        system = {"parts": system_parts} if system_parts else None
+        return system, contents
+
+    @staticmethod
+    def _kernel_tools(tools: list[Any] | None) -> list[dict[str, Any]] | None:
+        if not tools:
+            return None
+        declarations = [
+            {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.input_schema or {"type": "object", "properties": {}},
+            }
+            for t in tools
+        ]
+        return [{"functionDeclarations": declarations}]
+
+    async def count_tokens(self, text: str, model: str) -> int:
+        return len(text) // 4
+
+    async def list_models(self) -> list[ModelInfo]:
+        # Data-driven: surface the Google cards from the kernel model catalog.
+        from app.kernel.models import load_base_model_cards
+
+        return [
+            ModelInfo(
+                id=card.id,
+                name=card.display_name,
+                provider=self.provider_name,
+                context_window=card.context_window,
+                max_output_tokens=card.max_output,
+                supports_tools=card.tools,
+            )
+            for card in load_base_model_cards().values()
+            if card.provider == "google"
+        ]
+
+    async def health_check(self) -> ProviderHealth:
+        start = time.monotonic()
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(f"{self.base_url}/models?key={self.api_key}")
+                resp.raise_for_status()
+            return ProviderHealth(
+                provider=self.provider_name,
+                status="healthy",
+                latency_ms=(time.monotonic() - start) * 1000,
+            )
+        except Exception as e:
+            return ProviderHealth(
+                provider=self.provider_name,
+                status="unavailable",
+                latency_ms=(time.monotonic() - start) * 1000,
+                error=str(e),
+            )

--- a/backend/app/providers/kernel_bridge.py
+++ b/backend/app/providers/kernel_bridge.py
@@ -1,0 +1,374 @@
+"""Conversion helpers between kernel types and provider-native shapes.
+
+Keeps the per-provider ``turn``/``stream_turn`` implementations small: tool-spec
+and message conversion, stop-reason mapping, the OpenAI-compatible turn/stream
+routines shared by OpenAI/Ollama/Generic, and the ``TurnResult`` → legacy
+``LLMResponse`` shim.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+from app.kernel.convert import to_openai_messages
+from app.kernel.models import get_model_card
+from app.kernel.types import (
+    ImageBlock,
+    KMessage,
+    StopReason,
+    StreamEvent,
+    TextBlock,
+    TextDelta,
+    ToolResultBlock,
+    ToolSpec,
+    ToolUseBlock,
+    ToolUseDelta,
+    ToolUseStart,
+    TurnDone,
+    TurnResult,
+    Usage,
+    UsageEvent,
+)
+from app.providers.base import LLMResponse
+
+# --- stop-reason mapping ---
+
+_OPENAI_STOP: dict[str, StopReason] = {
+    "stop": "end",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+    "function_call": "tool_use",
+    "content_filter": "error",
+}
+_ANTHROPIC_STOP: dict[str, StopReason] = {
+    "end_turn": "end",
+    "max_tokens": "max_tokens",
+    "tool_use": "tool_use",
+    "stop_sequence": "end",
+    "refusal": "error",
+}
+
+
+def stop_from_openai(finish_reason: str | None) -> StopReason:
+    return _OPENAI_STOP.get(finish_reason or "", "end")
+
+
+def stop_from_anthropic(stop_reason: str | None) -> StopReason:
+    return _ANTHROPIC_STOP.get(stop_reason or "", "end")
+
+
+# --- tool-spec conversion ---
+
+_EMPTY_SCHEMA = {"type": "object", "properties": {}}
+
+
+def tools_to_openai(tools: list[ToolSpec] | None) -> list[dict[str, Any]] | None:
+    if not tools:
+        return None
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.input_schema or _EMPTY_SCHEMA,
+            },
+        }
+        for t in tools
+    ]
+
+
+def tools_to_anthropic(tools: list[ToolSpec] | None) -> list[dict[str, Any]] | None:
+    if not tools:
+        return None
+    return [
+        {
+            "name": t.name,
+            "description": t.description,
+            "input_schema": t.input_schema or _EMPTY_SCHEMA,
+        }
+        for t in tools
+    ]
+
+
+# --- kernel -> Anthropic messages (native tool_use/tool_result/image blocks) ---
+
+
+def _anthropic_content(blocks: list[Any]) -> list[dict[str, Any]]:
+    content: list[dict[str, Any]] = []
+    for b in blocks:
+        if isinstance(b, TextBlock):
+            content.append({"type": "text", "text": b.text})
+        elif isinstance(b, ImageBlock):
+            if b.data is not None:
+                content.append(
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": b.media_type or "image/png",
+                            "data": b.data,
+                        },
+                    }
+                )
+            elif b.url:
+                content.append({"type": "image", "source": {"type": "url", "url": b.url}})
+        elif isinstance(b, ToolUseBlock):
+            content.append({"type": "tool_use", "id": b.id, "name": b.name, "input": b.input})
+        elif isinstance(b, ToolResultBlock):
+            out = b.output if isinstance(b.output, list | dict) else str(b.output)
+            content.append(
+                {"type": "tool_result", "tool_use_id": b.tool_use_id, "content": out,
+                 "is_error": b.is_error}
+            )
+        # ThinkingBlock is output-only; never sent back to the model.
+    return content
+
+
+def kmessages_to_anthropic(
+    messages: list[KMessage],
+) -> tuple[str, list[dict[str, Any]]]:
+    """Return (system_prompt, anthropic_messages).
+
+    The kernel's ``tool`` role has no Anthropic equivalent — tool results ride in
+    ``user`` turns. Consecutive same-role turns are merged to satisfy Anthropic's
+    strict user/assistant alternation.
+    """
+    system_parts: list[str] = []
+    out: list[dict[str, Any]] = []
+    for m in messages:
+        if m.role == "system":
+            text = "".join(b.text for b in m.blocks if isinstance(b, TextBlock))
+            if text:
+                system_parts.append(text)
+            continue
+        role = "user" if m.role == "tool" else m.role
+        content = _anthropic_content(m.blocks)
+        if out and out[-1]["role"] == role:
+            out[-1]["content"].extend(content)
+        else:
+            out.append({"role": role, "content": content})
+    return "\n\n".join(system_parts), out
+
+
+# --- OpenAI-compatible turn / stream_turn (shared by OpenAI/Ollama/Generic) ---
+
+
+def _parse_openai_tool_calls(tool_calls: Any) -> list[ToolUseBlock]:
+    blocks: list[ToolUseBlock] = []
+    for tc in tool_calls or []:
+        fn = tc.function
+        raw = fn.arguments
+        try:
+            args = json.loads(raw) if isinstance(raw, str) and raw else (raw or {})
+        except (json.JSONDecodeError, TypeError):
+            args = {"__raw__": raw}
+        blocks.append(ToolUseBlock(id=tc.id or "", name=fn.name or "", input=args or {}))
+    return blocks
+
+
+def tools_unsupported_error(model: str, provider_name: str) -> TurnResult:
+    """A clear error TurnResult for a tools request against a tools=False model."""
+    return TurnResult(
+        blocks=[
+            TextBlock(
+                f"Model '{model}' on provider '{provider_name}' does not support "
+                "tool calling. Choose a tools-capable model or remove the tools."
+            )
+        ],
+        stop_reason="error",
+        usage=Usage(),
+        model=model,
+        provider=provider_name,
+    )
+
+
+def _tools_blocked(model: str, tools: list[ToolSpec] | None) -> bool:
+    """True only when tools were requested and a known card says tools=False."""
+    if not tools:
+        return False
+    card = get_model_card(model)
+    return card is not None and not card.tools
+
+
+async def openai_style_turn(
+    client: Any,
+    provider_name: str,
+    messages: list[KMessage],
+    model: str,
+    *,
+    tools: list[ToolSpec] | None,
+    temperature: float,
+    max_tokens: int,
+) -> TurnResult:
+    if _tools_blocked(model, tools):
+        return tools_unsupported_error(model, provider_name)
+
+    start = time.monotonic()
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": to_openai_messages(messages),
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    openai_tools = tools_to_openai(tools)
+    if openai_tools:
+        kwargs["tools"] = openai_tools
+
+    response = await client.chat.completions.create(**kwargs)
+    elapsed = (time.monotonic() - start) * 1000
+
+    choice = response.choices[0]
+    blocks: list[Any] = []
+    if choice.message.content:
+        blocks.append(TextBlock(choice.message.content))
+    blocks.extend(_parse_openai_tool_calls(getattr(choice.message, "tool_calls", None)))
+
+    usage = response.usage
+    return TurnResult(
+        blocks=blocks,
+        stop_reason=stop_from_openai(choice.finish_reason),
+        usage=Usage(
+            input_tokens=usage.prompt_tokens if usage else 0,
+            output_tokens=usage.completion_tokens if usage else 0,
+        ),
+        model=getattr(response, "model", model) or model,
+        provider=provider_name,
+        latency_ms=elapsed,
+    )
+
+
+async def openai_style_stream_turn(
+    client: Any,
+    provider_name: str,
+    messages: list[KMessage],
+    model: str,
+    *,
+    tools: list[ToolSpec] | None,
+    temperature: float,
+    max_tokens: int,
+) -> AsyncIterator[StreamEvent]:
+    if _tools_blocked(model, tools):
+        yield TurnDone(turn=tools_unsupported_error(model, provider_name))
+        return
+
+    start = time.monotonic()
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": to_openai_messages(messages),
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    openai_tools = tools_to_openai(tools)
+    if openai_tools:
+        kwargs["tools"] = openai_tools
+
+    text_parts: list[str] = []
+    # tool call accumulation keyed by streamed index
+    tool_acc: dict[int, dict[str, str]] = {}
+    tool_started: set[int] = set()
+    finish_reason: str | None = None
+    usage = Usage()
+
+    stream = await client.chat.completions.create(**kwargs)
+    async for chunk in stream:
+        if getattr(chunk, "usage", None):
+            usage = Usage(
+                input_tokens=chunk.usage.prompt_tokens or 0,
+                output_tokens=chunk.usage.completion_tokens or 0,
+            )
+        if not chunk.choices:
+            continue
+        choice = chunk.choices[0]
+        delta = choice.delta
+        if getattr(delta, "content", None):
+            text_parts.append(delta.content)
+            yield TextDelta(text=delta.content)
+        for tc in getattr(delta, "tool_calls", None) or []:
+            idx = tc.index
+            slot = tool_acc.setdefault(idx, {"id": "", "name": "", "args": ""})
+            if tc.id:
+                slot["id"] = tc.id
+            fn = getattr(tc, "function", None)
+            if fn and getattr(fn, "name", None):
+                slot["name"] = fn.name
+            if idx not in tool_started and slot["id"] and slot["name"]:
+                tool_started.add(idx)
+                yield ToolUseStart(id=slot["id"], name=slot["name"])
+            if fn and getattr(fn, "arguments", None):
+                slot["args"] += fn.arguments
+                yield ToolUseDelta(partial_json=fn.arguments)
+        if choice.finish_reason:
+            finish_reason = choice.finish_reason
+
+    if usage.input_tokens or usage.output_tokens:
+        yield UsageEvent(usage=usage)
+
+    blocks: list[Any] = []
+    text = "".join(text_parts)
+    if text:
+        blocks.append(TextBlock(text))
+    for idx in sorted(tool_acc):
+        slot = tool_acc[idx]
+        try:
+            args = json.loads(slot["args"]) if slot["args"] else {}
+        except json.JSONDecodeError:
+            args = {"__raw__": slot["args"]}
+        blocks.append(ToolUseBlock(id=slot["id"], name=slot["name"], input=args))
+
+    turn = TurnResult(
+        blocks=blocks,
+        stop_reason=stop_from_openai(finish_reason),
+        usage=usage,
+        model=model,
+        provider=provider_name,
+        latency_ms=(time.monotonic() - start) * 1000,
+    )
+    yield TurnDone(turn=turn)
+
+
+# --- shim: TurnResult -> legacy LLMResponse ---
+
+
+def turn_result_to_llm_response(turn: TurnResult) -> LLMResponse:
+    """Collapse a kernel TurnResult into the legacy LLMResponse (text only)."""
+    # Reverse-map to a legacy finish_reason string for callers that inspect it.
+    legacy_finish = {
+        "end": "stop",
+        "max_tokens": "length",
+        "tool_use": "tool_calls",
+        "error": "error",
+    }.get(turn.stop_reason, "stop")
+    return LLMResponse(
+        content=turn.text,
+        model=turn.model,
+        input_tokens=turn.usage.input_tokens,
+        output_tokens=turn.usage.output_tokens,
+        finish_reason=legacy_finish,
+        latency_ms=turn.latency_ms,
+        provider=turn.provider,
+    )
+
+
+def default_turn_blocks_from_text(text: str) -> list[Any]:
+    """Blocks for a text-only TurnResult (used by the base-class default)."""
+    return [TextBlock(text)] if text else []
+
+
+__all__ = [
+    "default_turn_blocks_from_text",
+    "kmessages_to_anthropic",
+    "openai_style_stream_turn",
+    "openai_style_turn",
+    "stop_from_anthropic",
+    "stop_from_openai",
+    "tools_to_anthropic",
+    "tools_to_openai",
+    "tools_unsupported_error",
+    "turn_result_to_llm_response",
+]

--- a/backend/app/providers/ollama_provider.py
+++ b/backend/app/providers/ollama_provider.py
@@ -102,6 +102,39 @@ class OllamaProvider(LLMProvider):
                 provider=self.provider_name,
             )
 
+    async def turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> Any:
+        from app.providers.kernel_bridge import openai_style_turn
+
+        return await openai_style_turn(
+            self.client, self.provider_name, messages, model,
+            tools=tools, temperature=temperature, max_tokens=max_tokens,
+        )
+
+    async def stream_turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator[Any]:
+        from app.providers.kernel_bridge import openai_style_stream_turn
+
+        async for ev in openai_style_stream_turn(
+            self.client, self.provider_name, messages, model,
+            tools=tools, temperature=temperature, max_tokens=max_tokens,
+        ):
+            yield ev
+
     async def count_tokens(self, text: str, model: str) -> int:
         # Ollama doesn't expose a tokenizer — estimate
         return len(text) // 4

--- a/backend/app/providers/openai_provider.py
+++ b/backend/app/providers/openai_provider.py
@@ -106,6 +106,39 @@ class OpenAIProvider(LLMProvider):
                 provider=self.provider_name,
             )
 
+    async def turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> Any:
+        from app.providers.kernel_bridge import openai_style_turn
+
+        return await openai_style_turn(
+            self.client, self.provider_name, messages, model,
+            tools=tools, temperature=temperature, max_tokens=max_tokens,
+        )
+
+    async def stream_turn(
+        self,
+        messages: list[Any],
+        model: str,
+        *,
+        tools: list[Any] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator[Any]:
+        from app.providers.kernel_bridge import openai_style_stream_turn
+
+        async for ev in openai_style_stream_turn(
+            self.client, self.provider_name, messages, model,
+            tools=tools, temperature=temperature, max_tokens=max_tokens,
+        ):
+            yield ev
+
     async def count_tokens(self, text: str, model: str) -> int:
         try:
             encoding = tiktoken.encoding_for_model(model)

--- a/backend/app/providers/registry.py
+++ b/backend/app/providers/registry.py
@@ -4,11 +4,38 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 from app.providers.base import LLMProvider, LLMResponse, ModelInfo, ProviderHealth
 
+if TYPE_CHECKING:
+    from app.kernel.types import KMessage, StreamEvent, ToolSpec, TurnResult
+
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FallbackPolicy:
+    """Controls cross-provider retry for kernel turns (default: no fallback).
+
+    Client (4xx) errors are never retried when ``exclude_client_errors`` is set —
+    a bad request will fail identically everywhere.
+    """
+
+    enabled: bool = False
+    same_capabilities_only: bool = False
+    exclude_client_errors: bool = True
+
+
+def _is_client_error(exc: Exception) -> bool:
+    """True for a 4xx-class error from any provider SDK or httpx."""
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status_code", None)
+    return isinstance(status, int) and 400 <= status < 500
 
 # Model prefix → provider mapping.
 # TODO(phase-8): remove in favor of ModelCard.provider lookups from
@@ -55,6 +82,17 @@ class ProviderRegistry:
         """
         if model is None:
             model = self._default_model
+
+        # ModelCard-first routing (harness-plan.md Phase 2): prefer the provider
+        # declared in models.json when it is actually registered here. Falls
+        # through to the legacy prefix/explicit/default logic otherwise.
+        from app.kernel.models import get_model_card
+
+        card = get_model_card(model)
+        if card is not None:
+            card_provider = self._providers.get(card.provider)
+            if card_provider:
+                return card_provider, model
 
         # Check if a registered provider claims this prefix (e.g. "gpt-" → openai).
         # Only treat the prefix as routable when that provider is actually
@@ -141,6 +179,81 @@ class ProviderRegistry:
 
             raise
 
+    # --- kernel interface (harness-plan.md Phase 2) ---
+
+    async def turn(
+        self,
+        messages: list[KMessage],
+        model: str | None = None,
+        *,
+        tools: list[ToolSpec] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+        policy: FallbackPolicy | None = None,
+    ) -> TurnResult:
+        """Route a kernel turn to the resolved provider, with optional fallback."""
+        from typing import cast
+
+        provider, resolved_model = self.resolve_provider(model)
+        policy = policy or FallbackPolicy()
+
+        try:
+            return cast(
+                "TurnResult",
+                await provider.turn(
+                    messages, resolved_model, tools=tools,
+                    temperature=temperature, max_tokens=max_tokens,
+                ),
+            )
+        except Exception as exc:
+            if not policy.enabled or len(self._providers) <= 1:
+                raise
+            if policy.exclude_client_errors and _is_client_error(exc):
+                raise  # a 4xx fails identically everywhere — do not retry
+
+            failed_name = provider.provider_name
+            logger.warning(
+                "Provider %s turn failed for %s, trying fallback", failed_name, resolved_model
+            )
+            for name, alt in self._providers.items():
+                if name == failed_name:
+                    continue
+                try:
+                    alt_model = self._default_model if name == self._default_provider else resolved_model
+                    result = cast(
+                        "TurnResult",
+                        await alt.turn(
+                            messages, alt_model, tools=tools,
+                            temperature=temperature, max_tokens=max_tokens,
+                        ),
+                    )
+                    logger.warning("Fallback turn succeeded on provider %s", name)
+                    return result
+                except Exception:
+                    continue
+            raise
+
+    async def stream(
+        self,
+        messages: list[KMessage],
+        model: str | None = None,
+        *,
+        tools: list[ToolSpec] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream a kernel turn from the resolved provider.
+
+        Mid-stream cross-provider fallback is intentionally not attempted (events
+        already emitted cannot be retracted); use ``turn`` for fallback.
+        """
+        provider, resolved_model = self.resolve_provider(model)
+        async for ev in provider.stream_turn(
+            messages, resolved_model, tools=tools,
+            temperature=temperature, max_tokens=max_tokens,
+        ):
+            yield ev
+
     async def list_all_models(self) -> list[ModelInfo]:
         """List models from all registered providers."""
         all_models: list[ModelInfo] = []
@@ -191,6 +304,13 @@ def create_registry() -> ProviderRegistry:
         from app.providers.anthropic_provider import AnthropicProvider
 
         registry.register("anthropic", AnthropicProvider(api_key=anthropic_key))
+
+    # Google (Gemini) — register if API key is set
+    google_key = os.getenv("GOOGLE_API_KEY")
+    if google_key:
+        from app.providers.google_provider import GoogleProvider
+
+        registry.register("google", GoogleProvider(api_key=google_key))
 
     # Ollama — register if OLLAMA_BASE_URL is set (or default localhost)
     ollama_url = os.getenv("OLLAMA_BASE_URL")
@@ -252,6 +372,10 @@ async def create_user_registry(user_id: str) -> ProviderRegistry:
                 from app.providers.anthropic_provider import AnthropicProvider
 
                 registry.register("anthropic", AnthropicProvider(api_key=api_key), default=is_default)
+            elif provider_name == "google":
+                from app.providers.google_provider import GoogleProvider
+
+                registry.register("google", GoogleProvider(api_key=api_key, base_url=base_url), default=is_default)
             elif provider_name == "ollama":
                 from app.providers.ollama_provider import OllamaProvider
 

--- a/backend/tests/test_provider_kernel.py
+++ b/backend/tests/test_provider_kernel.py
@@ -1,0 +1,310 @@
+"""Phase 2 — provider adapters speak kernel.
+
+Exercises turn()/stream_turn() across OpenAI, Anthropic, Google, and Ollama with
+mocked transports (no live keys): the same two-tool conversation must yield
+structurally identical TurnResults, a full tool round trip must convert
+correctly, and a streaming tool call must surface the right StreamEvents.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.kernel.types import (
+    KMessage,
+    TextBlock,
+    TextDelta,
+    ToolResultBlock,
+    ToolSpec,
+    ToolUseBlock,
+    ToolUseDelta,
+    ToolUseStart,
+    TurnDone,
+    UsageEvent,
+)
+from app.providers.anthropic_provider import AnthropicProvider
+from app.providers.google_provider import GoogleProvider
+from app.providers.ollama_provider import OllamaProvider
+from app.providers.openai_provider import OpenAIProvider
+
+TWO_TOOLS = [
+    ToolSpec(name="get_weather", description="Weather", input_schema={"type": "object"}),
+    ToolSpec(name="get_time", description="Time", input_schema={"type": "object"}),
+]
+
+CONVO = [
+    KMessage(role="system", blocks=[TextBlock("You are helpful.")]),
+    KMessage(role="user", blocks=[TextBlock("Weather and time in Paris?")]),
+]
+
+
+# --- fake transport responses (two tool calls, usage 10/5) ---
+
+
+def _fake_openai_response():
+    def tool_call(cid, name, args):
+        return SimpleNamespace(
+            id=cid, type="function", function=SimpleNamespace(name=name, arguments=args)
+        )
+
+    message = SimpleNamespace(
+        content=None,
+        tool_calls=[
+            tool_call("c1", "get_weather", '{"city": "Paris"}'),
+            tool_call("c2", "get_time", '{"tz": "UTC"}'),
+        ],
+    )
+    return SimpleNamespace(
+        model="gpt-4o",
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+def _fake_anthropic_response():
+    return SimpleNamespace(
+        model="claude-sonnet-4-20250514",
+        content=[
+            SimpleNamespace(type="tool_use", id="c1", name="get_weather", input={"city": "Paris"}),
+            SimpleNamespace(type="tool_use", id="c2", name="get_time", input={"tz": "UTC"}),
+        ],
+        stop_reason="tool_use",
+        usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+    )
+
+
+def _fake_gemini_json():
+    return {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "get_weather", "args": {"city": "Paris"}}},
+                        {"functionCall": {"name": "get_time", "args": {"tz": "UTC"}}},
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 5},
+    }
+
+
+def _signature(turn):
+    """Structural fingerprint that ignores provider-specific ids/model/latency."""
+    tools = [
+        (b.name, b.input) for b in turn.blocks if isinstance(b, ToolUseBlock)
+    ]
+    return (
+        sorted(tools),
+        turn.stop_reason,
+        turn.usage.input_tokens,
+        turn.usage.output_tokens,
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_tool_conversation_is_structurally_identical_across_adapters():
+    openai = OpenAIProvider(api_key="x")
+    anthropic = AnthropicProvider(api_key="x")
+    google = GoogleProvider(api_key="x")
+    ollama = OllamaProvider(base_url="http://localhost:11434")
+
+    with (
+        patch.object(
+            openai.client.chat.completions, "create",
+            AsyncMock(return_value=_fake_openai_response()),
+        ),
+        patch.object(
+            anthropic.client.messages, "create",
+            AsyncMock(return_value=_fake_anthropic_response()),
+        ),
+        patch.object(google, "_generate", AsyncMock(return_value=_fake_gemini_json())),
+        patch.object(
+            ollama.client.chat.completions, "create",
+            AsyncMock(return_value=_fake_openai_response()),
+        ),
+    ):
+        turns = {
+            "openai": await openai.turn(CONVO, "gpt-4o", tools=TWO_TOOLS),
+            "anthropic": await anthropic.turn(CONVO, "claude-sonnet-4-20250514", tools=TWO_TOOLS),
+            "google": await google.turn(CONVO, "gemini-1.5-pro", tools=TWO_TOOLS),
+            # a non-carded ollama model so tools are not degraded
+            "ollama": await ollama.turn(CONVO, "llama3.1:70b-tools", tools=TWO_TOOLS),
+        }
+
+    signatures = {name: _signature(t) for name, t in turns.items()}
+    expected = (
+        [("get_time", {"tz": "UTC"}), ("get_weather", {"city": "Paris"})],
+        "tool_use",
+        10,
+        5,
+    )
+    for name, sig in signatures.items():
+        assert sig == expected, f"{name} diverged: {sig}"
+
+
+@pytest.mark.asyncio
+async def test_ollama_degrades_gracefully_when_model_lacks_tools():
+    # qwen2.5:7b-instruct is carded with tools=False.
+    ollama = OllamaProvider(base_url="http://localhost:11434")
+    create = AsyncMock(return_value=_fake_openai_response())
+    with patch.object(ollama.client.chat.completions, "create", create):
+        turn = await ollama.turn(CONVO, "qwen2.5:7b-instruct", tools=TWO_TOOLS)
+    assert turn.stop_reason == "error"
+    assert "does not support tool calling" in turn.text
+    create.assert_not_called()  # never a silent call that would drop the tools
+
+
+@pytest.mark.asyncio
+async def test_full_tool_round_trip_converts_messages():
+    # assistant tool_use -> tool result -> assistant final answer.
+    convo = [
+        KMessage(role="user", blocks=[TextBlock("Weather in Paris?")]),
+        KMessage(role="assistant", blocks=[ToolUseBlock(id="c1", name="get_weather", input={"city": "Paris"})]),
+        KMessage(role="tool", blocks=[ToolResultBlock(tool_use_id="c1", output="18C sunny")]),
+    ]
+    final = SimpleNamespace(
+        model="gpt-4o",
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="It is 18C and sunny in Paris.", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=20, completion_tokens=8),
+    )
+    openai = OpenAIProvider(api_key="x")
+    create = AsyncMock(return_value=final)
+    with patch.object(openai.client.chat.completions, "create", create):
+        turn = await openai.turn(convo, "gpt-4o", tools=TWO_TOOLS)
+
+    assert turn.text == "It is 18C and sunny in Paris."
+    assert turn.stop_reason == "end"
+    # the tool_use/tool_result messages became valid OpenAI wire shapes
+    sent = create.call_args.kwargs["messages"]
+    assert any(m.get("tool_calls") for m in sent)
+    assert any(m.get("role") == "tool" and m.get("tool_call_id") == "c1" for m in sent)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_tool_result_rides_in_user_turn():
+    from app.providers.kernel_bridge import kmessages_to_anthropic
+
+    convo = [
+        KMessage(role="assistant", blocks=[ToolUseBlock(id="c1", name="f", input={})]),
+        KMessage(role="tool", blocks=[ToolResultBlock(tool_use_id="c1", output="done")]),
+    ]
+    _system, msgs = kmessages_to_anthropic(convo)
+    assert msgs[0]["role"] == "assistant"
+    assert msgs[0]["content"][0]["type"] == "tool_use"
+    assert msgs[1]["role"] == "user"  # tool role has no Anthropic equivalent
+    assert msgs[1]["content"][0]["type"] == "tool_result"
+    assert msgs[1]["content"][0]["tool_use_id"] == "c1"
+
+
+# --- streaming tool call ---
+
+
+async def _fake_openai_stream():
+    def chunk(content=None, tool_calls=None, finish=None, usage=None):
+        delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+        choices = [] if usage and content is None and tool_calls is None and finish is None else [
+            SimpleNamespace(delta=delta, finish_reason=finish)
+        ]
+        return SimpleNamespace(choices=choices, usage=usage)
+
+    def tc(index, cid=None, name=None, args=None):
+        fn = SimpleNamespace(name=name, arguments=args)
+        return SimpleNamespace(index=index, id=cid, function=fn)
+
+    yield chunk(content="Let me check. ")
+    yield chunk(tool_calls=[tc(0, cid="c1", name="get_weather")])
+    yield chunk(tool_calls=[tc(0, args='{"city": ')])
+    yield chunk(tool_calls=[tc(0, args='"Paris"}')])
+    yield chunk(finish="tool_calls")
+    yield chunk(usage=SimpleNamespace(prompt_tokens=12, completion_tokens=6))
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_call_emits_events_and_assembles_turn():
+    openai = OpenAIProvider(api_key="x")
+    with patch.object(
+        openai.client.chat.completions, "create",
+        AsyncMock(return_value=_fake_openai_stream()),
+    ):
+        events = [
+            ev async for ev in openai.stream_turn(CONVO, "gpt-4o", tools=TWO_TOOLS)
+        ]
+
+    assert any(isinstance(e, TextDelta) for e in events)
+    starts = [e for e in events if isinstance(e, ToolUseStart)]
+    assert len(starts) == 1 and starts[0].name == "get_weather"
+    assert any(isinstance(e, ToolUseDelta) for e in events)
+    assert any(isinstance(e, UsageEvent) for e in events)
+
+    done = events[-1]
+    assert isinstance(done, TurnDone)
+    tool_blocks = [b for b in done.turn.blocks if isinstance(b, ToolUseBlock)]
+    assert tool_blocks[0].input == {"city": "Paris"}
+    assert done.turn.stop_reason == "tool_use"
+    assert done.turn.usage.output_tokens == 6
+
+
+# --- registry routing + fallback + shim ---
+
+
+@pytest.mark.asyncio
+async def test_registry_resolves_via_model_card_provider():
+    from app.providers.registry import ProviderRegistry
+
+    reg = ProviderRegistry()
+    anthropic = AnthropicProvider(api_key="x")
+    reg.register("anthropic", anthropic)
+    # gpt-4o-mini would prefix-route to openai, but no openai is registered;
+    # claude-sonnet-4 is carded to anthropic, which IS registered.
+    provider, model = reg.resolve_provider("claude-sonnet-4-20250514")
+    assert provider is anthropic
+    assert model == "claude-sonnet-4-20250514"
+
+
+@pytest.mark.asyncio
+async def test_registry_turn_no_fallback_on_client_error():
+    from app.providers.registry import FallbackPolicy, ProviderRegistry
+
+    reg = ProviderRegistry()
+    good = OpenAIProvider(api_key="x")
+    bad = AnthropicProvider(api_key="x")
+    reg.register("anthropic", bad, default=False)
+    reg.register("openai", good, default=True)
+
+    err = Exception("bad request")
+    err.status_code = 400  # type: ignore[attr-defined]
+    with (
+        patch.object(bad, "turn", AsyncMock(side_effect=err)),
+        patch.object(good, "turn", AsyncMock(return_value="should-not-be-used")),
+        pytest.raises(Exception, match="bad request"),
+    ):
+        await reg.turn(CONVO, "claude-sonnet-4-20250514",
+                       policy=FallbackPolicy(enabled=True, exclude_client_errors=True))
+
+
+@pytest.mark.asyncio
+async def test_turn_result_to_llm_response_shim():
+    from app.kernel.types import TurnResult, Usage
+    from app.providers.kernel_bridge import turn_result_to_llm_response
+
+    turn = TurnResult(
+        blocks=[TextBlock("Hello "), TextBlock("world")],
+        stop_reason="end",
+        usage=Usage(input_tokens=3, output_tokens=2),
+        model="gpt-4o",
+        provider="openai",
+    )
+    resp = turn_result_to_llm_response(turn)
+    assert resp.content == "Hello world"
+    assert resp.finish_reason == "stop"
+    assert (resp.input_tokens, resp.output_tokens) == (3, 2)


### PR DESCRIPTION
## Phase 2 of the Forge harness transformation (docs/harness-plan.md) — the critical path

Every provider now speaks the kernel: `turn(messages: list[KMessage], model, *, tools: list[ToolSpec]) -> TurnResult` and `stream_turn(...) -> AsyncIterator[StreamEvent]`, with full tool-call / tool-result / image fidelity. Legacy `complete()`/`stream_complete()`/`LLMResponse` are **unchanged** and kept as shims.

### What's here
- **`kernel_bridge.py`** — shared converters: ToolSpec→OpenAI/Anthropic tools, kernel→Anthropic messages (native `tool_use`/`tool_result` in the right turns, base64 images, tool role → user turn), the OpenAI-compatible turn/stream routines, stop-reason maps, and the `TurnResult`→`LLMResponse` shim.
- **Base defaults** — concrete `turn`/`stream_turn` on `LLMProvider` derived from `complete`/`stream_complete`, so every existing provider **and every test double** speaks kernel with no edits (this is why I chose defaults over abstract methods — abstract would have broken the hand-rolled `MockProvider`/`FailingProvider`/`FakeProvider`).
- **Native overrides** — OpenAI, Anthropic, Ollama, Generic. Ollama/Generic reuse the OpenAI-compatible path and **degrade gracefully** when a ModelCard says `tools=False` (clear error `TurnResult`, never a silent text-only call).
- **`google_provider.py`** — native Gemini over httpx REST (text, inline base64 images, function calling, streaming), registered on `GOOGLE_API_KEY` in both registry factories. Makes the README's Google claim real.
- **Registry** — `turn()`/`stream()`, **ModelCard-first `resolve_provider`** (models.json provider before legacy prefixes; additive fall-through), and `FallbackPolicy` (default **off**, **never retries 4xx**).

### Verification
- **Exit test**: the same two-tool conversation through OpenAI, Anthropic, Google, and Ollama (mocked transports) yields **structurally identical `TurnResult`s** (same tool names/inputs, stop_reason, usage). ✅
- Plus: graceful tools-degrade, full tool round-trip (tool_use→tool_result→final, verifying wire shapes), Anthropic tool-result-in-user-turn, streaming tool call (TextDelta/ToolUseStart/ToolUseDelta/UsageEvent/TurnDone), ModelCard routing, no-fallback-on-4xx, LLMResponse shim.
- Full backend suite: **804 passed, 23 skipped** (+8; **parity untouched and green**). `ruff`/`mypy` clean.

### Deferred (with rationale, per guardrails)
- Vision routing via `ModelCard.vision` and kernel `ImageBlock` production in `agent_executor._prepare_attachments` — the native providers already handle kernel `ImageBlock`s; wiring the *legacy* attachment path to them would change behavior on the LangChain path, so it lands with the native loop in **Phase 4**. `_VISION_MODEL_HINTS` stays (TODO(phase-8)).
- `complete()` is **not** rewritten to route through `turn()` (behavior-risk to heavily-tested paths); the `TurnResult`→`LLMResponse` shim is provided for new code.

### Exit criteria (met)
- [x] One integration test: identical two-tool conversation through OpenAI/Anthropic/Gemini/Ollama → structurally identical TurnResults
- [x] Parity suite green