### PR TITLE
README: fix stale project structure (LangChain removed, forge-kernel added)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ graph TB
 
 | Layer | Technology |
 |-------|-----------|
-| Frontend | Next.js 14, TypeScript, Tailwind CSS, shadcn/ui, React Flow, Bun |
+| Frontend | Next.js 15, TypeScript, Tailwind CSS, shadcn/ui, React Flow, Bun |
 | Backend | Python 3.12, FastAPI, forge-kernel; OpenAI, Anthropic, Google, Ollama, any OpenAI-compatible |
 | Computer Use | CoreGraphics, cliclick, Vision OCR, ffmpeg, tmux, xdotool, pyautogui |
 | CLI | Typer, Rich, httpx |
@@ -453,14 +453,19 @@ make parity
 
 ```
 Forge/
-├── frontend/                    # Next.js 14 + TypeScript + Tailwind + shadcn/ui
-│   ├── app/dashboard/           # 15+ dashboard routes
+├── frontend/                    # Next.js 15 + TypeScript + Tailwind + shadcn/ui
+│   ├── app/dashboard/           # 15+ dashboard routes (incl. chat)
 │   ├── components/              # Blueprint editor, dashboard, UI primitives
 │   └── lib/                     # API client, auth client, demo data
-├── backend/                     # FastAPI + LangChain
+├── forge-kernel/                # The kernel as a zero-dependency pip package
+│   ├── forge_kernel/            # Types, model cards, converters, agent loop
+│   └── demo/                    # ~30-line standalone agent
+├── backend/                     # FastAPI on the Forge-native kernel loop
 │   ├── app/
+│   │   ├── kernel/              # Tool plane + permissions (rest re-exports forge-kernel)
+│   │   ├── mcp/                 # Real MCP client + Forge-as-MCP-server
 │   │   ├── db/                  # Pluggable database layer (SQLite + Supabase)
-│   │   ├── routers/             # 22 API route modules (incl. auth API)
+│   │   ├── routers/             # 34 API route modules (incl. auth API, sessions)
 │   │   ├── providers/           # Multi-model provider registry
 │   │   └── services/
 │   │       ├── blueprint_nodes/ # 44 node type executors
@@ -469,13 +474,13 @@ Forge/
 │   │           ├── drive/       # Terminal automation
 │   │           ├── linux/       # xdotool/tesseract fallback
 │   │           └── windows/     # pyautogui/PowerShell fallback
-│   └── tests/                   # 868 tests
-├── cli/                         # Typer + Rich CLI (35+ command groups)
+│   └── tests/                   # 868 tests (incl. the golden parity safety net)
+├── cli/                         # Typer + Rich CLI (35+ command groups, incl. chat)
 ├── scripts/                     # Bootstrap, Steer/Drive CLIs, OCR helper
-├── supabase/migrations/         # 17 SQL migrations (cloud mode only)
+├── supabase/migrations/         # 28 SQL migrations (cloud mode only)
 ├── setup.sh                     # One-command project setup
-├── Makefile                     # setup, up, down, test, lint targets
-├── docs/                        # Test & security reports
+├── Makefile                     # setup, up, down, test, lint, parity targets
+├── docs/                        # Harness plan, MCP server guide, API surface, QA reports
 └── .github/workflows/           # CI + deployment
 ```
 


### PR DESCRIPTION
The Phase-8 truth pass fixed the badges and feature sections but **missed the Project Structure tree and one Tech Stack row**, which still carried a now-false claim.

### Fixed
- **`backend/ # FastAPI + LangChain` → FastAPI on the Forge-native kernel loop.** LangChain was removed in v3.0.0 — this was the last false claim in the README.
- **Next.js 14 → 15** (Tech Stack row + tree; `package.json` is 15.5.18).
- **Added `forge-kernel/`** to the tree (the zero-dependency kernel package + its standalone demo) — it wasn't listed at all.
- **Added `app/kernel/` and `app/mcp/`** (tool plane/permissions, real MCP client + Forge-as-MCP-server).
- **Corrected counts**: routers 22 → **34**, Supabase migrations 17 → **28**, tests → **868** (incl. the parity safety net); noted `make parity` and the chat surfaces.

### Verified against the repo (not assumed)
| Claim | README | Actual |
|---|---|---|
| Node types | 44 (table sums to 44) | `len(NODE_REGISTRY)` = **44** |
| Routers | 34 | **34** |
| Supabase migrations | 28 | **28** |
| Backend tests | 868 | **868** collected |
| Frontend tests | 60 | **60** passed |
| Tests badge | 928 | 868 + 60 = **928** |

`grep -i langchain README.md` is now empty.