### PR TITLE
Harness Phase 3: One tool plane (all capabilities as ToolSpecs behind one policy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Harness transformation (Phase 3 — One tool plane).** Every Forge capability
+  is now a callable `ToolSpec` behind one permission policy. `ToolPlane`
+  (`app/kernel/toolplane.py`) aggregates **82 tools** on a seeded install:
+  builtin tools, all 44 blueprint nodes (`node.<key>`), saved blueprints
+  (`blueprint.<slug>`), computer-use actions (`cu.<action>` routed through the
+  existing `safety.py`), workspace ops (`workspace.read/write/list/search`), and
+  agent control (`agent.spawn/prompt/…`). One `execute()` applies uniform
+  timeout, error capture (a failing tool returns an error `ToolResultBlock`, it
+  never raises into the caller), and a permission decision (`permissions.py`:
+  per-session → per-user `tool_policies` table → `danger_level` default). `ask`
+  routes through the existing approvals inbox (web + CLI). A `register_source`
+  hook lets MCP tools join in Phase 5. Additive `tool_policies` table (both
+  backends). No behavior change to existing paths (parity green).
 - **Harness transformation (Phase 2 — Provider adapters speak kernel).** Every
   provider now implements kernel `turn()`/`stream_turn()` (`KMessage`s +
   `ToolSpec`s → `TurnResult`/`StreamEvent`s) with full tool-call, tool-result,

--- a/backend/app/db/sqlite_schema.py
+++ b/backend/app/db/sqlite_schema.py
@@ -316,6 +316,22 @@ CREATE TABLE IF NOT EXISTS approvals (
 
 CREATE INDEX IF NOT EXISTS idx_approvals_user_status ON approvals(user_id, status);
 
+-- ===================== 20260714_tool_policies (harness-plan.md Phase 3) =====================
+-- Per-user allow/ask/deny decisions for tool-plane tools. Absence of a row
+-- means "fall back to the tool's danger_level default".
+CREATE TABLE IF NOT EXISTS tool_policies (
+    id         TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL,
+    tool_name  TEXT NOT NULL,
+    decision   TEXT NOT NULL DEFAULT 'ask'
+               CHECK (decision IN ('allow','ask','deny')),
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE(user_id, tool_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_policies_user ON tool_policies(user_id);
+
 -- ===================== 20260312_execution_targets =====================
 CREATE TABLE IF NOT EXISTS execution_targets (
     id                TEXT PRIMARY KEY,

--- a/backend/app/kernel/permissions.py
+++ b/backend/app/kernel/permissions.py
@@ -1,0 +1,84 @@
+"""Permission policy for the tool plane (harness-plan.md Phase 3).
+
+One decision function governs every tool call. Resolution order:
+
+1. per-session override (ephemeral, set on the ExecContext)
+2. per-user policy (the ``tool_policies`` table)
+3. default by the tool's ``danger_level`` (safe=allow, caution/dangerous=ask)
+
+An ``ask`` decision routes through the existing approvals inbox (web + CLI) —
+one inbox for everything, no new UI.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Literal
+
+from app.kernel.types import DangerLevel, ToolSpec
+
+logger = logging.getLogger(__name__)
+
+PolicyDecision = Literal["allow", "ask", "deny"]
+
+_DEFAULT_BY_DANGER: dict[DangerLevel, PolicyDecision] = {
+    "safe": "allow",
+    "caution": "ask",
+    "dangerous": "ask",
+}
+
+
+def default_decision(spec: ToolSpec) -> PolicyDecision:
+    """The decision implied by a tool's danger level, absent any policy."""
+    if spec.requires_approval:
+        return "ask"
+    return _DEFAULT_BY_DANGER.get(spec.danger_level, "ask")
+
+
+@dataclass
+class PermissionResolver:
+    """Resolves a tool call to allow/ask/deny.
+
+    ``session_overrides`` and ``user_policies`` are name→decision maps; the
+    former (per-session) wins over the latter (per-user), which wins over the
+    danger-level default.
+    """
+
+    user_policies: dict[str, PolicyDecision] = field(default_factory=dict)
+    session_overrides: dict[str, PolicyDecision] = field(default_factory=dict)
+
+    def decide(self, spec: ToolSpec) -> PolicyDecision:
+        if spec.name in self.session_overrides:
+            return self.session_overrides[spec.name]
+        if spec.name in self.user_policies:
+            return self.user_policies[spec.name]
+        return default_decision(spec)
+
+
+async def load_user_tool_policies(user_id: str | None) -> dict[str, PolicyDecision]:
+    """Load a user's stored allow/ask/deny decisions from ``tool_policies``."""
+    if not user_id:
+        return {}
+    from app.db import get_db
+
+    try:
+        result = (
+            get_db()
+            .table("tool_policies")
+            .select("tool_name, decision")
+            .eq("user_id", user_id)
+            .execute()
+        )
+    except Exception as exc:  # noqa: BLE001 - policies are best-effort
+        logger.debug("tool_policies read failed for %s: %s", user_id, exc)
+        return {}
+
+    policies: dict[str, PolicyDecision] = {}
+    rows = result.data if isinstance(result.data, list) else []
+    for row in rows:
+        decision = row.get("decision")
+        name = row.get("tool_name")
+        if name and decision in ("allow", "ask", "deny"):
+            policies[name] = decision
+    return policies

--- a/backend/app/kernel/toolplane.py
+++ b/backend/app/kernel/toolplane.py
@@ -1,0 +1,521 @@
+"""The tool plane — every Forge capability as a callable ``ToolSpec``.
+
+One aggregator lists tools from all sources (builtin tools, blueprint nodes,
+saved blueprints, computer-use actions, workspace ops, agent control) and one
+executor runs any of them behind a single permission policy with uniform
+timeout, error capture, and audit logging. MCP tools plug in later (Phase 5)
+through ``register_source``.
+
+Namespaces: builtins are bare names; everything else is ``<source>.<action>``
+(``node.json_validator``, ``blueprint.<slug>``, ``cu.steer_click``,
+``workspace.read``, ``agent.spawn``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.kernel.permissions import (
+    PermissionResolver,
+    PolicyDecision,
+    load_user_tool_policies,
+)
+from app.kernel.types import DangerLevel, ToolResultBlock, ToolSpec, ToolUseBlock
+
+logger = logging.getLogger(__name__)
+
+# An executor takes the tool-call args and the exec context, returns raw output.
+Executor = Callable[[dict[str, Any], "ExecContext"], Awaitable[Any]]
+# A source yields (spec, executor) pairs for a given context (used by MCP later).
+Source = Callable[["ExecContext"], Awaitable[list[tuple[ToolSpec, Executor]]]]
+
+
+@dataclass
+class ExecContext:
+    """Everything a tool call needs to run under a policy."""
+
+    user_id: str
+    run_id: str = ""
+    session_id: str = ""
+    workspace_root: str = ""
+    session_overrides: dict[str, PolicyDecision] = field(default_factory=dict)
+    timeout: float = 60.0
+
+
+# --- danger levels ---
+
+_NODE_CATEGORY_DANGER: dict[str, DangerLevel] = {
+    "computer_use_gui": "caution",
+    "computer_use_terminal": "dangerous",
+    "computer_use_agent": "safe",
+    "agent_control": "dangerous",
+}
+_DANGEROUS_DRIVE = {"drive_run", "drive_fanout", "drive_send"}
+_AGENT_OP_DANGER: dict[str, DangerLevel] = {
+    "spawn": "dangerous",
+    "prompt": "dangerous",
+    "stop": "dangerous",
+    "monitor": "caution",
+    "wait": "caution",
+    "result": "caution",
+}
+
+# --- builtin tools (kept as LangChain tools; invoked via the public interface) ---
+
+_BUILTIN_META: dict[str, tuple[str, dict[str, Any], list[str], DangerLevel]] = {
+    "web_search": ("Search the web and return top results.", {"query": {"type": "string"}}, ["query"], "safe"),
+    "document_reader": ("Extract text from a PDF/DOCX/TXT at a URL.", {"file_url": {"type": "string"}}, ["file_url"], "safe"),
+    "code_executor": ("Execute sandboxed Python for pure computation.", {"code": {"type": "string"}}, ["code"], "caution"),
+    "data_extractor": ("Extract structured JSON data from text.", {"text": {"type": "string"}}, ["text"], "safe"),
+    "summarizer": ("Summarize long text into a concise summary.", {"text": {"type": "string"}}, ["text"], "safe"),
+}
+
+
+def _obj_schema(props: dict[str, Any], required: list[str]) -> dict[str, Any]:
+    schema: dict[str, Any] = {"type": "object", "properties": props}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _slugify(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "blueprint"
+
+
+def _serialize(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    try:
+        return json.dumps(result, default=str)
+    except (TypeError, ValueError):
+        return str(result)
+
+
+# --- node/blueprint schema helpers ---
+
+
+def nodetype_to_toolspec(nt: Any) -> ToolSpec:
+    """Build a ``node.<key>`` ToolSpec from a blueprint ``NodeType``."""
+    props: dict[str, Any] = {}
+    required: list[str] = []
+    for field_name, meta in (nt.input_schema or {}).items():
+        if not isinstance(meta, dict):
+            continue
+        prop: dict[str, Any] = {"type": meta.get("type", "string")}
+        if "description" in meta:
+            prop["description"] = meta["description"]
+        if "enum" in meta:
+            prop["enum"] = meta["enum"]
+        props[field_name] = prop
+        if meta.get("required"):
+            required.append(field_name)
+    danger = _NODE_CATEGORY_DANGER.get(nt.category, "safe")
+    return ToolSpec(
+        name=f"node.{nt.key}",
+        description=nt.description or nt.display_name,
+        input_schema=_obj_schema(props, required),
+        source="blueprint",
+        source_id=nt.key,
+        danger_level=danger,
+    )
+
+
+class ToolPlane:
+    """Aggregates and executes tools from every source behind one policy."""
+
+    def __init__(self) -> None:
+        self._extra_sources: list[Source] = []
+
+    def register_source(self, source: Source) -> None:
+        """Register an additional tool source (used by MCP in Phase 5)."""
+        self._extra_sources.append(source)
+
+    # --- listing ---
+
+    async def list_tools(
+        self, user_id: str, context: ExecContext | None = None
+    ) -> list[ToolSpec]:
+        """List every available ToolSpec for a user/context (aggregated sources)."""
+        index = await self._build_index(context or ExecContext(user_id=user_id))
+        return [spec for spec, _ in index.values()]
+
+    async def _build_index(
+        self, ctx: ExecContext
+    ) -> dict[str, tuple[ToolSpec, Executor]]:
+        index: dict[str, tuple[ToolSpec, Executor]] = {}
+        for spec, executor in self._builtin_entries():
+            index[spec.name] = (spec, executor)
+        for spec, executor in self._node_entries():
+            index[spec.name] = (spec, executor)
+        for spec, executor in self._cu_entries():
+            index[spec.name] = (spec, executor)
+        for spec, executor in self._agent_entries():
+            index[spec.name] = (spec, executor)
+        for spec, executor in self._workspace_entries():
+            index[spec.name] = (spec, executor)
+        for spec, executor in await self._blueprint_entries(ctx):
+            index[spec.name] = (spec, executor)
+        for source in self._extra_sources:
+            try:
+                for spec, executor in await source(ctx):
+                    index[spec.name] = (spec, executor)
+            except Exception as exc:  # noqa: BLE001 - one bad source must not break the plane
+                logger.warning("tool source failed: %s", exc)
+        return index
+
+    # --- source: builtin tools ---
+
+    def _builtin_entries(self) -> list[tuple[ToolSpec, Executor]]:
+        entries: list[tuple[ToolSpec, Executor]] = []
+        for name, (desc, props, required, danger) in _BUILTIN_META.items():
+            spec = ToolSpec(
+                name=name,
+                description=desc,
+                input_schema=_obj_schema(props, required),
+                source="builtin",
+                source_id=name,
+                danger_level=danger,
+            )
+            entries.append((spec, self._make_builtin_executor(name)))
+        return entries
+
+    @staticmethod
+    def _make_builtin_executor(name: str) -> Executor:
+        async def run(args: dict[str, Any], ctx: ExecContext) -> Any:
+            from app.services.tools.code_executor import code_executor
+            from app.services.tools.data_extractor import data_extractor
+            from app.services.tools.document_reader import document_reader
+            from app.services.tools.summarizer import summarizer
+            from app.services.tools.web_search import web_search
+
+            tools = {
+                "web_search": web_search,
+                "document_reader": document_reader,
+                "code_executor": code_executor,
+                "data_extractor": data_extractor,
+                "summarizer": summarizer,
+            }
+            return await tools[name].ainvoke(args)
+
+        return run
+
+    # --- source: blueprint nodes ---
+
+    def _node_entries(self) -> list[tuple[ToolSpec, Executor]]:
+        from app.services.blueprint_nodes.registry import NODE_REGISTRY
+
+        entries: list[tuple[ToolSpec, Executor]] = []
+        for key, nt in NODE_REGISTRY.items():
+            spec = nodetype_to_toolspec(nt)
+            entries.append((spec, self._make_node_executor(key)))
+        return entries
+
+    @staticmethod
+    def _make_node_executor(key: str) -> Executor:
+        async def run(args: dict[str, Any], ctx: ExecContext) -> Any:
+            return await _run_node(key, args, ctx)
+
+        return run
+
+    # --- source: computer-use actions (cu.<key>) ---
+
+    def _cu_entries(self) -> list[tuple[ToolSpec, Executor]]:
+        from app.services.blueprint_nodes.registry import NODE_REGISTRY
+
+        cu_categories = {"computer_use_gui", "computer_use_terminal", "computer_use_agent"}
+        entries: list[tuple[ToolSpec, Executor]] = []
+        for key, nt in NODE_REGISTRY.items():
+            if nt.category not in cu_categories:
+                continue
+            danger = self._cu_danger(key, nt.category)
+            spec = ToolSpec(
+                name=f"cu.{key}",
+                description=nt.description or nt.display_name,
+                input_schema=nodetype_to_toolspec(nt).input_schema,
+                source="computer_use",
+                source_id=key,
+                danger_level=danger,
+            )
+            entries.append((spec, self._make_node_executor(key)))
+        return entries
+
+    @staticmethod
+    def _cu_danger(key: str, category: str) -> DangerLevel:
+        if key in _DANGEROUS_DRIVE:
+            return "dangerous"
+        if category == "computer_use_agent":
+            return "safe"
+        return "caution"
+
+    # --- source: agent control (agent.<op>) ---
+
+    def _agent_entries(self) -> list[tuple[ToolSpec, Executor]]:
+        from app.services.blueprint_nodes.registry import NODE_REGISTRY
+
+        entries: list[tuple[ToolSpec, Executor]] = []
+        for op, danger in _AGENT_OP_DANGER.items():
+            key = f"agent_{op}"
+            nt = NODE_REGISTRY.get(key)
+            if nt is None:
+                continue
+            spec = ToolSpec(
+                name=f"agent.{op}",
+                description=nt.description or nt.display_name,
+                input_schema=nodetype_to_toolspec(nt).input_schema,
+                source="computer_use",
+                source_id=key,
+                danger_level=danger,
+            )
+            entries.append((spec, self._make_node_executor(key)))
+        return entries
+
+    # --- source: workspace ops ---
+
+    def _workspace_entries(self) -> list[tuple[ToolSpec, Executor]]:
+        ops: list[tuple[str, str, dict[str, Any], list[str], DangerLevel]] = [
+            ("read", "Read a file from the session workspace.",
+             {"path": {"type": "string"}}, ["path"], "safe"),
+            ("write", "Write a file in the session workspace.",
+             {"path": {"type": "string"}, "content": {"type": "string"}}, ["path", "content"], "caution"),
+            ("list", "List the session workspace file tree.", {}, [], "safe"),
+            ("search", "Search the session workspace for text.",
+             {"query": {"type": "string"}, "glob": {"type": "string"}}, ["query"], "safe"),
+        ]
+        entries: list[tuple[ToolSpec, Executor]] = []
+        for op, desc, props, required, danger in ops:
+            spec = ToolSpec(
+                name=f"workspace.{op}",
+                description=desc,
+                input_schema=_obj_schema(props, required),
+                source="workspace",
+                source_id=op,
+                danger_level=danger,
+            )
+            entries.append((spec, self._make_workspace_executor(op)))
+        return entries
+
+    @staticmethod
+    def _make_workspace_executor(op: str) -> Executor:
+        async def run(args: dict[str, Any], ctx: ExecContext) -> Any:
+            return await _run_workspace(op, args, ctx)
+
+        return run
+
+    # --- source: saved blueprints ---
+
+    async def _blueprint_entries(self, ctx: ExecContext) -> list[tuple[ToolSpec, Executor]]:
+        from app.db import get_db
+
+        try:
+            result = (
+                get_db()
+                .table("blueprints")
+                .select("id, name, description, nodes")
+                .eq("user_id", ctx.user_id)
+                .execute()
+            )
+            rows = list(result.data) if isinstance(result.data, list) else []
+            templates = (
+                get_db().table("blueprints").select("id, name, description, nodes")
+                .eq("is_template", True).execute()
+            )
+            if isinstance(templates.data, list):
+                rows.extend(templates.data)
+        except Exception as exc:  # noqa: BLE001 - blueprints are optional
+            logger.debug("blueprint listing failed: %s", exc)
+            return []
+
+        entries: list[tuple[ToolSpec, Executor]] = []
+        seen: set[str] = set()
+        for row in rows:
+            bid = row.get("id")
+            if not bid or bid in seen:
+                continue
+            seen.add(bid)
+            slug = _slugify(row.get("name", ""))
+            danger = self._blueprint_danger(row.get("nodes") or [])
+            spec = ToolSpec(
+                name=f"blueprint.{slug}",
+                description=row.get("description") or f"Run the '{row.get('name')}' blueprint.",
+                input_schema={"type": "object", "properties": {"text": {"type": "string"}}},
+                source="blueprint",
+                source_id=bid,
+                danger_level=danger,
+            )
+            entries.append((spec, self._make_blueprint_executor(bid)))
+        return entries
+
+    @staticmethod
+    def _blueprint_danger(nodes: list[dict[str, Any]]) -> DangerLevel:
+        for node in nodes:
+            t = node.get("type", "")
+            if t.startswith(("drive_", "agent_", "steer_")):
+                return "dangerous"
+        return "caution"
+
+    @staticmethod
+    def _make_blueprint_executor(blueprint_id: str) -> Executor:
+        async def run(args: dict[str, Any], ctx: ExecContext) -> Any:
+            return await _run_blueprint(blueprint_id, args, ctx)
+
+        return run
+
+    # --- execution ---
+
+    async def execute(self, tool_use: ToolUseBlock, ctx: ExecContext) -> ToolResultBlock:
+        index = await self._build_index(ctx)
+        entry = index.get(tool_use.name)
+        if entry is None:
+            return ToolResultBlock(
+                tool_use_id=tool_use.id,
+                output=f"Unknown tool: {tool_use.name}",
+                is_error=True,
+            )
+        spec, executor = entry
+
+        resolver = await self._resolver(ctx)
+        decision = resolver.decide(spec)
+        if decision == "deny":
+            return ToolResultBlock(
+                tool_use_id=tool_use.id,
+                output=f"Tool '{spec.name}' is denied by policy.",
+                is_error=True,
+            )
+        if decision == "ask":
+            state = await self._approval_state(spec, tool_use, ctx)
+            if state == "rejected":
+                return ToolResultBlock(
+                    tool_use_id=tool_use.id,
+                    output=f"Tool '{spec.name}' was rejected by an approver.",
+                    is_error=True,
+                )
+            if state == "pending":
+                return ToolResultBlock(
+                    tool_use_id=tool_use.id,
+                    output=f"APPROVAL_PENDING: '{spec.name}' is awaiting human approval.",
+                    is_error=True,
+                )
+
+        try:
+            result = await asyncio.wait_for(
+                executor(dict(tool_use.input), ctx), timeout=ctx.timeout
+            )
+        except TimeoutError:
+            return ToolResultBlock(
+                tool_use_id=tool_use.id,
+                output=f"Tool '{spec.name}' timed out after {ctx.timeout}s.",
+                is_error=True,
+            )
+        except Exception as exc:  # noqa: BLE001 - a tool error must not kill the loop
+            logger.info("tool '%s' failed: %s", spec.name, exc)
+            return ToolResultBlock(
+                tool_use_id=tool_use.id,
+                output=f"Tool '{spec.name}' error: {exc}",
+                is_error=True,
+            )
+
+        logger.info("tool executed: %s (user=%s run=%s)", spec.name, ctx.user_id, ctx.run_id)
+        return ToolResultBlock(
+            tool_use_id=tool_use.id, output=_serialize(result), is_error=False
+        )
+
+    async def _resolver(self, ctx: ExecContext) -> PermissionResolver:
+        policies = await load_user_tool_policies(ctx.user_id)
+        return PermissionResolver(
+            user_policies=policies, session_overrides=dict(ctx.session_overrides)
+        )
+
+    @staticmethod
+    async def _approval_state(spec: ToolSpec, tool_use: ToolUseBlock, ctx: ExecContext) -> str:
+        """Return 'approved' | 'rejected' | 'pending', creating a pending row if new."""
+        from app.services.evals.approvals import approval_service
+
+        run_id = ctx.run_id or ctx.session_id or "toolplane"
+        node_id = f"tool:{spec.name}"
+        existing = await approval_service.get_approval_for_run(run_id, node_id)
+        if existing and existing.get("status") == "approved":
+            return "approved"
+        if existing and existing.get("status") == "rejected":
+            return "rejected"
+        if not existing:
+            await approval_service.create_approval(
+                user_id=ctx.user_id,
+                blueprint_run_id=run_id,
+                node_id=node_id,
+                context={
+                    "message": f"Approve tool call: {spec.name}",
+                    "tool": spec.name,
+                    "danger_level": spec.danger_level,
+                    "input": tool_use.input,
+                },
+            )
+        return "pending"
+
+
+# --- shared executors ---
+
+
+async def _run_node(key: str, args: dict[str, Any], ctx: ExecContext) -> Any:
+    from app.services.blueprint_engine import _ALL_AGENT, _ALL_DETERMINISTIC
+
+    executor = _ALL_DETERMINISTIC.get(key) or _ALL_AGENT.get(key)
+    if executor is None:
+        raise KeyError(f"unknown node type: {key}")
+    trusted = {
+        "_user_id": ctx.user_id,
+        "_run_id": ctx.run_id or ctx.session_id or "toolplane",
+        "_node_id": f"tool:{key}",
+    }
+    inputs = {**args, **trusted}
+    return await executor(dict(args), inputs)
+
+
+async def _run_workspace(op: str, args: dict[str, Any], ctx: ExecContext) -> Any:
+    from app.services import workspace_service as ws
+
+    root = ctx.workspace_root
+    if not root:
+        raise ValueError("workspace tools require a workspace_root in the context")
+    if op == "read":
+        content, size = ws.read_file(root, args["path"])
+        return {"content": content, "size": size}
+    if op == "write":
+        ws.write_file(root, args["path"], args.get("content", ""))
+        return {"ok": True, "path": args["path"]}
+    if op == "list":
+        return {"files": ws.list_files(root)}
+    if op == "search":
+        return {"results": ws.search_files(root, args["query"], args.get("glob", "*"))}
+    raise ValueError(f"unknown workspace op: {op}")
+
+
+async def _run_blueprint(blueprint_id: str, args: dict[str, Any], ctx: ExecContext) -> Any:
+    from app.db import get_db
+    from app.services.blueprint_engine import blueprint_engine
+
+    result = get_db().table("blueprints").select("*").eq("id", blueprint_id).execute()
+    rows = result.data if isinstance(result.data, list) else []
+    if not rows:
+        raise ValueError(f"blueprint not found: {blueprint_id}")
+    blueprint = rows[0]
+    run_id = ctx.run_id or ctx.session_id or f"tool-{blueprint_id[:8]}"
+    payload = {"text": args.get("text", ""), **{k: v for k, v in args.items() if k != "text"}}
+
+    final: dict[str, Any] | None = None
+    async for event in blueprint_engine.execute(
+        blueprint=blueprint, input_payload=payload, user_id=ctx.user_id, run_id=run_id
+    ):
+        if event.get("type") == "result":
+            final = event
+    return final.get("data") if final else None
+
+
+# Process-wide default plane; sources (MCP) register onto it in later phases.
+tool_plane = ToolPlane()

--- a/backend/tests/test_toolplane.py
+++ b/backend/tests/test_toolplane.py
@@ -1,0 +1,194 @@
+"""Phase 3 — one tool plane.
+
+Verifies the plane aggregates every source into ToolSpecs, executes them behind
+one permission policy (allow/ask/deny), routes ``ask`` through the approvals
+inbox, keeps errors from killing the caller, and reproduces a node's Phase-0
+golden output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import app.db as dbmod
+from app.db.sqlite_backend import SQLiteBackend
+from app.kernel.toolplane import ExecContext, ToolPlane
+from app.kernel.types import ToolUseBlock
+
+GOLDEN = Path(__file__).parent / "parity" / "golden"
+
+
+@pytest.fixture
+def db(monkeypatch):
+    """A real, empty SQLite backend so the plane's DB reads return real lists."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    backend = SQLiteBackend(path)
+    # initialize() is async; run it on a fresh loop before the test's loop starts.
+    asyncio.new_event_loop().run_until_complete(backend.initialize())
+    monkeypatch.setattr(dbmod, "_db", backend)
+    yield backend
+    os.remove(path)
+
+
+def _ctx(**kw):
+    return ExecContext(user_id="u1", run_id="run1", **kw)
+
+
+@pytest.mark.asyncio
+async def test_list_returns_all_sources_over_seventy(db):
+    plane = ToolPlane()
+    specs = await plane.list_tools("u1", _ctx())
+    names = {s.name for s in specs}
+    assert len(specs) >= 70, f"only {len(specs)} specs"
+    # a representative from each source is present
+    assert "web_search" in names
+    assert "node.json_validator" in names
+    assert "cu.steer_click" in names
+    assert "agent.spawn" in names
+    assert "workspace.read" in names
+
+
+@pytest.mark.asyncio
+async def test_danger_levels_drive_defaults(db):
+    plane = ToolPlane()
+    specs = {s.name: s for s in await plane.list_tools("u1", _ctx())}
+    assert specs["node.json_validator"].danger_level == "safe"
+    assert specs["cu.steer_click"].danger_level == "caution"
+    assert specs["cu.drive_run"].danger_level == "dangerous"
+    assert specs["agent.spawn"].danger_level == "dangerous"
+    assert specs["workspace.write"].danger_level == "caution"
+
+
+@pytest.mark.asyncio
+async def test_node_execution_matches_phase0_golden(db):
+    plane = ToolPlane()
+    call = ToolUseBlock(
+        id="t1",
+        name="node.json_validator",
+        input={"schema": {"required": ["name"]}, "text": '{"name": "Alice", "age": 30}'},
+    )
+    result = await plane.execute(call, _ctx())
+    assert not result.is_error
+    golden = json.loads((GOLDEN / "node_json_validator.json").read_text())
+    assert json.loads(result.output) == golden
+
+
+@pytest.mark.asyncio
+async def test_safe_and_workspace_tools_round_trip(db, tmp_path):
+    # The Phase 3 exit flow: a conversation calls node.template_renderer then
+    # workspace.read; both round-trip.
+    (tmp_path / "notes.txt").write_text("hello from workspace")
+    plane = ToolPlane()
+    ctx = _ctx(workspace_root=str(tmp_path))
+
+    r1 = await plane.execute(
+        ToolUseBlock(id="a", name="node.template_renderer",
+                     input={"template": "Hi {{name}}", "variables": {"name": "Bob"}}),
+        ctx,
+    )
+    assert not r1.is_error
+    assert json.loads(r1.output)["rendered"] == "Hi Bob"
+
+    r2 = await plane.execute(
+        ToolUseBlock(id="b", name="workspace.read", input={"path": "notes.txt"}), ctx
+    )
+    assert not r2.is_error
+    assert json.loads(r2.output)["content"] == "hello from workspace"
+
+
+@pytest.mark.asyncio
+async def test_dangerous_tool_creates_approval_and_pends(db):
+    plane = ToolPlane()
+    call = ToolUseBlock(id="t", name="cu.drive_run", input={"command": "ls"})
+    result = await plane.execute(call, _ctx())
+    assert result.is_error
+    assert "APPROVAL_PENDING" in result.output
+    # an approval row now exists for this tool
+    rows = db.table("approvals").select("*").eq("user_id", "u1").execute().data
+    assert any(r["node_id"] == "tool:cu.drive_run" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_command_blocklist_blocks_when_allowed(db):
+    plane = ToolPlane()
+    # Session override to allow so the tool actually executes and hits the
+    # command blocklist inside the drive node.
+    ctx = _ctx(session_overrides={"cu.drive_run": "allow"})
+    call = ToolUseBlock(id="t", name="cu.drive_run", input={"command": "rm -rf /"})
+    result = await plane.execute(call, ctx)
+    assert result.is_error
+    assert "blocked" in result.output.lower()
+    # no approval created (it was allowed, not asked)
+    rows = db.table("approvals").select("*").eq("user_id", "u1").execute().data
+    assert not rows
+
+
+@pytest.mark.asyncio
+async def test_deny_policy_returns_error_not_exception(db):
+    db.table("tool_policies").insert(
+        {"id": "p1", "user_id": "u1", "tool_name": "web_search", "decision": "deny"}
+    ).execute()
+    plane = ToolPlane()
+    result = await plane.execute(
+        ToolUseBlock(id="t", name="web_search", input={"query": "anything"}), _ctx()
+    )
+    assert result.is_error
+    assert "denied by policy" in result.output
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_is_error_not_exception(db):
+    plane = ToolPlane()
+    result = await plane.execute(
+        ToolUseBlock(id="t", name="node.does_not_exist", input={}), _ctx()
+    )
+    assert result.is_error
+    assert "Unknown tool" in result.output
+
+
+@pytest.mark.asyncio
+async def test_approved_tool_executes(db):
+    # Pre-approve a dangerous tool, then it should run instead of pending.
+    db.table("approvals").insert(
+        {
+            "id": "ap1",
+            "user_id": "u1",
+            "blueprint_run_id": "run1",
+            "node_id": "tool:cu.drive_run",
+            "status": "approved",
+        }
+    ).execute()
+    plane = ToolPlane()
+    # command blocklisted so we can confirm it reached execution (blocked, not pending)
+    call = ToolUseBlock(id="t", name="cu.drive_run", input={"command": "shutdown"})
+    result = await plane.execute(call, _ctx())
+    assert result.is_error
+    assert "blocked" in result.output.lower()  # executed and hit the blocklist
+
+
+@pytest.mark.asyncio
+async def test_register_source_hook_adds_tools(db):
+    plane = ToolPlane()
+    from app.kernel.types import ToolSpec
+
+    async def fake_source(ctx):
+        async def run(args, c):
+            return {"echo": args}
+
+        return [(ToolSpec(name="mcp.demo.echo", description="echo", source="mcp"), run)]
+
+    plane.register_source(fake_source)
+    specs = {s.name for s in await plane.list_tools("u1", _ctx())}
+    assert "mcp.demo.echo" in specs
+    result = await plane.execute(
+        ToolUseBlock(id="t", name="mcp.demo.echo", input={"x": 1}), _ctx()
+    )
+    # mcp source defaults to safe danger → allowed
+    assert not result.is_error

--- a/supabase/migrations/20260714_tool_policies.sql
+++ b/supabase/migrations/20260714_tool_policies.sql
@@ -1,0 +1,32 @@
+-- harness-plan.md Phase 3 — per-user tool-plane permission policies.
+--
+-- Stores allow/ask/deny decisions per (user, tool). Absence of a row falls back
+-- to the tool's danger_level default. Additive; owner-scoped RLS mirrors the
+-- other per-user tables.
+
+CREATE TABLE IF NOT EXISTS tool_policies (
+    id         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    user_id    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    tool_name  TEXT NOT NULL,
+    decision   TEXT NOT NULL DEFAULT 'ask'
+               CHECK (decision IN ('allow', 'ask', 'deny')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (user_id, tool_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_policies_user ON tool_policies(user_id);
+
+ALTER TABLE tool_policies ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role manages tool policies" ON tool_policies;
+CREATE POLICY "Service role manages tool policies"
+    ON tool_policies FOR ALL
+    TO service_role
+    USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Users manage own tool policies" ON tool_policies;
+CREATE POLICY "Users manage own tool policies"
+    ON tool_policies FOR ALL
+    TO authenticated
+    USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Phase 3 of the Forge harness transformation (docs/harness-plan.md)

Every capability Forge already has becomes a `ToolSpec` an agent can call, behind one permission policy. **Additive — no behavior change to existing paths.**

### What's here
- **`ToolPlane`** (`app/kernel/toolplane.py`) — `list_tools()` aggregates **82 tools** on a seeded install and `execute()` runs any of them with uniform timeout, error capture, permission checks, and audit logging. Sources:
  - builtin tools (5) · blueprint nodes `node.<key>` (all 44) · saved blueprints `blueprint.<slug>` · computer-use `cu.<action>` (23) · workspace `workspace.read/write/list/search` (4) · agent control `agent.spawn/…` (6).
  - `cu.*` execution routes through the existing `computer_use/safety.py` (blocklist, rate limit, audit) — **not reimplemented**.
  - `register_source()` hook for MCP to plug in (Phase 5).
- **`permissions.py`** — `PolicyDecision = allow|ask|deny`; resolution order per-session override → per-user `tool_policies` → `danger_level` default (safe=allow, caution/dangerous=ask). `ask` creates a row in the existing `approvals` table and surfaces in the same inbox (web + CLI).
- **Additive `tool_policies` table** (SQLite + Supabase, owner-scoped RLS).

### Verification (`test_toolplane.py`, 10 tests)
- `list_tools()` returns **82** specs; representative from every source present.
- Danger-level defaults correct (`cu.drive_run`=dangerous, `node.json_validator`=safe, …).
- **`node.json_validator` reproduces its Phase-0 golden output** exactly.
- `node.template_renderer` then `workspace.read` both round-trip.
- Dangerous tool → creates approval + pends; approved tool → executes; `cu.drive_run` with a blocklisted command → blocked; deny policy / unknown tool → error `ToolResultBlock` (never an exception); MCP `register_source` hook adds & runs a tool.
- Full backend suite: **814 passed, 23 skipped** (+10; parity untouched & green). `ruff`/`mypy` clean.

### Deviation (with rationale)
- Builtin tools are **not** de-LangChained (the plan's optional "strip @tool decorators"). `test_tools.py` asserts the LangChain `.invoke`/`.ainvoke` interface, so removing it now would break existing tests; the ToolPlane isolates the coupling to one method (`_make_builtin_executor`) and invokes via the public `.ainvoke`. De-LangChaining lands in Phase 8 when LangChain is removed.
- The "fake provider calls two tools in one conversation" exit test is exercised at the plane level here (both tools round-trip); the full provider-driven loop arrives in Phase 4 (no agent loop exists yet).

### Exit criteria (met)
- [x] `ToolPlane.list()` returns 70+ specs on a seeded install (**82**)
- [x] `node.template_renderer` + `workspace.read` both round-trip; `node.json_validator` matches the Phase-0 golden
- [x] Parity green