### PR TITLE
Drop redundant GitHub Actions Render deploy trigger (native auto-deploy works)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,25 +28,9 @@ jobs:
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: frontend
 
-  deploy-backend:
-    name: Deploy Backend to Render
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger Render Deploy
-        run: |
-          # Bounded + retried so a stalled or unauthorized API call fails fast
-          # and legibly instead of hanging (the trigger returns 401 when the
-          # RENDER_API_KEY secret is expired — rotate it in repo settings).
-          status=$(curl -sS -o /tmp/render.json -w '%{http_code}' \
-            --connect-timeout 15 --max-time 60 --retry 3 --retry-delay 5 \
-            -X POST "https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys" \
-            -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d '{}')
-          echo "Render API HTTP $status"
-          cat /tmp/render.json 2>/dev/null || true
-          echo
-          if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
-            echo "::error::Render deploy trigger failed (HTTP $status). If 401, rotate the RENDER_API_KEY secret."
-            exit 1
-          fi
+  # The backend (Render service `agentforge-api`) has native auto-deploy on
+  # (`autoDeploy: yes`) and ships every push to `main` on its own — verified live
+  # at https://agentforge-api.onrender.com (v3.0.0). The old GitHub Actions curl
+  # trigger duplicated that and only ever failed once the RENDER_API_KEY secret
+  # expired, so it was removed. If you ever need a manual trigger, mint a fresh
+  # dashboard API key and re-add a step here.


### PR DESCRIPTION
## The "failed backend deploy" was a false alarm

Investigation (via the authenticated Render CLI) shows the backend is **live and healthy**:
- Render service `agentforge-api` has **`autoDeploy: yes`** and ships every push to `main` natively. The latest deploy (the forge-kernel consolidation) is **`live`**.
- Verified: `https://agentforge-api.onrender.com/health` → `200 {"status":"ok"}`, `/` → `{"name":"Forge API","version":"3.0.0","status":"running"}`.

The only thing that ever "failed" was the **GitHub Actions `Deploy Backend to Render` job** — a `curl` trigger that duplicated Render's native auto-deploy and started failing once the `RENDER_API_KEY` secret expired (401).

## Change
Remove the redundant `deploy-backend` job from `.github/workflows/deploy.yml`. The Deploy workflow now just deploys the frontend to Vercel; the backend auto-deploys on Render natively. No `RENDER_API_KEY` secret needed anymore. A comment documents how to re-add a manual trigger with a fresh dashboard key if ever wanted.

This makes the Deploy workflow green without minting/rotating a key.