### PR TITLE
docs(render): clarify live service vs blueprint name

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,7 @@
+# NOTE: the LIVE backend is the pre-existing Render service `agentforge-api`
+# (srv-d6o6h36a2pns73d314s0), re-linked to this repo on 2026-07-15 with
+# auto-deploy on commit. This blueprint's `forge-api` name is what a fresh
+# `render blueprint launch` would create — it is not the running service.
 services:
   - type: web
     name: forge-api


### PR DESCRIPTION
The running backend is the pre-existing Render service `agentforge-api`, re-linked to this repo (post-rename) on 2026-07-15 with auto-deploy on commit. Documents that this blueprint's `forge-api` is not the live service. Also serves as the end-to-end test that commit-triggered deploys fire again after the re-link.