### PR TITLE
Harness Phase 4: Forge-native agent loop (kernel loop behind FORGE_NATIVE_LOOP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Harness transformation (Phase 4 — Forge-native agent loop).** A
+  provider-neutral, tool-plane-driven, streamed agent loop
+  (`app/kernel/loop.py`) behind `FORGE_NATIVE_LOOP` (default off). `AgentRunner`
+  runs it when the flag is on, emitting the **identical** legacy `step`/`token`
+  SSE subsequence plus rich `tool_use`/`tool_result`/`thinking`/`usage` events;
+  tools resolve to ToolPlane `ToolSpec`s instead of the LangChain registry.
+  Observers are ported: time-travel records kernel `model_turn`/`tool_call`
+  events (compatible payloads), and trace spans, heartbeats, and token usage
+  write as before. Includes a token/wall-clock `Budget` and a max-iterations
+  cap. The runs SSE endpoint forwards the new events; the runs view renders them
+  as tool cards. Legacy path unchanged (parity green).
 - **Harness transformation (Phase 3 — One tool plane).** Every Forge capability
   is now a callable `ToolSpec` behind one permission policy. `ToolPlane`
   (`app/kernel/toolplane.py`) aggregates **82 tools** on a seeded install:

--- a/backend/app/kernel/loop.py
+++ b/backend/app/kernel/loop.py
@@ -1,0 +1,117 @@
+"""The Forge-native agent loop (harness-plan.md Phase 4).
+
+Provider-neutral, tool-plane-driven, streamed. One kernel turn runs on the
+registry; if it stops to call tools, the plane executes them under policy, the
+results are appended, and the loop continues until the model stops or a budget
+is hit. Cancellation propagates through the async generator.
+
+The loop is observer-agnostic: pass a ``recorder`` to capture time-travel events
+and a ``budget`` to bound tokens/wall-clock. It yields the provider's
+``StreamEvent``s plus a ``ToolExecuted`` marker per tool call so callers can
+render rich progress; the terminal ``TurnDone`` of each turn carries the full
+``TurnResult``.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+
+from app.kernel.types import (
+    KMessage,
+    StreamEvent,
+    ToolResultBlock,
+    ToolSpec,
+    ToolUseBlock,
+    TurnDone,
+    TurnResult,
+)
+
+
+@dataclass
+class Budget:
+    """Bounds a run's tokens and wall-clock. ``None`` limits are unbounded."""
+
+    max_tokens: int | None = None
+    max_seconds: float | None = None
+    _started: float = field(default_factory=time.monotonic)
+    _tokens: int = 0
+
+    def add_usage(self, input_tokens: int, output_tokens: int) -> None:
+        self._tokens += input_tokens + output_tokens
+
+    @property
+    def tokens_spent(self) -> int:
+        return self._tokens
+
+    def exceeded(self) -> bool:
+        if self.max_tokens is not None and self._tokens >= self.max_tokens:
+            return True
+        if self.max_seconds is not None:
+            return (time.monotonic() - self._started) >= self.max_seconds
+        return False
+
+
+@dataclass
+class ToolExecuted:
+    """A completed tool call — yielded by the loop after the plane runs it."""
+
+    tool_use: ToolUseBlock
+    result: ToolResultBlock
+    kind: str = field(default="tool_executed", init=False)
+
+
+LoopEvent = StreamEvent | ToolExecuted
+
+
+async def run_agent_turn(
+    messages: list[KMessage],
+    tools: list[ToolSpec] | None,
+    model: str | None,
+    *,
+    registry: object,
+    plane: object,
+    ctx: object,
+    recorder: object | None = None,
+    budget: Budget | None = None,
+    max_iterations: int = 12,
+    step: int = 0,
+) -> AsyncIterator[LoopEvent]:
+    """Run the kernel agent loop, mutating ``messages`` in place as it goes.
+
+    Yields the provider stream events plus a ``ToolExecuted`` per tool call.
+    Stops when a turn does not request tools, ``max_iterations`` is reached, or
+    the ``budget`` is exhausted.
+    """
+    for _ in range(max_iterations):
+        turn: TurnResult | None = None
+        async for ev in registry.stream(messages, model, tools=tools):  # type: ignore[attr-defined]
+            if isinstance(ev, TurnDone):
+                turn = ev.turn
+            yield ev
+
+        if turn is None:
+            return
+
+        if recorder is not None:
+            recorder.model_turn(step, turn)  # type: ignore[attr-defined]
+        if budget is not None:
+            budget.add_usage(turn.usage.input_tokens, turn.usage.output_tokens)
+
+        if turn.stop_reason != "tool_use":
+            return
+
+        # Record the assistant turn, then execute each requested tool.
+        messages.append(KMessage(role="assistant", blocks=list(turn.blocks)))
+        results: list[ToolResultBlock] = []
+        for tool_use in turn.tool_calls:
+            result = await plane.execute(tool_use, ctx)  # type: ignore[attr-defined]
+            if recorder is not None:
+                recorder.tool_call_kernel(step, tool_use, result)  # type: ignore[attr-defined]
+            results.append(result)
+            yield ToolExecuted(tool_use=tool_use, result=result)
+        messages.append(KMessage(role="tool", blocks=list(results)))
+
+        if budget is not None and budget.exceeded():
+            return

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -149,6 +149,12 @@ async def run_agent(
                 elif event.get("type") == "tool_call":
                     yield f"data: {json.dumps({'type': 'tool_call', 'data': event})}\n\n"
 
+                elif event.get("type") in ("tool_use", "tool_result", "thinking", "usage"):
+                    # Rich kernel-loop events (harness-plan.md Phase 4). Forwarded
+                    # verbatim; the frontend renders them when present, ignores
+                    # them otherwise.
+                    yield f"data: {json.dumps({'type': event['type'], 'data': event})}\n\n"
+
                 total_tokens += event.get("tokens", 0)
 
             duration_ms = int((time.time() - start_time) * 1000)

--- a/backend/app/services/agent_executor.py
+++ b/backend/app/services/agent_executor.py
@@ -128,6 +128,196 @@ class AgentRunner:
                 mcp_tools.append(name)
         return lc_tools, mcp_tools
 
+    async def _resolve_tools_native(self, tool_names: list[str], user_id: str | None):
+        """Map tool-name strings to ToolPlane ToolSpecs (kernel loop, Phase 4).
+
+        MCP names pass through when the plane has them registered (Phase 5);
+        unknown names are dropped with a debug log rather than failing the run.
+        """
+        from app.kernel.toolplane import ExecContext, tool_plane
+
+        if not tool_names:
+            return []
+        specs = await tool_plane.list_tools(
+            user_id or "", ExecContext(user_id=user_id or "")
+        )
+        by_name = {s.name: s for s in specs}
+        resolved = []
+        for name in tool_names:
+            spec = by_name.get(name)
+            if spec is not None:
+                resolved.append(spec)
+            else:
+                logger.debug("native loop: tool %s not found in plane", name)
+        return resolved
+
+    async def _execute_native(
+        self,
+        agent_config: dict,
+        user_input: str,
+        *,
+        heartbeat_id: str | None = None,
+        run_id: str | None = None,
+        user_id: str | None = None,
+        attachments: list[dict] | None = None,
+    ) -> AsyncIterator[dict]:
+        """Kernel-loop implementation of execute() — see execute() for the flag."""
+        from app.kernel.loop import Budget, ToolExecuted, run_agent_turn
+        from app.kernel.toolplane import ExecContext, tool_plane
+        from app.kernel.types import (
+            KMessage,
+            TextBlock,
+            TextDelta,
+            ThinkingDelta,
+            ToolUseStart,
+            TurnDone,
+            UsageEvent,
+        )
+        from app.providers.registry import create_user_registry, provider_registry
+        from app.services.heartbeat import heartbeat_service
+        from app.services.observability.trace_service import trace_service
+        from app.services.tailoring import load_custom_instructions, prepend_about
+
+        uid = user_id or self.user_id
+        system_prompt = prepend_about(
+            agent_config.get("system_prompt", ""), load_custom_instructions(uid)
+        )
+        tool_names = agent_config.get("tools", [])
+        workflow_steps = agent_config.get("workflow_steps") or [
+            "Process the user's input according to your instructions."
+        ]
+        agent_id = agent_config.get("id")
+        model = agent_config.get("model") or self.model
+
+        doc_context, image_blocks, notes = await self._prepare_attachments(attachments, model)
+        registry = await create_user_registry(uid) if uid else provider_registry
+        specs = await self._resolve_tools_native(tool_names, uid)
+        ctx = ExecContext(
+            user_id=uid or "",
+            run_id=run_id or "",
+            workspace_root=agent_config.get("workspace_root", ""),
+        )
+
+        if heartbeat_id:
+            heartbeat_service.update(heartbeat_id, state="running", current_step=0)
+        self._current_step = 0
+        self.recorder.run_start(
+            agent_id=agent_id, user_input=user_input, model=model, attachments=attachments
+        )
+
+        yield {"type": "step", "content": f"Starting agent: {agent_config.get('name', 'Unnamed')}", "tokens": 0}
+        for note in notes:
+            yield {"type": "step", "content": note, "tokens": 0}
+
+        accumulated_context = doc_context
+        if notes:
+            accumulated_context = (accumulated_context + "\n\n" + "\n".join(notes)).strip()
+        total_tokens = 0
+        budget = Budget()
+
+        for i, step in enumerate(workflow_steps, 1):
+            self._current_step = i
+            self.recorder.step_boundary(i, step)
+            yield {"type": "step", "content": f"Step {i}: {step}", "tokens": 0}
+            if heartbeat_id:
+                heartbeat_service.update(heartbeat_id, state="running", current_step=i)
+
+            full_input = user_input
+            if accumulated_context:
+                full_input = f"{user_input}\n\nPrevious step results:\n{accumulated_context}"
+            user_blocks: list = [TextBlock(full_input)]
+            if i == 1:
+                user_blocks.extend(self._kernel_image_blocks(image_blocks))
+
+            messages = [
+                KMessage(role="system", blocks=[TextBlock(f"{system_prompt}\n\nCurrent task: {step}")]),
+                KMessage(role="user", blocks=user_blocks),
+            ]
+
+            step_text = ""
+            step_tokens = 0
+            final_provider = None
+            async for ev in run_agent_turn(
+                messages, specs, model, registry=registry, plane=tool_plane,
+                ctx=ctx, recorder=self.recorder, budget=budget, step=i,
+            ):
+                if isinstance(ev, ThinkingDelta):
+                    yield {"type": "thinking", "content": ev.text, "tokens": 0}
+                elif isinstance(ev, ToolUseStart):
+                    yield {"type": "tool_use", "id": ev.id, "name": ev.name, "tokens": 0}
+                elif isinstance(ev, UsageEvent):
+                    yield {
+                        "type": "usage",
+                        "input_tokens": ev.usage.input_tokens,
+                        "output_tokens": ev.usage.output_tokens,
+                        "tokens": ev.usage.input_tokens + ev.usage.output_tokens,
+                    }
+                elif isinstance(ev, ToolExecuted):
+                    yield {
+                        "type": "tool_result",
+                        "tool": ev.tool_use.name,
+                        "output": str(ev.result.output)[:2000],
+                        "is_error": ev.result.is_error,
+                        "tokens": 0,
+                    }
+                elif isinstance(ev, TurnDone):
+                    # The final (non-tool) turn holds the step's answer + usage.
+                    if ev.turn.stop_reason != "tool_use":
+                        step_text = ev.turn.text
+                        step_tokens = ev.turn.usage.input_tokens + ev.turn.usage.output_tokens
+                        final_provider = ev.turn.provider
+                elif isinstance(ev, TextDelta):
+                    pass  # accumulated via the final TurnDone
+            total_tokens += step_tokens
+
+            if uid:
+                try:
+                    await trace_service.record_span(
+                        user_id=uid, span_type="agent_step",
+                        span_name=f"Step {i}: {step[:100]}", run_id=run_id,
+                        agent_id=agent_id, model=model, provider=final_provider,
+                        input_tokens=0, output_tokens=step_tokens,
+                        input_preview=user_input[:500], output_preview=step_text[:500],
+                    )
+                except Exception:
+                    logger.warning("trace span failed on native step %s", i, exc_info=True)
+            if uid and run_id and agent_id:
+                try:
+                    from app.services.token_tracker import token_tracker
+
+                    token_tracker.record(
+                        run_id=run_id, agent_id=agent_id, user_id=uid, step_number=i,
+                        model=model or "unknown", provider=final_provider or "unknown",
+                        input_tokens=0, output_tokens=step_tokens,
+                    )
+                except Exception:
+                    logger.warning("token tracking failed on native step %s", i, exc_info=True)
+            if heartbeat_id:
+                heartbeat_service.update(
+                    heartbeat_id, tokens_used=total_tokens, output_preview=step_text[:500]
+                )
+
+            accumulated_context += f"\n\n--- Step {i} result ---\n{step_text}"
+            self.recorder.state(i, key="accumulated_context", value=accumulated_context)
+            yield {"type": "token", "content": step_text, "tokens": step_tokens}
+            yield {"type": "step", "content": f"Step {i} completed", "tokens": 0}
+
+        self.recorder.run_end(status="completed", output=accumulated_context, total_tokens=total_tokens)
+        if heartbeat_id:
+            heartbeat_service.complete(heartbeat_id, tokens_used=total_tokens)
+
+    @staticmethod
+    def _kernel_image_blocks(image_blocks: list[dict]) -> list:
+        """Convert OpenAI-format image dicts to kernel ImageBlocks."""
+        from app.kernel.convert import _image_block_from_url
+
+        blocks = []
+        for ib in image_blocks or []:
+            url = ib.get("image_url", {}).get("url", "")
+            if url:
+                blocks.append(_image_block_from_url(url))
+        return blocks
+
     async def execute(
         self,
         agent_config: dict,
@@ -139,6 +329,19 @@ class AgentRunner:
         attachments: list[dict] | None = None,
     ) -> AsyncIterator[dict]:
         """Execute an agent's workflow and yield streaming events."""
+        from app.config.flags import native_loop_enabled
+
+        # Forge-native kernel loop (harness-plan.md Phase 4), behind the flag.
+        # Emits the identical legacy step/token subsequence plus rich
+        # tool_use/tool_result/thinking/usage events. Default off.
+        if native_loop_enabled():
+            async for event in self._execute_native(
+                agent_config, user_input, heartbeat_id=heartbeat_id,
+                run_id=run_id, user_id=user_id, attachments=attachments,
+            ):
+                yield event
+            return
+
         from app.services.heartbeat import heartbeat_service
         from app.services.observability.trace_service import trace_service
         from app.services.tailoring import load_custom_instructions, prepend_about

--- a/backend/app/services/timetravel/recorder.py
+++ b/backend/app/services/timetravel/recorder.py
@@ -94,6 +94,51 @@ class RunRecorder:
         """Record a tool invocation: tool name, arguments, and its result."""
         self._append(EVENT_TOOL_CALL, step, {"name": name, "args": args, "result": result})
 
+    def model_turn(self, step: int, turn: Any) -> None:
+        """Record a kernel model turn (harness-plan.md Phase 4).
+
+        Written as a ``model_call`` event with a response payload compatible with
+        the legacy reader (``response.content`` present) plus kernel extras, so
+        replay/fork read both old and new shapes.
+        """
+        from dataclasses import asdict
+
+        blocks = []
+        for b in turn.blocks:
+            try:
+                blocks.append(asdict(b))
+            except Exception:  # noqa: BLE001 - never let recording break a run
+                blocks.append({"repr": str(b)})
+        self._append(
+            EVENT_MODEL_CALL,
+            step,
+            {
+                "request": {"model": turn.model, "provider": turn.provider},
+                "response": {
+                    "content": turn.text,
+                    "blocks": blocks,
+                    "stop_reason": turn.stop_reason,
+                    "input_tokens": turn.usage.input_tokens,
+                    "output_tokens": turn.usage.output_tokens,
+                },
+                "kernel": True,
+            },
+        )
+
+    def tool_call_kernel(self, step: int, tool_use: Any, result: Any) -> None:
+        """Record a kernel tool call/result (harness-plan.md Phase 4)."""
+        self._append(
+            EVENT_TOOL_CALL,
+            step,
+            {
+                "name": tool_use.name,
+                "args": tool_use.input,
+                "result": result.output,
+                "is_error": result.is_error,
+                "kernel": True,
+            },
+        )
+
     def state(self, step: int, *, key: str, value: Any) -> None:
         """Record a state mutation (e.g. accumulated context after a step)."""
         self._append(EVENT_STATE, step, {"key": key, "value": value})

--- a/backend/tests/test_native_loop.py
+++ b/backend/tests/test_native_loop.py
@@ -1,0 +1,262 @@
+"""Phase 4 — Forge-native agent loop.
+
+Asserts that with FORGE_NATIVE_LOOP on, the legacy step/token event subsequence
+is byte-identical to the flag-off path (and the Phase-0 golden), that a tool
+loop streams rich events and records time-travel, and that the loop drives tools
+through the plane to completion.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.kernel.types import (
+    KMessage,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+    ToolUseStart,
+    TurnDone,
+    TurnResult,
+    Usage,
+    UsageEvent,
+)
+
+GOLDEN = Path(__file__).parent / "parity" / "golden" / "agent_execute_stream.json"
+
+AGENT_CONFIG = {
+    "id": "agent-1",
+    "name": "Parity Agent",
+    "system_prompt": "You are a helpful assistant.",
+    "tools": [],
+    "workflow_steps": ["Understand the request.", "Produce the answer."],
+}
+
+ANSWER = "This is the model's answer for the step."
+
+
+class _FakeRegistry:
+    """A registry whose stream yields a fixed single final turn per call."""
+
+    def __init__(self, turns):
+        self._turns = turns
+        self.calls = 0
+
+    async def stream(self, messages, model, *, tools=None):
+        events = self._turns[min(self.calls, len(self._turns) - 1)]
+        self.calls += 1
+        for ev in events:
+            yield ev
+
+
+def _final_turn_events(text=ANSWER, provider="openai"):
+    return [
+        TextDelta(text=text),
+        UsageEvent(usage=Usage(input_tokens=7, output_tokens=11)),
+        TurnDone(
+            turn=TurnResult(
+                blocks=[TextBlock(text)],
+                stop_reason="end",
+                usage=Usage(input_tokens=7, output_tokens=11),
+                model="gpt-4o-mini",
+                provider=provider,
+            )
+        ),
+    ]
+
+
+def _legacy_subsequence(events):
+    return [e for e in events if e.get("type") in ("step", "token")]
+
+
+@pytest.mark.asyncio
+async def test_native_loop_legacy_subsequence_matches_golden(monkeypatch):
+    from app.services.agent_executor import AgentRunner
+
+    monkeypatch.setenv("FORGE_NATIVE_LOOP", "1")
+    fake = _FakeRegistry([_final_turn_events(), _final_turn_events()])
+
+    with (
+        patch("app.providers.registry.create_user_registry", AsyncMock(return_value=fake)),
+        patch("app.services.tailoring.load_custom_instructions", return_value=""),
+    ):
+        runner = AgentRunner(user_id="u1")
+        events = [e async for e in runner.execute(AGENT_CONFIG, "Hello there")]
+
+    golden = json.loads(GOLDEN.read_text())
+    assert _legacy_subsequence(events) == golden
+
+
+@pytest.mark.asyncio
+async def test_flag_off_and_on_produce_identical_legacy_events(monkeypatch):
+    from app.providers.base import LLMResponse
+    from app.services.agent_executor import AgentRunner
+
+    # flag OFF — legacy path via provider_registry.complete
+    resp = LLMResponse(
+        content=ANSWER, model="gpt-4o-mini", input_tokens=7, output_tokens=11,
+        finish_reason="stop", latency_ms=0.0, provider="openai",
+    )
+    with (
+        patch("app.services.agent_executor.provider_registry") as reg,
+        patch("app.services.tailoring.load_custom_instructions", return_value=""),
+    ):
+        reg.default_model = "gpt-4o-mini"
+        reg.complete = AsyncMock(return_value=resp)
+        off = AgentRunner(user_id=None)
+        off_events = [e async for e in off.execute(AGENT_CONFIG, "Hello there")]
+
+    # flag ON — kernel loop via registry.stream
+    monkeypatch.setenv("FORGE_NATIVE_LOOP", "1")
+    fake = _FakeRegistry([_final_turn_events(), _final_turn_events()])
+    with (
+        patch("app.providers.registry.create_user_registry", AsyncMock(return_value=fake)),
+        patch("app.services.tailoring.load_custom_instructions", return_value=""),
+    ):
+        on = AgentRunner(user_id="u1")
+        on_events = [e async for e in on.execute(AGENT_CONFIG, "Hello there")]
+
+    assert _legacy_subsequence(off_events) == _legacy_subsequence(on_events)
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_streams_events_and_records_timetravel(monkeypatch):
+    from app.services.agent_executor import AgentRunner
+    from app.services.timetravel.recorder import RunRecorder
+
+    monkeypatch.setenv("FORGE_NATIVE_LOOP", "1")
+
+    # Turn 1 asks to call node.template_renderer; turn 2 (after the tool result)
+    # returns the final answer.
+    tool_turn = [
+        ToolUseStart(id="c1", name="node.template_renderer"),
+        TurnDone(
+            turn=TurnResult(
+                blocks=[ToolUseBlock(
+                    id="c1", name="node.template_renderer",
+                    input={"template": "Hi {{name}}", "variables": {"name": "Bob"}},
+                )],
+                stop_reason="tool_use",
+                usage=Usage(input_tokens=5, output_tokens=3),
+                model="gpt-4o-mini", provider="openai",
+            )
+        ),
+    ]
+    # Call 1 requests the tool; call 2 (after the tool result) is the final answer.
+    fake = _FakeRegistry([tool_turn, _final_turn_events(text="Done: Hi Bob")])
+
+    recorded = []
+
+    class CapturingRecorder(RunRecorder):
+        def __init__(self):
+            super().__init__(run_id="run1", enabled=False)
+
+        def model_turn(self, step, turn):
+            recorded.append(("model_turn", turn.stop_reason))
+
+        def tool_call_kernel(self, step, tool_use, result):
+            recorded.append(("tool_call", tool_use.name, result.is_error))
+
+    config = {**AGENT_CONFIG, "tools": ["node.template_renderer"], "workflow_steps": ["Do it."]}
+    with (
+        patch("app.providers.registry.create_user_registry", AsyncMock(return_value=fake)),
+        patch("app.services.tailoring.load_custom_instructions", return_value=""),
+    ):
+        runner = AgentRunner(user_id="u1", recorder=CapturingRecorder())
+        events = [e async for e in runner.execute(config, "go", run_id="run1", user_id="u1")]
+
+    types = [e["type"] for e in events]
+    assert "tool_use" in types
+    assert "tool_result" in types
+    # the final token event carries the post-tool answer
+    tokens = [e for e in events if e["type"] == "token"]
+    assert tokens[-1]["content"] == "Done: Hi Bob"
+    # tool result round-tripped through the plane (template rendered)
+    tool_results = [e for e in events if e["type"] == "tool_result"]
+    assert not tool_results[0]["is_error"]
+    assert "Hi Bob" in tool_results[0]["output"]
+    # time-travel captured both a model turn and the tool call
+    assert ("tool_call", "node.template_renderer", False) in recorded
+    assert any(r[0] == "model_turn" for r in recorded)
+
+
+async def _openai_text_stream():
+    from types import SimpleNamespace
+
+    def chunk(content=None, finish=None, usage=None):
+        choices = (
+            [SimpleNamespace(delta=SimpleNamespace(content=content, tool_calls=None), finish_reason=finish)]
+            if (content is not None or finish is not None)
+            else []
+        )
+        return SimpleNamespace(choices=choices, usage=usage)
+
+    yield chunk(content="Answer from the real adapter.")
+    yield chunk(finish="stop")
+    yield chunk(usage=SimpleNamespace(prompt_tokens=4, completion_tokens=6))
+
+
+@pytest.mark.asyncio
+async def test_native_loop_drives_real_provider_adapter():
+    # loop → registry.stream → resolve_provider → provider.stream_turn → transport
+    from app.kernel.loop import run_agent_turn
+    from app.providers.ollama_provider import OllamaProvider
+    from app.providers.registry import ProviderRegistry
+
+    reg = ProviderRegistry()
+    ollama = OllamaProvider(base_url="http://localhost:11434")
+    reg.register("ollama", ollama, default=True)
+
+    messages = [KMessage(role="user", blocks=[TextBlock("hi")])]
+    with patch.object(
+        ollama.client.chat.completions, "create",
+        AsyncMock(return_value=_openai_text_stream()),
+    ):
+        events = [
+            ev async for ev in run_agent_turn(
+                messages, None, "llama3.1:8b-notools",
+                registry=reg, plane=None, ctx=None,
+            )
+        ]
+
+    done = [e for e in events if isinstance(e, TurnDone)]
+    assert done and done[0].turn.text == "Answer from the real adapter."
+    assert done[0].turn.stop_reason == "end"
+    assert any(isinstance(e, TextDelta) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_at_max_iterations(monkeypatch):
+    # A registry that always asks for a tool would loop forever without the cap.
+    from app.kernel.loop import run_agent_turn
+
+    class AlwaysToolRegistry:
+        async def stream(self, messages, model, *, tools=None):
+            yield TurnDone(
+                turn=TurnResult(
+                    blocks=[ToolUseBlock(id="c", name="node.template_renderer", input={"template": "x"})],
+                    stop_reason="tool_use",
+                    usage=Usage(),
+                    model="m", provider="p",
+                )
+            )
+
+    class NoopPlane:
+        async def execute(self, tool_use, ctx):
+            from app.kernel.types import ToolResultBlock
+
+            return ToolResultBlock(tool_use_id=tool_use.id, output="ok")
+
+    messages = [KMessage(role="user", blocks=[TextBlock("go")])]
+    count = 0
+    async for _ in run_agent_turn(
+        messages, None, "m", registry=AlwaysToolRegistry(), plane=NoopPlane(),
+        ctx=None, max_iterations=3,
+    ):
+        count += 1
+    # 3 iterations × (1 TurnDone + 1 ToolExecuted) = 6 events, then it stops.
+    assert count == 6

--- a/frontend/components/runner/RunnerPanel.tsx
+++ b/frontend/components/runner/RunnerPanel.tsx
@@ -104,6 +104,20 @@ export function RunnerPanel({ agent }: RunnerPanelProps) {
                 ...prev,
                 { type: "tool", data: `Tool: ${event.data?.tool || "unknown"}` },
               ]);
+            } else if (event.type === "tool_use") {
+              // Kernel-loop event (Phase 4): the model requested a tool.
+              setLogs((prev) => [
+                ...prev,
+                { type: "tool", data: `→ ${event.data?.name || "tool"}` },
+              ]);
+            } else if (event.type === "tool_result") {
+              const status = event.data?.is_error ? "✗" : "✓";
+              setLogs((prev) => [
+                ...prev,
+                { type: "tool", data: `${status} ${event.data?.tool || "tool"}` },
+              ]);
+            } else if (event.type === "thinking") {
+              setLogs((prev) => [...prev, { type: "step", data: "thinking…" }]);
             } else if (event.type === "error") {
               setError(event.data);
             } else if (event.type === "done") {


### PR DESCRIPTION
## Phase 4 of the Forge harness transformation (docs/harness-plan.md)

Replaces the LangChain/ChatOpenAI loop with a kernel loop on the registry, **behind `FORGE_NATIVE_LOOP` (default off)**. Any provider, any tool, streamed. The legacy path is byte-for-byte unchanged when the flag is off.

### What's here
- **`app/kernel/loop.py`** — `run_agent_turn(messages, tools, model, *, registry, plane, ctx, recorder, budget, max_iterations)`: streams a turn, and if it stops to call tools, the ToolPlane executes them under policy, results are appended, and it loops. Yields provider `StreamEvent`s + a `ToolExecuted` marker per tool. Includes a token/wall-clock `Budget`, a max-iterations cap, and cancellation via the async generator.
- **`AgentRunner._execute_native`** — used when the flag is on. Emits the **identical legacy `step`/`token` subsequence** plus rich `tool_use`/`tool_result`/`thinking`/`usage` events. `_resolve_tools_native` maps tool names to ToolPlane `ToolSpec`s (MCP names pass through in Phase 5). Custom-instructions weaving preserved.
- **Observers ported** (the migration's real cost, not skipped): time-travel `recorder.model_turn`/`tool_call_kernel` (payloads compatible with the existing replay/fork readers), per-turn trace spans, heartbeats, and `token_usage` all write as before.
- **Runs SSE** forwards the four new event types; **RunnerPanel** renders them as tool-call log lines (demo-safe; unknown types already ignored).

### Verification (`test_native_loop.py`, 5 tests)
- **Dual-flag parity**: the `step`/`token` subsequence is identical under flag-off (legacy) and flag-on (kernel loop), and both equal the **Phase-0 golden** `agent_execute_stream.json`. ✅
- Tool loop: streams `tool_use`+`tool_result`, the tool round-trips through the plane (template rendered), the final token carries the post-tool answer, and **time-travel captured both the model turn and the tool call**.
- The loop drives a **real provider adapter** end-to-end (registry → `resolve_provider` → `OllamaProvider.stream_turn` → mocked transport).
- Max-iterations cap prevents runaway tool loops.
- Full backend suite: **819 passed, 23 skipped** (+5; parity untouched & green). `ruff`/`mypy`/frontend `tsc`+`lint` clean.

### Deferred (with rationale)
- **Flag stays default OFF.** The plan flips it on "after a week of local soak"; a week isn't available in one session, and flipping now would route the legacy-mocked test suite (which patches `provider_registry.complete`) through the kernel loop and break it. Phase 8 flips all flags on and updates those tests.
- Full cross-provider vision (base64 fetch for Anthropic/Gemini) is a refinement; the native path forwards URL `ImageBlock`s today.

### Exit criteria (met, behind the flag)
- [x] Agent using `node.*` + a tool completes via the kernel loop, streams tool events, records time-travel
- [x] Legacy event subsequence matches the golden snapshot under both flags
- [x] Multi-provider loop path exercised through a real adapter